### PR TITLE
docs: add Quick Start and ensure_casefile guidance; fix import autodocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,33 @@ This package contains tools for subsequent network calculations. It primarily fe
 
 ---
 
+## Documentation
+
+- User documentation: <https://welthulk.github.io/Sparlectra.jl/>
+- API reference: <https://welthulk.github.io/Sparlectra.jl/reference/>
+
 ## Installation
 ```julia
 using Pkg
 Pkg.add("Sparlectra")
+```
+
+## Quick Start
+
+```julia
+using Sparlectra
+
+# Ensure case file exists locally (downloads on demand into data/mpower)
+case_path = ensure_casefile("case14.m")
+
+# Build network and run Newton-Raphson power flow
+net = createNetFromMatPowerFile(case_path, false)
+ite, erg = runpf!(net, 10, 1e-6, 0)
+
+if erg == 0
+    calcNetLosses!(net)
+    printACPFlowResults(net, 0.0, ite, 1e-6)
+end
 ```
 
 ### Network Creation
@@ -33,7 +56,6 @@ data while still allowing reproducible experiments and benchmarks.
 ### License
 This project is licensed under the Apache License, Version 2.0.
 [The license file](LICENSE) contains the complete licensing information.
-
 
 
 

--- a/docs/src/import.md
+++ b/docs/src/import.md
@@ -36,6 +36,25 @@ file_path = "path/to/case5.m"
 net = createNetFromMatPowerFile(file_path, false)  # Second parameter controls logging
 ```
 
+### Ensuring Test Cases Exist Locally
+
+When working with standard MATPOWER test cases (for example `case14.m`), you can
+let Sparlectra download the file on demand:
+
+```julia
+using Sparlectra
+
+# Downloads to Sparlectra.data/mpower if missing and returns absolute path
+case_path = ensure_casefile("case14.m")
+net = createNetFromMatPowerFile(case_path, false)
+```
+
+You can also request a generated `.jl` companion file by passing a `.jl` name:
+
+```julia
+case_jl_path = ensure_casefile("case14.jl")
+```
+
 ### Import Parser
 
 The `casefileparser` function parses Matpower case files and returns the raw data arrays:
@@ -134,6 +153,6 @@ writeMatpowerCasefile(net, output_path)
 
 ```@autodocs 
   Modules = [Sparlectra]   
-  Pages = ["import.jl", "createnet_powermat.jl", "exportMatPower.jl", "run_acpflow.jl"]
+  Pages = ["FetchMatpowerCase.jl", "createnet_powermat.jl", "exportMatPower.jl", "run_acpflow.jl"]
   Order = [:type, :function]
 ```


### PR DESCRIPTION
### Motivation
- Improve onboarding by providing direct links to user docs and the API reference from the project root.
- Give a concise Quick Start that demonstrates the common workflow to fetch a MATPOWER case, import it and run a power flow.
- Clarify how standard MATPOWER test cases are obtained on demand to close the gap between helper utilities and their usage.

### Description
- Added a `Documentation` section and an actionable `Quick Start` snippet to `README.md` that uses `ensure_casefile`, `createNetFromMatPowerFile` and `runpf!`.
- Inserted an `Ensuring Test Cases Exist Locally` section in `docs/src/import.md` that documents `ensure_casefile("case14.m")` and `.jl` companion behavior.
- Updated the import page autodocs `Pages` list to reference `FetchMatpowerCase.jl` instead of the non-existent `import.jl`.
- Changes applied to `README.md` and `docs/src/import.md` and committed.

### Testing
- Attempted to build the documentation with `julia --project=docs docs/make.jl`, which failed in this environment because `julia` is not available in `PATH`.
- No unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b0eaa5608330b7e5b0c637765fc8)