### PR TITLE
Add Julia setup to docs workflow and expand README/docs with Quick Start and casefile helper

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+
       - name: Install Sparlectra and Documenter packages
         run: |
           julia -e 'using Pkg; Pkg.add(["Sparlectra", "Documenter"])'

--- a/README.md
+++ b/README.md
@@ -8,10 +8,33 @@ This package contains tools for subsequent network calculations. It primarily fe
 
 ---
 
+## Documentation
+
+- User documentation: <https://welthulk.github.io/Sparlectra.jl/>
+- API reference: <https://welthulk.github.io/Sparlectra.jl/reference/>
+
 ## Installation
 ```julia
 using Pkg
 Pkg.add("Sparlectra")
+```
+
+## Quick Start
+
+```julia
+using Sparlectra
+
+# Ensure case file exists locally (downloads on demand into data/mpower)
+case_path = ensure_casefile("case14.m")
+
+# Build network and run Newton-Raphson power flow
+net = createNetFromMatPowerFile(case_path, false)
+ite, erg = runpf!(net, 10, 1e-6, 0)
+
+if erg == 0
+    calcNetLosses!(net)
+    printACPFlowResults(net, 0.0, ite, 1e-6)
+end
 ```
 
 ### Network Creation
@@ -33,7 +56,6 @@ data while still allowing reproducible experiments and benchmarks.
 ### License
 This project is licensed under the Apache License, Version 2.0.
 [The license file](LICENSE) contains the complete licensing information.
-
 
 
 

--- a/docs/src/import.md
+++ b/docs/src/import.md
@@ -36,6 +36,25 @@ file_path = "path/to/case5.m"
 net = createNetFromMatPowerFile(file_path, false)  # Second parameter controls logging
 ```
 
+### Ensuring Test Cases Exist Locally
+
+When working with standard MATPOWER test cases (for example `case14.m`), you can
+let Sparlectra download the file on demand:
+
+```julia
+using Sparlectra
+
+# Downloads to Sparlectra.data/mpower if missing and returns absolute path
+case_path = ensure_casefile("case14.m")
+net = createNetFromMatPowerFile(case_path, false)
+```
+
+You can also request a generated `.jl` companion file by passing a `.jl` name:
+
+```julia
+case_jl_path = ensure_casefile("case14.jl")
+```
+
 ### Import Parser
 
 The `casefileparser` function parses Matpower case files and returns the raw data arrays:
@@ -134,6 +153,6 @@ writeMatpowerCasefile(net, output_path)
 
 ```@autodocs 
   Modules = [Sparlectra]   
-  Pages = ["import.jl", "createnet_powermat.jl", "exportMatPower.jl", "run_acpflow.jl"]
+  Pages = ["FetchMatpowerCase.jl", "createnet_powermat.jl", "exportMatPower.jl", "run_acpflow.jl"]
   Order = [:type, :function]
 ```


### PR DESCRIPTION
### Motivation

- Ensure the GitHub Pages documentation workflow has Julia available on the runner so docs can be built with the package's Julia scripts.  
- Provide users with quick-start instructions and documentation links to lower the barrier to running example power flows.  
- Document the helper that fetches MATPOWER test cases on demand and update the docs autodoc pages list to include the new page name.

### Description

- Added a `Setup Julia` step to `.github/workflows/jekyll-gh-pages.yml` using `julia-actions/setup-julia@v2` with `version: '1'`.  
- Augmented `README.md` with a `Documentation` section and a `Quick Start` example demonstrating `ensure_casefile`, `createNetFromMatPowerFile`, `runpf!`, `calcNetLosses!`, and `printACPFlowResults`.  
- Expanded `docs/src/import.md` to document how to use `ensure_casefile` (including requesting a `.jl` companion) and updated the `@autodocs` `Pages` list to include `FetchMatpowerCase.jl` in place of `import.jl`.  
- Minor formatting and link additions for documentation and API reference URLs in the README.

### Testing

- No automated unit tests were executed as part of this change.  
- The documentation workflow configuration was updated (`.github/workflows/jekyll-gh-pages.yml`) but the workflow was not run during this rollout.  
- No CI artifacts or doc builds were produced in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b0eaa5608330b7e5b0c637765fc8)