### PR TITLE
Improve network analyzer, add quickstart docs, and enable Julia in GH Pages workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+
       - name: Install Sparlectra and Documenter packages
         run: |
           julia -e 'using Pkg; Pkg.add(["Sparlectra", "Documenter"])'

--- a/README.md
+++ b/README.md
@@ -8,10 +8,33 @@ This package contains tools for subsequent network calculations. It primarily fe
 
 ---
 
+## Documentation
+
+- User documentation: <https://welthulk.github.io/Sparlectra.jl/>
+- API reference: <https://welthulk.github.io/Sparlectra.jl/reference/>
+
 ## Installation
 ```julia
 using Pkg
 Pkg.add("Sparlectra")
+```
+
+## Quick Start
+
+```julia
+using Sparlectra
+
+# Ensure case file exists locally (downloads on demand into data/mpower)
+case_path = ensure_casefile("case14.m")
+
+# Build network and run Newton-Raphson power flow
+net = createNetFromMatPowerFile(case_path, false)
+ite, erg = runpf!(net, 10, 1e-6, 0)
+
+if erg == 0
+    calcNetLosses!(net)
+    printACPFlowResults(net, 0.0, ite, 1e-6)
+end
 ```
 
 ### Network Creation
@@ -33,7 +56,6 @@ data while still allowing reproducible experiments and benchmarks.
 ### License
 This project is licensed under the Apache License, Version 2.0.
 [The license file](LICENSE) contains the complete licensing information.
-
 
 
 

--- a/docs/src/import.md
+++ b/docs/src/import.md
@@ -36,6 +36,25 @@ file_path = "path/to/case5.m"
 net = createNetFromMatPowerFile(file_path, false)  # Second parameter controls logging
 ```
 
+### Ensuring Test Cases Exist Locally
+
+When working with standard MATPOWER test cases (for example `case14.m`), you can
+let Sparlectra download the file on demand:
+
+```julia
+using Sparlectra
+
+# Downloads to Sparlectra.data/mpower if missing and returns absolute path
+case_path = ensure_casefile("case14.m")
+net = createNetFromMatPowerFile(case_path, false)
+```
+
+You can also request a generated `.jl` companion file by passing a `.jl` name:
+
+```julia
+case_jl_path = ensure_casefile("case14.jl")
+```
+
 ### Import Parser
 
 The `casefileparser` function parses Matpower case files and returns the raw data arrays:
@@ -134,6 +153,6 @@ writeMatpowerCasefile(net, output_path)
 
 ```@autodocs 
   Modules = [Sparlectra]   
-  Pages = ["import.jl", "createnet_powermat.jl", "exportMatPower.jl", "run_acpflow.jl"]
+  Pages = ["FetchMatpowerCase.jl", "createnet_powermat.jl", "exportMatPower.jl", "run_acpflow.jl"]
   Order = [:type, :function]
 ```

--- a/src/examples/network_analyzer.jl
+++ b/src/examples/network_analyzer.jl
@@ -17,86 +17,80 @@
 using Sparlectra
 
 """
-    analyze_network(net::Net)
+    analyze_network(net::Net; verbose_components::Bool=true, io::IO=stdout)
 
-Analyze a Sparlectra network structure and print detailed information about its components.
-Helpful for debugging issues with removal operations.
+Analyze a `Sparlectra.Net` and print:
+- a compact summary (number of buses/branches/shunts/prosumers),
+- optional component-level details,
+- dictionary mappings,
+- consistency checks (invalid references/mismatches).
+
+Useful for debugging network edits and remove operations.
 """
-function analyze_network(net::Net)
-  println("\n====================== NETWORK ANALYSIS ======================")
-  println("Network: $(net.name) (BaseMVA: $(net.baseMVA))")
+function analyze_network(net::Net; verbose_components::Bool=true, io::IO=stdout)
+  bus_name_by_idx = Dict{Int, String}(idx => String(name) for (name, idx) in net.busDict)
 
-  # Bus analysis
-  println("\n--- BUSES ($(length(net.nodeVec))) ---")
-  for (i, node) in enumerate(net.nodeVec)
-    bus_type = toString(node._nodeType)
-    slack = isSlack(node) ? "SLACK" : ""
-    println("$i: $(node.comp.cName) (busIdx: $(node.busIdx), type: $bus_type) $slack")
-  end
+  println(io, "\n====================== NETWORK ANALYSIS ======================")
+  println(io, "Network: $(net.name) (BaseMVA: $(net.baseMVA))")
+  println(io, "Summary: buses=$(length(net.nodeVec)), branches=$(length(net.branchVec)), shunts=$(length(net.shuntVec)), prosumers=$(length(net.prosumpsVec)), isolated=$(length(net.isoNodes))")
 
-  # Branch analysis
-  println("\n--- BRANCHES ($(length(net.branchVec))) ---")
-  for (i, branch) in enumerate(net.branchVec)
-    println("$i: $(branch.comp.cName) (from: $(branch.fromBus), to: $(branch.toBus), status: $(branch.status))")
-  end
-
-  # Bus dictionary mapping
-  println("\n--- BUS DICTIONARY ---")
-  for (name, idx) in net.busDict
-    println("$name => $idx")
-  end
-
-  # Shunt analysis
-  println("\n--- SHUNTS ($(length(net.shuntVec))) ---")
-  for (i, shunt) in enumerate(net.shuntVec)
-    println("$i: $(shunt.comp.cName) (busIdx: $(shunt.busIdx))")
-  end
-
-  # Shunt dictionary mapping
-  println("\n--- SHUNT DICTIONARY ---")
-  for (busIdx, shuntIdx) in net.shuntDict
-    bus_name = "Unknown"
-    for (name, idx) in net.busDict
-      if idx == busIdx
-        bus_name = name
-        break
-      end
+  if verbose_components
+    println(io, "\n--- BUSES ($(length(net.nodeVec))) ---")
+    for (i, node) in enumerate(net.nodeVec)
+      bus_type = toString(node._nodeType)
+      slack = isSlack(node) ? " [SLACK]" : ""
+      println(io, "$i: $(node.comp.cName) (busIdx=$(node.busIdx), type=$bus_type)$slack")
     end
-    println("Bus $busIdx ($bus_name) => Shunt $shuntIdx")
-  end
 
-  # Prosumer analysis
-  println("\n--- PROSUMERS ($(length(net.prosumpsVec))) ---")
-  for (i, prosumer) in enumerate(net.prosumpsVec)
-    p_type = toString(prosumer.proSumptionType)
-    bus_idx = prosumer.comp.cFrom_bus
-    bus_name = "Unknown"
-    for (name, idx) in net.busDict
-      if idx == bus_idx
-        bus_name = name
-        break
-      end
+    println(io, "\n--- BRANCHES ($(length(net.branchVec))) ---")
+    for (i, branch) in enumerate(net.branchVec)
+      from_name = get(bus_name_by_idx, branch.fromBus, "Unknown")
+      to_name = get(bus_name_by_idx, branch.toBus, "Unknown")
+      println(io, "$i: $(branch.comp.cName) (from=$(branch.fromBus):$from_name, to=$(branch.toBus):$to_name, status=$(branch.status))")
     end
-    println("$i: $(prosumer.comp.cName) (busIdx: $bus_idx ($bus_name), type: $p_type)")
+
+    println(io, "\n--- SHUNTS ($(length(net.shuntVec))) ---")
+    for (i, shunt) in enumerate(net.shuntVec)
+      bus_name = get(bus_name_by_idx, shunt.busIdx, "Unknown")
+      println(io, "$i: $(shunt.comp.cName) (busIdx=$(shunt.busIdx):$bus_name)")
+    end
+
+    println(io, "\n--- PROSUMERS ($(length(net.prosumpsVec))) ---")
+    for (i, prosumer) in enumerate(net.prosumpsVec)
+      p_type = toString(prosumer.proSumptionType)
+      bus_idx = prosumer.comp.cFrom_bus
+      bus_name = get(bus_name_by_idx, bus_idx, "Unknown")
+      println(io, "$i: $(prosumer.comp.cName) (busIdx=$bus_idx:$bus_name, type=$p_type)")
+    end
   end
 
-  # Isolated nodes
-  println("\n--- ISOLATED NODES ($(length(net.isoNodes))) ---")
-  for idx in net.isoNodes
-    println("$idx")
+  println(io, "\n--- BUS DICTIONARY ---")
+  for (name, idx) in sort(collect(net.busDict); by=x -> x[2])
+    println(io, "$name => $idx")
   end
 
-  println("\n================================================================")
+  println(io, "\n--- SHUNT DICTIONARY ---")
+  for (busIdx, shuntIdx) in sort(collect(net.shuntDict); by=x -> x[1])
+    bus_name = get(bus_name_by_idx, busIdx, "Unknown")
+    println(io, "Bus $busIdx ($bus_name) => Shunt $shuntIdx")
+  end
+
+  println(io, "\n--- ISOLATED NODES ($(length(net.isoNodes))) ---")
+  for idx in sort(collect(net.isoNodes))
+    bus_name = get(bus_name_by_idx, idx, "Unknown")
+    println(io, "$idx ($bus_name)")
+  end
+
+  _print_consistency_report(net, bus_name_by_idx; io)
+  println(io, "\n================================================================")
 end
 
 """
-    test_debug()
+    build_demo_network() -> Net
 
-Create a test network and analyze it with detailed debug information.
-This helps understand the network structure before and after removal operations.
+Build a compact demo grid that can be used for analyzer debugging.
 """
-function test_debug()
-  # Create a test network as in testremove.jl
+function build_demo_network()::Net
   net = Net(name = "remove_test", baseMVA = 100.0)
 
   # Add buses
@@ -125,10 +119,21 @@ function test_debug()
   addProsumer!(net = net, busName = "B5", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.03, va_deg = 0.0, referencePri = "B5")
   addProsumer!(net = net, busName = "B6", type = "GENERATOR", p = 80.0, q = 30.0, vm_pu = 1.02)
 
+  return net
+end
+
+"""
+    run_demo() -> Net
+
+Build a demo network, run analysis before and after removing branch 2.
+Returns the modified network.
+"""
+function run_demo()::Net
+  net = build_demo_network()
+
   println("\n=================== INITIAL NETWORK STATE ===================")
   analyze_network(net)
 
-  # Test removing a branch
   println("\n\n=================== AFTER BRANCH REMOVAL ===================")
   println("Removing branch 2...")
   removeBranch!(net = net, branchNr = 2)
@@ -137,5 +142,77 @@ function test_debug()
   return net
 end
 
-# Call the test_debug function
-net = test_debug()
+function _print_consistency_report(net::Net, bus_name_by_idx::Dict{Int, String}; io::IO=stdout)
+  issues = String[]
+  bus_count = length(net.nodeVec)
+  shunt_count = length(net.shuntVec)
+
+  # busDict indices should point to valid nodes
+  for (name, idx) in net.busDict
+    if !(1 <= idx <= bus_count)
+      push!(issues, "busDict[$name] = $idx is out of bounds (1:$bus_count)")
+    elseif String(name) != net.nodeVec[idx].comp.cName
+      push!(issues, "busDict[$name] = $idx points to node $(net.nodeVec[idx].comp.cName)")
+    end
+  end
+
+  # branch endpoints should reference valid buses
+  for (i, branch) in enumerate(net.branchVec)
+    if !(1 <= branch.fromBus <= bus_count)
+      push!(issues, "branch[$i] has invalid fromBus=$(branch.fromBus)")
+    end
+    if !(1 <= branch.toBus <= bus_count)
+      push!(issues, "branch[$i] has invalid toBus=$(branch.toBus)")
+    end
+  end
+
+  # shunt vector and shuntDict should reference valid buses/shunt indices
+  for (i, shunt) in enumerate(net.shuntVec)
+    if !(1 <= shunt.busIdx <= bus_count)
+      push!(issues, "shunt[$i] has invalid busIdx=$(shunt.busIdx)")
+    end
+  end
+  for (busIdx, shuntIdx) in net.shuntDict
+    if !(1 <= busIdx <= bus_count)
+      push!(issues, "shuntDict has invalid busIdx=$busIdx")
+    end
+    if !(1 <= shuntIdx <= shunt_count)
+      push!(issues, "shuntDict[$busIdx] has invalid shunt index=$shuntIdx")
+    end
+  end
+
+  # prosumers must point to valid buses
+  for (i, prosumer) in enumerate(net.prosumpsVec)
+    bus_idx = prosumer.comp.cFrom_bus
+    if !(1 <= bus_idx <= bus_count)
+      push!(issues, "prosumer[$i] has invalid cFrom_bus=$bus_idx")
+    end
+  end
+
+  # isolated node list should reference existing buses
+  for idx in net.isoNodes
+    if !(1 <= idx <= bus_count)
+      push!(issues, "isoNodes contains invalid bus index=$idx")
+    end
+  end
+
+  println(io, "\n--- CONSISTENCY CHECKS ---")
+  if isempty(issues)
+    println(io, "OK: no structural issues detected.")
+  else
+    println(io, "Found $(length(issues)) issue(s):")
+    for msg in issues
+      println(io, "- $msg")
+    end
+  end
+
+  # quick reachability info for isolated nodes
+  if !isempty(net.isoNodes)
+    names = [get(bus_name_by_idx, idx, "Unknown") for idx in sort(collect(net.isoNodes))]
+    println(io, "Isolated buses: ", join(names, ", "))
+  end
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+  run_demo()
+end


### PR DESCRIPTION
### Motivation

- Improve developer tooling to better inspect and validate Sparlectra network structures when editing or removing components.
- Provide users with clearer documentation and a Quick Start example for running power flow and obtaining test case files.
- Ensure the documentation build on GitHub Pages can run Julia/Documenter tooling in CI.

### Description

- Updated the GitHub Pages workflow (`.github/workflows/jekyll-gh-pages.yml`) to `setup-julia` and install `Sparlectra` and `Documenter` before running `docs/make.jl` so the docs build supports Julia content.
- Extended `README.md` with `Documentation` links and a `Quick Start` Julia example that shows `ensure_casefile`, `createNetFromMatPowerFile`, and running `runpf!` followed by result reporting.
- Enhanced `docs/src/import.md` with usage examples for `ensure_casefile` (including `.jl` companion generation) and updated the `@autodocs` `Pages` list to include `FetchMatpowerCase.jl`.
- Heavily refactored `src/examples/network_analyzer.jl` to a more robust analyzer by adding a configurable signature `analyze_network(net::Net; verbose_components::Bool=true, io::IO=stdout)`, bus-name mapping, improved formatted outputs, sorted dictionary listings, a `_print_consistency_report` function that validates `busDict`, branches, shunts, prosumers and `isoNodes`, reusable builders `build_demo_network()` and `run_demo()`, and an executable guard to run the demo when the file is invoked directly.

### Testing

- No automated tests were executed as part of this change; no unit tests were added or modified in this PR.
- The docs workflow was updated to run on push to `main` and will perform a documentation build with Julia/Documenter on next CI run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6b0eaa5608330b7e5b0c637765fc8)