### PR TITLE
Add BusLink topological links with KCL flow calculation and reporting

### DIFF
--- a/src/Sparlectra.jl
+++ b/src/Sparlectra.jl
@@ -49,6 +49,8 @@ export
   ProSumer,
   # Branch
   AbstractBranch, Branch, BranchModel, BranchFlow, getBranchFlow, setBranchFlow!, getBranchNumber, getBranchLosses, setBranchLosses!, setBranchStatus!,
+  # Link
+  BusLink, setLinkStatus!, setLinkFlow!, setLinkCurrent!,
   # Shunt
   Shunt,
   # Net
@@ -79,7 +81,7 @@ export
   addBus!, addShunt!, addACLine!, addPIModelACLine!, add2WTrafo!, addPIModelTrafo!, addProsumer!, lockNet!, validate!, hasBusInNet, addBusGenPower!, addBusLoadPower!, addBusShuntPower!, setNodeVoltage!, setNodeAngle!,
   getNetOrigBusIdx, geNetBusIdx, setNetBranchStatus!, getNetBranch, getNetBranchNumberVec, setTotalLosses!, getTotalLosses, getBusType, get_bus_vn_kV, get_vn_kV, updateBranchParameters!, hasShunt!, 
   getShunt!, markIsolatedBuses!,setTotalBusPower!, setPVBusVset!, setQLimits!, getNodeVm,distributeBusResults!, getTotalBusPower, getTotalLosses, buildVoltageVector,initialVrect, buildComplexSVec,
-  add2WTPIModelTrafo!, add3WTPiModelTrafo!,
+  add2WTPIModelTrafo!, add3WTPiModelTrafo!, addLink!, setNetLinkStatus!, getNetLinks, calcLinkFlowsKCL!,
   # remove_functions.jl
   removeBus!, removeBranch!, removeACLine!, removeTrafo!, removeShunt!, removeProsumer!, clearIsolatedBuses!,
   # import.jl
@@ -112,6 +114,7 @@ include("transformer.jl")
 include("prosumer.jl")
 include("node.jl")
 include("branch.jl")
+include("link.jl")
 include("shunt.jl")
 include("network.jl")
 include("busdata.jl")

--- a/src/link.jl
+++ b/src/link.jl
@@ -1,0 +1,62 @@
+# Author: Udo Schmitz (https://github.com/Welthulk)
+# include-file link.jl
+
+"""
+    BusLink
+
+Topological, impedance-less connection between two buses. Bus links are not part
+of the electrical branch model (YBUS). They are intended for post-power-flow KCL
+allocation, e.g. busbar couplers / sectionalizers.
+"""
+mutable struct BusLink
+  linkIdx::Int
+  fromBus::Int
+  toBus::Int
+  status::Int
+  pFlow_MW::Union{Nothing,Float64}
+  qFlow_MVar::Union{Nothing,Float64}
+  iFrom_kA::Union{Nothing,Float64}
+  iTo_kA::Union{Nothing,Float64}
+
+  function BusLink(; linkIdx::Int, fromBus::Int, toBus::Int, status::Int = 1)
+    @assert fromBus != toBus "fromBus and toBus must differ"
+    @assert status in (0, 1) "status must be 0 or 1"
+    new(linkIdx, fromBus, toBus, status, nothing, nothing, nothing, nothing)
+  end
+
+  function Base.show(io::IO, l::BusLink)
+    print(io, "BusLink(")
+    print(io, "idx=", l.linkIdx, ", ")
+    print(io, "from=", l.fromBus, ", ")
+    print(io, "to=", l.toBus, ", ")
+    print(io, "status=", l.status)
+    if !isnothing(l.pFlow_MW)
+      print(io, ", P=", l.pFlow_MW, " MW")
+    end
+    if !isnothing(l.qFlow_MVar)
+      print(io, ", Q=", l.qFlow_MVar, " MVar")
+    end
+    if !isnothing(l.iFrom_kA)
+      print(io, ", Ifrom=", l.iFrom_kA, " kA")
+    end
+    if !isnothing(l.iTo_kA)
+      print(io, ", Ito=", l.iTo_kA, " kA")
+    end
+    print(io, ")")
+  end
+end
+
+function setLinkStatus!(link::BusLink, status::Int)
+  @assert status in (0, 1) "status must be 0 or 1"
+  link.status = status
+end
+
+function setLinkFlow!(link::BusLink, pFlow_MW::Float64, qFlow_MVar::Float64)
+  link.pFlow_MW = pFlow_MW
+  link.qFlow_MVar = qFlow_MVar
+end
+
+function setLinkCurrent!(link::BusLink, iFrom_kA::Float64, iTo_kA::Float64)
+  link.iFrom_kA = iFrom_kA
+  link.iTo_kA = iTo_kA
+end

--- a/src/losses.jl
+++ b/src/losses.jl
@@ -116,3 +116,144 @@ function calcNetLosses!(net::Net, V::Vector{ComplexF64})
 
   setTotalLosses!(net = net, pLosses = ∑pv, qLosses = ∑qv)
 end
+
+"""
+    calcLinkFlowsKCL!(net::Net; tol::Float64 = 1e-6)
+
+Computes active bus-link flows after power flow via nodal KCL, without adding
+links to YBUS. Link directions follow `fromBus -> toBus` sign convention.
+
+For each bus i:
+    sum(P_link,out - P_link,in) = P_inj(i) - P_branch,out(i)
+(and analog for Q).
+
+If a connected link component has a small non-zero residual sum, the residual is
+uniformly distributed across buses in that component to enforce solvability.
+"""
+function calcLinkFlowsKCL!(net::Net; tol::Float64 = 1e-6)
+  isempty(net.linkVec) && return
+
+  active = [l for l in net.linkVec if l.status == 1]
+  isempty(active) && return
+
+  nbus = length(net.nodeVec)
+
+  # Bus injections from static specs in MW/MVar (same sign convention as PF setup)
+  P_inj = zeros(Float64, nbus)
+  Q_inj = zeros(Float64, nbus)
+  for (k, node) in enumerate(net.nodeVec)
+    Pgen = isnothing(node._pƩGen) ? 0.0 : node._pƩGen
+    Qgen = isnothing(node._qƩGen) ? 0.0 : node._qƩGen
+    Pload = isnothing(node._pƩLoad) ? 0.0 : node._pƩLoad
+    Qload = isnothing(node._qƩLoad) ? 0.0 : node._qƩLoad
+    P_inj[k] = Pgen - Pload
+    Q_inj[k] = Qgen - Qload
+  end
+
+  # Outgoing branch terminal powers per bus in MW/MVar
+  P_branch_out = zeros(Float64, nbus)
+  Q_branch_out = zeros(Float64, nbus)
+  for br in net.branchVec
+    br.status == 0 && continue
+    if !isnothing(br.fBranchFlow)
+      P_branch_out[br.fromBus] += br.fBranchFlow.pFlow
+      Q_branch_out[br.fromBus] += br.fBranchFlow.qFlow
+    end
+    if !isnothing(br.tBranchFlow)
+      P_branch_out[br.toBus] += br.tBranchFlow.pFlow
+      Q_branch_out[br.toBus] += br.tBranchFlow.qFlow
+    end
+  end
+
+  bP = P_inj .- P_branch_out
+  bQ = Q_inj .- Q_branch_out
+
+  m = length(active)
+  A = zeros(Float64, nbus, m)
+  for (j, l) in enumerate(active)
+    A[l.fromBus, j] += 1.0
+    A[l.toBus, j] -= 1.0
+  end
+
+  # Split by connected components in link graph for robust solving
+  bus_to_links = [Int[] for _ in 1:nbus]
+  for (j, l) in enumerate(active)
+    push!(bus_to_links[l.fromBus], j)
+    push!(bus_to_links[l.toBus], j)
+  end
+
+  visited = falses(nbus)
+  flowsP = zeros(Float64, m)
+  flowsQ = zeros(Float64, m)
+
+  for b0 in 1:nbus
+    if visited[b0] || isempty(bus_to_links[b0])
+      continue
+    end
+
+    # BFS buses in this link component
+    q = [b0]
+    comp_buses = Int[]
+    comp_links_set = Set{Int}()
+    visited[b0] = true
+
+    while !isempty(q)
+      b = popfirst!(q)
+      push!(comp_buses, b)
+      for lj in bus_to_links[b]
+        push!(comp_links_set, lj)
+        l = active[lj]
+        nb = (l.fromBus == b) ? l.toBus : l.fromBus
+        if !visited[nb]
+          visited[nb] = true
+          push!(q, nb)
+        end
+      end
+    end
+
+    comp_links = sort!(collect(comp_links_set))
+    Ab = A[comp_buses, comp_links]
+    bbP = copy(bP[comp_buses])
+    bbQ = copy(bQ[comp_buses])
+
+    # enforce sum(b)=0 for each connected component
+    sumP = sum(bbP)
+    sumQ = sum(bbQ)
+    if abs(sumP) > tol
+      bbP .-= sumP / length(bbP)
+    end
+    if abs(sumQ) > tol
+      bbQ .-= sumQ / length(bbQ)
+    end
+
+    # least-squares (handles tree and meshed components)
+    fp = Ab \ bbP
+    fq = Ab \ bbQ
+
+    for (k, gj) in enumerate(comp_links)
+      flowsP[gj] = fp[k]
+      flowsQ[gj] = fq[k]
+    end
+  end
+
+  # reset + write back to original link objects
+  for l in net.linkVec
+    setLinkFlow!(l, 0.0, 0.0)
+    setLinkCurrent!(l, 0.0, 0.0)
+  end
+  for (j, l) in enumerate(active)
+    p = flowsP[j]
+    q = flowsQ[j]
+    setLinkFlow!(l, p, q)
+
+    # Three-phase current magnitudes per terminal:
+    # |I|[kA] = |S|[MVA] / (sqrt(3) * V_LL[kV])
+    s_abs = hypot(p, q)
+    vf_kV = net.nodeVec[l.fromBus]._vm_pu * net.nodeVec[l.fromBus].comp.cVN
+    vt_kV = net.nodeVec[l.toBus]._vm_pu * net.nodeVec[l.toBus].comp.cVN
+
+    ifrom = (vf_kV > 1e-12) ? (s_abs / (Wurzel3 * vf_kV)) : NaN
+    ito = (vt_kV > 1e-12) ? (s_abs / (Wurzel3 * vt_kV)) : NaN
+    setLinkCurrent!(l, ifrom, ito)
+  end
+end

--- a/src/network.jl
+++ b/src/network.jl
@@ -64,6 +64,7 @@ struct Net
   linesAC::Vector{ACLineSegment}
   trafos::Vector{PowerTransformer}
   branchVec::Vector{Branch}
+  linkVec::Vector{BusLink}
   prosumpsVec::Vector{ProSumer}
   shuntVec::Vector{Shunt}
   busDict::Dict{String,Int}
@@ -93,6 +94,7 @@ struct Net
         [], # linesAC
         [], # trafos
         [], # branchVec
+        [], # linkVec
         [], # prosumpsVec
         [], # shuntVec
         Dict{String,Int}(), # busDict
@@ -122,6 +124,7 @@ struct Net
     println(io, "Lines: ", length(o.linesAC))
     println(io, "Transformers: ", length(o.trafos))
     println(io, "Branches: ", length(o.branchVec))
+    println(io, "Links: ", length(o.linkVec))
     println(io, "Prosumers: ", length(o.prosumpsVec))
     println(io, "Shunts: ", length(o.shuntVec))
     if !isempty(o.qLimitLog)
@@ -373,6 +376,45 @@ function addBranch!(; net::Net, from::Int, to::Int, branch::AbstractBranch, stat
   end
   br = Branch(branchIdx = idBrunch, from = from, to = to, baseMVA = net.baseMVA, branch = branch, id = idBrunch, status = status, ratio = ratio, side = side, vn_kV = vn_kV, fromOid = fOrig, toOid = tOrig)
   push!(net.branchVec, br)
+end
+
+
+"""
+    addLink!(; net::Net, fromBus::String, toBus::String, status::Int = 1)::Int
+
+Adds an impedance-less topological bus link (e.g. busbar coupler) used for
+post-power-flow KCL allocation.
+"""
+function addLink!(; net::Net, fromBus::String, toBus::String, status::Int = 1)::Int
+  @assert !net._locked "Network is locked"
+  from = geNetBusIdx(net = net, busName = fromBus)
+  to = geNetBusIdx(net = net, busName = toBus)
+  @assert from != to "fromBus and toBus must be different"
+
+  idLink = length(net.linkVec) + 1
+  push!(net.linkVec, BusLink(linkIdx = idLink, fromBus = from, toBus = to, status = status))
+  return idLink
+end
+
+"""
+    setNetLinkStatus!(; net::Net, linkNr::Int, status::Int)
+
+Sets an existing link status (0/1).
+"""
+function setNetLinkStatus!(; net::Net, linkNr::Int, status::Int)
+  @assert 1 <= linkNr <= length(net.linkVec) "linkNr out of range"
+  setLinkStatus!(net.linkVec[linkNr], status)
+end
+
+"""
+    getNetLinks(; net::Net, fromBus::String, toBus::String)::Vector{BusLink}
+
+Returns all links between two buses (both directions).
+"""
+function getNetLinks(; net::Net, fromBus::String, toBus::String)::Vector{BusLink}
+  from = geNetBusIdx(net = net, busName = fromBus)
+  to = geNetBusIdx(net = net, busName = toBus)
+  return [l for l in net.linkVec if (l.fromBus == from && l.toBus == to) || (l.fromBus == to && l.toBus == from)]
 end
 
 """

--- a/src/results.jl
+++ b/src/results.jl
@@ -76,6 +76,7 @@ function printACPFlowResults(net::Net, ct::Float64, ite::Int, tol::Float64, toFi
 
   busses = length(net.nodeVec)
   branches = length(net.branchVec)
+  links = length(net.linkVec)
   lines = length(net.linesAC)
   trafos = length(net.trafos)
   gens = 0
@@ -121,6 +122,7 @@ function printACPFlowResults(net::Net, ct::Float64, ite::Int, tol::Float64, toFi
     @printf(io, "Nodes          :%10d (PV: %d PQ: %d Slack: %d)\n", busses, npv, npq, 1)
   end
   @printf(io, "Branches       :%10d\n", branches)
+  @printf(io, "Links          :%10d\n", links)
   @printf(io, "Lines          :%10d\n", lines)
   @printf(io, "Trafos         :%10d\n", trafos)
   @printf(io, "Generators     :%10d\n", gens)
@@ -200,6 +202,19 @@ function printACPFlowResults(net::Net, ct::Float64, ite::Int, tol::Float64, toFi
   @printf(io, "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n")
   println(io, flowResults)
 
+
+  if !isempty(net.linkVec)
+    @printf(io, "\n----------------------------------- Link Flows (KCL) -----------------------------------\n")
+    @printf(io, "| %-5s | %-8s | %-8s | %-6s | %-12s | %-12s | %-12s | %-12s |\n", "Nr", "From", "To", "Stat", "P [MW]", "Q [MVar]", "Ifrom [kA]", "Ito [kA]")
+    @printf(io, "----------------------------------------------------------------------------------------------------------------\n")
+    for l in net.linkVec
+      p = isnothing(l.pFlow_MW) ? NaN : l.pFlow_MW
+      q = isnothing(l.qFlow_MVar) ? NaN : l.qFlow_MVar
+      ifrom = isnothing(l.iFrom_kA) ? NaN : l.iFrom_kA
+      ito = isnothing(l.iTo_kA) ? NaN : l.iTo_kA
+      @printf(io, "| %-5d | %-8d | %-8d | %-6d | %-12.3f | %-12.3f | %-12.4f | %-12.4f |\n", l.linkIdx, l.fromBus, l.toBus, l.status, p, q, ifrom, ito)
+    end
+  end
   if toFile
     close(io)
     #println("Results have been written to $(joinpath(path, filename))")

--- a/src/run_acpflow.jl
+++ b/src/run_acpflow.jl
@@ -46,6 +46,7 @@ function run_acpflow(; max_ite::Int = 10, tol::Float64 = 1e-6, casefile::String,
   if erg == 0 || printResultAnyCase
     # Calculate network losses and print results
     calcNetLosses!(myNet)
+    calcLinkFlowsKCL!(myNet)
     jpath = printResultToFile ? out_path : ""
     printACPFlowResults(myNet, etime, ite, tol, printResultToFile, jpath; converged = (erg == 0), solver = method)
   elseif erg == 1
@@ -79,6 +80,7 @@ function run_net_acpflow(; net::Net, max_ite::Int = 10, tol::Float64 = 1e-6, ver
   if erg == 0 || printResultAnyCase
     # Calculate network losses and print results
     calcNetLosses!(net)
+    calcLinkFlowsKCL!(net)
     jpath = printResultToFile ? out_path : ""
     printACPFlowResults(net, etime, ite, tol, printResultToFile, jpath; converged = (erg == 0), solver = method)
   elseif erg == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,4 +24,5 @@ include("testremove.jl")
   @test test_5BusNet(0, 10.0) == true
   @test test_3BusNet(0, 150.0, :rectangular, false, false) == true
   @test test_3BusNet(0, 150.0, :polar_full, false, false) == true
+  @test test_link_kcl_simple() == true
 end

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -607,3 +607,22 @@ function test_5BusNet(verbose::Int = 0, qlim::Float64 = 20.0, method::Symbol = :
   return hit==true
 end
 export test_3BusNet, test_5BusNet
+
+function test_link_kcl_simple()
+  net = Net(name = "link_kcl", baseMVA = 100.0)
+  addBus!(net = net, busName = "B1", busType = "SLACK", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
+
+  addBusGenPower!(net = net, busName = "B1", pGen = 10.0, qGen = 2.0)
+  addBusLoadPower!(net = net, busName = "B2", pLoad = 10.0, qLoad = 2.0)
+
+  addLink!(net = net, fromBus = "B1", toBus = "B2", status = 1)
+  calcLinkFlowsKCL!(net)
+
+  l = net.linkVec[1]
+  iexp = hypot(10.0, 2.0) / (Sparlectra.Wurzel3 * 110.0)
+  return isapprox(l.pFlow_MW, 10.0; atol = 1e-8) &&
+         isapprox(l.qFlow_MVar, 2.0; atol = 1e-8) &&
+         isapprox(l.iFrom_kA, iexp; atol = 1e-10) &&
+         isapprox(l.iTo_kA, iexp; atol = 1e-10)
+end


### PR DESCRIPTION
### Motivation
- Provide support for impedance-less topological connections between buses (e.g. busbar couplers/sectionalizers) that are not part of the YBUS but need post-power-flow KCL allocation.
- Expose link objects and control APIs to manage link status and inspect flows and currents after power flow.
- Integrate link flow calculation into result reporting so link information is available in normal power-flow runs.

### Description
- Added a new `BusLink` type and helper functions in `src/link.jl`, including `BusLink`, `setLinkStatus!`, `setLinkFlow!`, and `setLinkCurrent!`.
- Extended `Sparlectra.jl` to export and include the new link module and functions (`BusLink`, `setLinkStatus!`, `setLinkFlow!`, `setLinkCurrent!`).
- Added `linkVec` to the `Net` struct and updated `Base.show` for `Net` to list link counts in `src/network.jl`.
- Implemented `addLink!`, `setNetLinkStatus!`, and `getNetLinks` in `src/network.jl` for creating and managing links in a network.
- Implemented `calcLinkFlowsKCL!` in `src/losses.jl` that computes active/reactive link flows and terminal currents using nodal KCL per connected link components, with least-squares solving and small-residual distribution.
- Integrated link flow calculation into run flows by calling `calcLinkFlowsKCL!` after `calcNetLosses!` in `src/run_acpflow.jl` and `src/run_acpflow.jl`'s `run_net_acpflow`.
- Updated result printing in `src/results.jl` to include link counts and a formatted link flow table with P, Q and terminal currents.
- Added a unit test `test_link_kcl_simple()` in `test/testgrid.jl` and registered it in `test/runtests.jl` to verify simple two-bus link flow and current computation.

### Testing
- Added and ran the package test suite via the test runner that executes `test/runtests.jl` including the new `test_link_kcl_simple()` test.
- The full test suite (including `test_link_kcl_simple`) completed successfully.
- The new link behavior was exercised in power-flow runs by calling `calcLinkFlowsKCL!` after `calcNetLosses!` and verified by the added unit test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae8493c8b083308369cd7b0b96a328)