### PR TITLE
Fix return value and tuple typo in test/testgrid.jl

### DIFF
--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -135,7 +135,7 @@ function test_3WTPITrafo(verbose::Int = 0; method::Symbol = :rectangular, opt_fd
     printQLimitLog(net; sort_by = :bus)
   end
 
-  return true
+  return result
 end
 
 function test_acpflow(verbose::Int = 0; lLine_6a6b::Float64 = 0.01, damp::Float64 = 1.0, method::Symbol = :rectangular, opt_sparse = true)::Bool
@@ -180,9 +180,9 @@ function test_NBI_MDO()
   end
 
   for b in myNet.branchVec
-    tupple = (b.fromBus, b.toBus)
-    if tupple ∉ branchTupleSet
-      push!(branchTupleSet, tupple)
+    tuple = (b.fromBus, b.toBus)
+    if tuple ∉ branchTupleSet
+      push!(branchTupleSet, tuple)
     end
   end
 


### PR DESCRIPTION
### Motivation

- Ensure `test_3WTPITrafo` returns the actual computed result so a non-convergent power-flow is reported as failure instead of always passing. 
- Fix a local variable name typo in `test_NBI_MDO` to avoid confusion and improve readability.

### Description

- Change `return true` to `return result` at the end of `test_3WTPITrafo` so the function reflects the computed convergence outcome.
- Rename the local variable `tupple` to `tuple` in `test_NBI_MDO` and push the corrected `tuple` into `branchTupleSet`.
- Commit updates applied to `test/testgrid.jl` and verified the diff/commit.

### Testing

- Attempted to run the test suite with `julia --project -e 'include("test/runtests.jl")'`, but the command failed because `julia` is not available in this environment (`bash: command not found: julia`).
- No automated test results are available due to the missing `julia` runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae94607e248330ab8ffb5ea7e91d6d)