### PR TITLE
Add Q-limit validation, PV/Q locking options, and PF reporting enhancements

### DIFF
--- a/src/Sparlectra.jl
+++ b/src/Sparlectra.jl
@@ -117,7 +117,7 @@ export
   # jacobian_full.jl
   runpf_full!, 
   # limits.jl
-  printQLimitLog, printPVQLimitsTable, logQLimitHit!, lastQLimitIter, getQLimits_pu, logQLimitHit!,lastQLimitIter, resetQLimitLog!, pv_hit_q_limit,has_q_limits,active_set_q_limits!,
+  printQLimitLog, printPVQLimitsTable, printFinalLimitValidation, validate_q_limit_signs!, logQLimitHit!, lastQLimitIter, getQLimits_pu, logQLimitHit!,lastQLimitIter, resetQLimitLog!, pv_hit_q_limit,has_q_limits,active_set_q_limits!,
   # losses.jl
   calcNetLosses!, 
   # results.jl

--- a/src/examples/matpower_import.jl
+++ b/src/examples/matpower_import.jl
@@ -101,28 +101,37 @@ end
 # -----------------------------------------------------------------------------
 # Benchmark helper: benchmark exactly run_acpflow(...)
 # -----------------------------------------------------------------------------
-function bench_run_acpflow(; casefile::String, methods::Vector{Symbol}, opt_fd::Bool = true, opt_sparse::Bool = true, opt_flatstart::Bool = true, verbose::Int = 0, cooldown_iters::Int = 0, q_hyst_pu::Float64 = 0.0, seconds::Float64 = 2.0, samples::Int = 50, show_once::Bool = false)
+function bench_run_acpflow(; casefile::String, methods::Vector{Symbol}, opt_fd::Bool = true, opt_sparse::Bool = true, opt_flatstart::Bool = true, verbose::Int = 0, cooldown_iters::Int = 0, q_hyst_pu::Float64 = 0.0, pv_table_rows::Int = 30, check_q_limit_signs::Bool = false, autocorrect_q_limit_signs::Bool = false, validate_limits_after_pf::Bool = false, q_limit_violation_headroom::Float64 = 0.20, lock_pv_to_pq_buses::AbstractVector{Int} = Int[], seconds::Float64 = 2.0, samples::Int = 50, show_once::Bool = false)
   results = Dict{Symbol,Any}()
 
   # Warmup (compile) once per method with minimal output
   for m in methods
-    run_acpflow(casefile = casefile, opt_fd = opt_fd, opt_sparse = opt_sparse, method = m, opt_flatstart = opt_flatstart, show_results = false, verbose = 0, cooldown_iters = cooldown_iters, q_hyst_pu = q_hyst_pu)
+    run_acpflow(casefile = casefile, opt_fd = opt_fd, opt_sparse = opt_sparse, method = m, opt_flatstart = opt_flatstart, show_results = false, verbose = 0, cooldown_iters = cooldown_iters, q_hyst_pu = q_hyst_pu, pv_table_rows = pv_table_rows, check_q_limit_signs = check_q_limit_signs, autocorrect_q_limit_signs = autocorrect_q_limit_signs, validate_limits_after_pf = validate_limits_after_pf, q_limit_violation_headroom = q_limit_violation_headroom, lock_pv_to_pq_buses = lock_pv_to_pq_buses)
   end
 
   println("\n==================== Benchmark run_acpflow ====================")
   println("casefile        = ", casefile)
   println("opt_fd          = ", opt_fd, "   opt_sparse = ", opt_sparse, "   flatstart = ", opt_flatstart)
   println("cooldown_iters  = ", cooldown_iters, "   q_hyst_pu = ", q_hyst_pu)
+  println("pv_table_rows   = ", pv_table_rows, "   q_headroom = ", q_limit_violation_headroom)
+  println("q_sign_check    = ", check_q_limit_signs, "   q_sign_autocorrect = ", autocorrect_q_limit_signs)
+  println("validate_limits = ", validate_limits_after_pf, "   lock PV->PQ = ", collect(lock_pv_to_pq_buses))
   println("seconds/method  = ", seconds, "   samples = ", samples)
   println("===============================================================\n")
 
   for m in methods
-    benchable = @benchmarkable run_acpflow(casefile = casefile_, opt_fd = opt_fd_, opt_sparse = opt_sparse_, method = method_, opt_flatstart = opt_flatstart_, show_results = false, verbose = 0, cooldown_iters = cooldown_iters_, q_hyst_pu = q_hyst_pu_) setup = (casefile_ = $casefile;
+    benchable = @benchmarkable run_acpflow(casefile = casefile_, opt_fd = opt_fd_, opt_sparse = opt_sparse_, method = method_, opt_flatstart = opt_flatstart_, show_results = false, verbose = 0, cooldown_iters = cooldown_iters_, q_hyst_pu = q_hyst_pu_, pv_table_rows = pv_table_rows_, check_q_limit_signs = check_q_limit_signs_, autocorrect_q_limit_signs = autocorrect_q_limit_signs_, validate_limits_after_pf = validate_limits_after_pf_, q_limit_violation_headroom = q_limit_violation_headroom_, lock_pv_to_pq_buses = lock_pv_to_pq_buses_) setup = (casefile_ = $casefile;
     opt_fd_ = $opt_fd;
     opt_sparse_ = $opt_sparse;
     opt_flatstart_ = $opt_flatstart;
     cooldown_iters_ = $cooldown_iters;
     q_hyst_pu_ = $q_hyst_pu;
+    pv_table_rows_ = $pv_table_rows;
+    check_q_limit_signs_ = $check_q_limit_signs;
+    autocorrect_q_limit_signs_ = $autocorrect_q_limit_signs;
+    validate_limits_after_pf_ = $validate_limits_after_pf;
+    q_limit_violation_headroom_ = $q_limit_violation_headroom;
+    lock_pv_to_pq_buses_ = $lock_pv_to_pq_buses;
     method_ = $m)
 
     b = run(benchable; seconds = seconds, samples = samples)
@@ -157,7 +166,7 @@ function bench_run_acpflow(; casefile::String, methods::Vector{Symbol}, opt_fd::
             println("RUN method = ", m)
             println("=================================================================\n")
 
-            net_res = run_acpflow(casefile = casefile, opt_fd = opt_fd, opt_sparse = opt_sparse, method = m, opt_flatstart = opt_flatstart, show_results = true, verbose = verbose, cooldown_iters = cooldown_iters, q_hyst_pu = q_hyst_pu)
+            net_res = run_acpflow(casefile = casefile, opt_fd = opt_fd, opt_sparse = opt_sparse, method = m, opt_flatstart = opt_flatstart, show_results = true, verbose = verbose, cooldown_iters = cooldown_iters, q_hyst_pu = q_hyst_pu, pv_table_rows = pv_table_rows, check_q_limit_signs = check_q_limit_signs, autocorrect_q_limit_signs = autocorrect_q_limit_signs, validate_limits_after_pf = validate_limits_after_pf, q_limit_violation_headroom = q_limit_violation_headroom, lock_pv_to_pq_buses = lock_pv_to_pq_buses)
 
             # compare (still computed, but details go to logfile)
             if mp_has_vm_va(mpc)
@@ -193,8 +202,9 @@ methods = [:polar_full, :rectangular, :classic]
 
 function main()
   methods = [:polar_full, :rectangular, :classic]
+  lock_pv_to_pq_buses = [44] # analysis example: keep Bus 44 as PV
 
-  bench = bench_run_acpflow(casefile = basename(local_case), methods = methods, opt_fd = false, opt_sparse = true, opt_flatstart = false, verbose = 1, cooldown_iters = 0, q_hyst_pu = 0.0, seconds = 2.0, samples = 50, show_once = true)
+  bench = bench_run_acpflow(casefile = basename(local_case), methods = methods, opt_fd = false, opt_sparse = true, opt_flatstart = false, verbose = 1, cooldown_iters = 0, q_hyst_pu = 0.0, pv_table_rows = 30, check_q_limit_signs = true, autocorrect_q_limit_signs = true, validate_limits_after_pf = true, q_limit_violation_headroom = 0.20, lock_pv_to_pq_buses = lock_pv_to_pq_buses, seconds = 2.0, samples = 50, show_once = true)
   return bench
 end
 

--- a/src/jacobian_complex.jl
+++ b/src/jacobian_complex.jl
@@ -654,7 +654,7 @@ polar formulations.
 - `build_rectangular_jacobian_pq_pv()`: Analytic Jacobian construction
 """
 
-function run_complex_nr_rectangular_for_net!(net::Net; maxiter::Int = 20, tol::Float64 = 1e-8, damp::Float64 = 0.2, verbose::Int = 0, use_fd::Bool = false, opt_sparse::Bool = true, opt_flatstart::Bool = net.flatstart)
+function run_complex_nr_rectangular_for_net!(net::Net; maxiter::Int = 20, tol::Float64 = 1e-8, damp::Float64 = 0.2, verbose::Int = 0, use_fd::Bool = false, opt_sparse::Bool = true, opt_flatstart::Bool = net.flatstart, pv_table_rows::Int = 30, pv_to_pq_blocked::AbstractVector{Bool} = falses(length(net.nodeVec)))
   if verbose > 1
     @info "Running complex rectangular NR power flow... use_fd=$use_fd, opt_sparse=$opt_sparse"
   end
@@ -696,8 +696,10 @@ function run_complex_nr_rectangular_for_net!(net::Net; maxiter::Int = 20, tol::F
 
   # 4) Q-limit data 
   qmin_pu, qmax_pu = getQLimits_pu(net)
-  if verbose > 0
-    printPVQLimitsTable(net)
+  if verbose > 1
+    printPVQLimitsTable(net; max_rows = typemax(Int))
+  elseif verbose > 0
+    printPVQLimitsTable(net; max_rows = pv_table_rows)
   end
 
   # --- Active-set bookkeeping (rectangular solver) ------------------------
@@ -763,6 +765,7 @@ function run_complex_nr_rectangular_for_net!(net::Net; maxiter::Int = 20, tol::F
         allow_reenable = allow_reenable,
         q_hyst_pu = q_hyst_pu,
         cooldown_iters = cooldown_iters,
+        pv_to_pq_blocked = pv_to_pq_blocked,
         verbose = verbose,
 
         # Q required at bus in terms of GENERATOR Q (p.u.)
@@ -890,8 +893,8 @@ Returns:
     (iterations::Int, status::Int)
 where `status == 0` indicates convergence.
 """
-function runpf_rectangular!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; opt_fd::Bool = false, opt_sparse::Bool = true, damp = 1.0, opt_flatstart::Bool = net.flatstart)
-  iters, erg = run_complex_nr_rectangular_for_net!(net; maxiter = maxIte, tol = tolerance, damp = damp, verbose = verbose, use_fd = opt_fd, opt_sparse = opt_sparse, opt_flatstart = opt_flatstart)
+function runpf_rectangular!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; opt_fd::Bool = false, opt_sparse::Bool = true, damp = 1.0, opt_flatstart::Bool = net.flatstart, pv_table_rows::Int = 30, pv_to_pq_blocked::AbstractVector{Bool} = falses(length(net.nodeVec)))
+  iters, erg = run_complex_nr_rectangular_for_net!(net; maxiter = maxIte, tol = tolerance, damp = damp, verbose = verbose, use_fd = opt_fd, opt_sparse = opt_sparse, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, pv_to_pq_blocked = pv_to_pq_blocked)
   return iters, erg
 end
 
@@ -1039,8 +1042,22 @@ Returns:
 
 where `status == 0` indicates convergence.
 """
-function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; method::Symbol = :rectangular, opt_fd::Bool = false, opt_sparse::Bool = true, opt_flatstart::Bool = net.flatstart, damp = 1.0)
+function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; method::Symbol = :rectangular, opt_fd::Bool = false, opt_sparse::Bool = true, opt_flatstart::Bool = net.flatstart, damp = 1.0, pv_table_rows::Int = 30, check_q_limit_signs::Bool = false, autocorrect_q_limit_signs::Bool = false, validate_limits_after_pf::Bool = false, q_limit_violation_headroom::Float64 = 0.20, lock_pv_to_pq_buses::AbstractVector{Int} = Int[])
   wnet, reps, has_merges = _merged_pf_net(net)
+  q_limit_violation_headroom = max(q_limit_violation_headroom, 0.0)
+  lock_pv_to_pq_mask = falses(length(wnet.nodeVec))
+  for bus in lock_pv_to_pq_buses
+    if has_merges && (1 <= bus <= length(reps))
+      lock_pv_to_pq_mask[reps[bus]] = true
+    elseif 1 <= bus <= length(lock_pv_to_pq_mask)
+      lock_pv_to_pq_mask[bus] = true
+    end
+  end
+
+  if check_q_limit_signs
+    qmin_pu, qmax_pu = getQLimits_pu(wnet)
+    validate_q_limit_signs!(qmin_pu, qmax_pu; io = stdout, autocorrect = autocorrect_q_limit_signs, warn = (verbose > 0))
+  end
 
   function _sync_merged_results_to_original!()
     for i in eachindex(net.nodeVec)
@@ -1053,9 +1070,12 @@ function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int =
 
   #@info "Running AC Power Flow using method: $(method)"
   if method === :polar_full
-    iters, erg = runpf_full!(wnet, maxIte, tolerance, verbose; opt_sparse = opt_sparse, opt_flatstart = opt_flatstart)
+    iters, erg = runpf_full!(wnet, maxIte, tolerance, verbose; opt_sparse = opt_sparse, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, pv_to_pq_blocked = lock_pv_to_pq_mask)
     if erg == 0 && has_merges
       _sync_merged_results_to_original!()
+    end
+    if validate_limits_after_pf && (verbose > 0)
+      printFinalLimitValidation(has_merges ? net : wnet; q_headroom = q_limit_violation_headroom)
     end
     return iters, erg
   elseif method === :rectangular
@@ -1063,18 +1083,24 @@ function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int =
       if verbose > 0
         @warn "runpf!: rectangular solver does not support internal Isolated buses from active-link merges; falling back to :polar_full"
       end
-      iters, erg = runpf_full!(wnet, maxIte, tolerance, verbose; opt_sparse = opt_sparse, opt_flatstart = opt_flatstart)
+      iters, erg = runpf_full!(wnet, maxIte, tolerance, verbose; opt_sparse = opt_sparse, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, pv_to_pq_blocked = lock_pv_to_pq_mask)
     else
-      iters, erg = runpf_rectangular!(wnet, maxIte, tolerance, verbose; opt_fd = opt_fd, opt_sparse = opt_sparse, damp = damp, opt_flatstart = opt_flatstart)
+      iters, erg = runpf_rectangular!(wnet, maxIte, tolerance, verbose; opt_fd = opt_fd, opt_sparse = opt_sparse, damp = damp, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, pv_to_pq_blocked = lock_pv_to_pq_mask)
     end
     if erg == 0 && has_merges
       _sync_merged_results_to_original!()
+    end
+    if validate_limits_after_pf && (verbose > 0)
+      printFinalLimitValidation(has_merges ? net : wnet; q_headroom = q_limit_violation_headroom)
     end
     return iters, erg
   elseif method === :classic
     iters, erg = runpf_classic!(wnet, maxIte, tolerance, verbose, opt_sparse, opt_flatstart)
     if erg == 0 && has_merges
       _sync_merged_results_to_original!()
+    end
+    if validate_limits_after_pf && (verbose > 0)
+      printFinalLimitValidation(has_merges ? net : wnet; q_headroom = q_limit_violation_headroom)
     end
     return iters, erg
   else

--- a/src/jacobian_full.jl
+++ b/src/jacobian_full.jl
@@ -223,7 +223,7 @@ end
 # ------------------------------
 # Full Newton-Raphson including PV identity rows (separate from the reduced version)
 # ------------------------------
-function calcNewtonRaphson_withPVIdentity!(net::Net, Y::AbstractMatrix{ComplexF64}, maxIte::Int; tolerance::Float64 = 1e-6, verbose::Int = 0, sparse::Bool = false, flatStart::Bool = false, angle_limit::Bool = false, debug::Bool = false)
+function calcNewtonRaphson_withPVIdentity!(net::Net, Y::AbstractMatrix{ComplexF64}, maxIte::Int; tolerance::Float64 = 1e-6, verbose::Int = 0, sparse::Bool = false, flatStart::Bool = false, angle_limit::Bool = false, debug::Bool = false, pv_table_rows::Int = 30, pv_to_pq_blocked::AbstractVector{Bool} = falses(length(net.nodeVec)))
   if verbose > 0
     @info "Running full-system Newton-Raphson with PV identity rows...sparse=$sparse, flatStart=$flatStart, angle_limit=$angle_limit, debug=$debug"
   end
@@ -260,8 +260,10 @@ function calcNewtonRaphson_withPVIdentity!(net::Net, Y::AbstractMatrix{ComplexF6
 
   adjBranch = adjacentBranches(Y, debug)
   qmin_pu, qmax_pu = getQLimits_pu(net)
-  if verbose > 0
-    printPVQLimitsTable(net)
+  if verbose > 1
+    printPVQLimitsTable(net; max_rows = typemax(Int))
+  elseif verbose > 0
+    printPVQLimitsTable(net; max_rows = pv_table_rows)
   end
 
 
@@ -284,6 +286,7 @@ function calcNewtonRaphson_withPVIdentity!(net::Net, Y::AbstractMatrix{ComplexF6
         allow_reenable = allow_reenable,
         q_hyst_pu = q_hyst_pu,
         cooldown_iters = cooldown_iters,
+        pv_to_pq_blocked = pv_to_pq_blocked,
         verbose = verbose,
 
         # Q required at bus (p.u.) from last residuum evaluation
@@ -409,7 +412,7 @@ end
 # ------------------------------
 # Convenience wrapper similar to runpf!, but for the full system
 # ------------------------------
-function runpf_full!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; opt_sparse::Bool = false, opt_flatstart::Bool = net.flatstart)
+function runpf_full!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; opt_sparse::Bool = false, opt_flatstart::Bool = net.flatstart, pv_table_rows::Int = 30, pv_to_pq_blocked::AbstractVector{Bool} = falses(length(net.nodeVec)))
   printYBus = (length(net.nodeVec) < 20) && (verbose > 1)
   Y = createYBUS(net = net, sparse = opt_sparse, printYBUS = printYBus)
   if verbose > 1
@@ -418,5 +421,5 @@ function runpf_full!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::
     Ydiag_imag_max = maximum(abs.(imag.(diag(Y))))
     @printf "Ybus summary: Yabs_max=%.6e, Ydiag_max=%.6e, Ydiag_imag_max=%.6e\n" Yabs_max Ydiag_max Ydiag_imag_max
   end
-  return calcNewtonRaphson_withPVIdentity!(net, Y, maxIte; tolerance = tolerance, verbose = verbose, sparse = opt_sparse, flatStart = opt_flatstart, angle_limit = false, debug = false)  
+  return calcNewtonRaphson_withPVIdentity!(net, Y, maxIte; tolerance = tolerance, verbose = verbose, sparse = opt_sparse, flatStart = opt_flatstart, angle_limit = false, debug = false, pv_table_rows = pv_table_rows, pv_to_pq_blocked = pv_to_pq_blocked)
 end

--- a/src/limits.jl
+++ b/src/limits.jl
@@ -101,12 +101,12 @@ function getQLimits_pu(net::Net)
 end
 
 """
-    printPVQLimitsTable(net::Net; io::IO=stdout)
+    printPVQLimitsTable(net::Net; io::IO=stdout, max_rows::Int=30)
 
 Print a compact table of PV-bus reactive limits before the PF iteration starts.
 Values are shown in **MVAr**.
 """
-function printPVQLimitsTable(net::Net; io::IO = stdout)
+function printPVQLimitsTable(net::Net; io::IO = stdout, max_rows::Int = 30)
   qmin_pu, qmax_pu = getQLimits_pu(net)
   rows = Tuple{Int,Float64,Float64}[]
 
@@ -126,8 +126,14 @@ function printPVQLimitsTable(net::Net; io::IO = stdout)
   println(io, "──────────────────────────────────────────────")
   println(io, " Bus │      Qmin [MVAr] │      Qmax [MVAr]")
   println(io, "──────────────────────────────────────────────")
-  for (bus, qmin, qmax) in rows
+  shown = max_rows < 0 ? length(rows) : min(max_rows, length(rows))
+  for i in 1:shown
+    bus, qmin, qmax = rows[i]
     @printf(io, " %3d │ %15.6f │ %15.6f\n", bus, qmin, qmax)
+  end
+  if shown < length(rows)
+    println(io, " ...")
+    @printf(io, " (%d more PV rows omitted; increase max_rows for full output)\n", length(rows) - shown)
   end
   println(io, "──────────────────────────────────────────────")
   return nothing
@@ -179,6 +185,136 @@ function _sanitize_q_limits!(qmin_pu::Vector{Float64}, qmax_pu::Vector{Float64},
 end
 
 """
+    validate_q_limit_signs!(qmin_pu, qmax_pu; io::IO=stdout, autocorrect::Bool=false, warn::Bool=true)
+
+Validate Q-limit sign conventions per bus:
+- expect `qmin ≤ 0`
+- expect `qmax ≥ 0`
+- expect `qmin ≤ qmax`
+
+If `autocorrect=true`, suspicious sign-only limits are flipped and inverted ranges are swapped.
+"""
+function validate_q_limit_signs!(qmin_pu::AbstractVector{Float64}, qmax_pu::AbstractVector{Float64}; io::IO = stdout, autocorrect::Bool = false, warn::Bool = true)
+  n = min(length(qmin_pu), length(qmax_pu))
+  corrected = 0
+  flagged = 0
+
+  for bus in 1:n
+    qmin = qmin_pu[bus]
+    qmax = qmax_pu[bus]
+    (isfinite(qmin) || isfinite(qmax)) || continue
+
+    changed = false
+    msgs = String[]
+
+    if isfinite(qmin) && isfinite(qmax) && (qmin > qmax)
+      push!(msgs, "qmin > qmax")
+      if autocorrect
+        qmin_pu[bus], qmax_pu[bus] = qmax, qmin
+        qmin, qmax = qmin_pu[bus], qmax_pu[bus]
+        changed = true
+      end
+    end
+
+    if isfinite(qmin) && (qmin > 0.0)
+      push!(msgs, "qmin positive")
+      if autocorrect
+        qmin_pu[bus] = -abs(qmin)
+        qmin = qmin_pu[bus]
+        changed = true
+      end
+    end
+
+    if isfinite(qmax) && (qmax < 0.0)
+      push!(msgs, "qmax negative")
+      if autocorrect
+        qmax_pu[bus] = abs(qmax)
+        qmax = qmax_pu[bus]
+        changed = true
+      end
+    end
+
+    if !isempty(msgs)
+      flagged += 1
+      if warn
+        action = changed ? "corrected" : "detected"
+        @printf(io, "Warning: Q-limit sign issue at bus %d (%s) -> %s [qmin=%.6f, qmax=%.6f]\n", bus, join(msgs, ", "), action, qmin, qmax)
+      end
+      corrected += changed ? 1 : 0
+    end
+  end
+
+  return (flagged = flagged, corrected = corrected)
+end
+
+function _qlimit_headroom(limit::Float64, headroom::Float64)
+  if !isfinite(limit)
+    return Inf
+  end
+  return abs(limit) * max(headroom, 0.0)
+end
+
+"""
+    printFinalLimitValidation(net::Net; q_headroom::Float64=0.20, io::IO=stdout)
+
+Prints post-PF validation tables for violated Q limits and voltage limits.
+Returns `(q_violations, v_violations)`.
+"""
+function printFinalLimitValidation(net::Net; q_headroom::Float64 = 0.20, io::IO = stdout)
+  qmin_pu, qmax_pu = getQLimits_pu(net)
+  qrows = Tuple{Int,Float64,Float64,Float64,Float64}[]
+  vrows = Tuple{Int,Float64,Float64,Float64}[]
+
+  for (bus, node) in enumerate(net.nodeVec)
+    qgen = node._qƩGen / net.baseMVA
+    if bus <= length(qmin_pu) && isfinite(qmin_pu[bus])
+      lo = qmin_pu[bus]
+      if qgen < (lo - _qlimit_headroom(lo, q_headroom))
+        push!(qrows, (bus, qgen * net.baseMVA, lo * net.baseMVA, qmax_pu[bus] * net.baseMVA, (lo - qgen) * net.baseMVA))
+      end
+    end
+    if bus <= length(qmax_pu) && isfinite(qmax_pu[bus])
+      hi = qmax_pu[bus]
+      if qgen > (hi + _qlimit_headroom(hi, q_headroom))
+        push!(qrows, (bus, qgen * net.baseMVA, qmin_pu[bus] * net.baseMVA, hi * net.baseMVA, (qgen - hi) * net.baseMVA))
+      end
+    end
+
+    vm = node._vm_pu
+    isnothing(vm) && continue
+    vmin = isnothing(node._vmin_pu) ? net.vmin_pu : node._vmin_pu
+    vmax = isnothing(node._vmax_pu) ? net.vmax_pu : node._vmax_pu
+    vmf = Float64(vm)
+    if vmf < vmin || vmf > vmax
+      push!(vrows, (bus, vmf, vmin, vmax))
+    end
+  end
+
+  println(io, "Final limit validation:")
+  if isempty(qrows)
+    @printf(io, "  Q-limits: no violations beyond %.1f%% headroom.\n", 100 * max(q_headroom, 0.0))
+  else
+    println(io, "  Q-limit violations (MVAr):")
+    println(io, "  Bus │      Qgen │      Qmin │      Qmax │  Violation")
+    for (bus, qgen, qmin, qmax, vio) in qrows
+      @printf(io, " %4d │ %9.3f │ %9.3f │ %9.3f │ %10.3f\n", bus, qgen, qmin, qmax, vio)
+    end
+  end
+
+  if isempty(vrows)
+    println(io, "  Voltage limits: no violations.")
+  else
+    println(io, "  Voltage limit violations (p.u.):")
+    println(io, "  Bus │        Vm │      Vmin │      Vmax")
+    for (bus, vm, vmin, vmax) in vrows
+      @printf(io, " %4d │ %9.5f │ %9.5f │ %9.5f\n", bus, vm, vmin, vmax)
+    end
+  end
+
+  return (q_violations = length(qrows), v_violations = length(vrows))
+end
+
+"""
     active_set_q_limits!(
         net, it, nb;
         get_qreq_pu,
@@ -216,6 +352,7 @@ function active_set_q_limits!(
   allow_reenable::Bool,
   q_hyst_pu::Float64,
   cooldown_iters::Int,
+  pv_to_pq_blocked::AbstractVector{Bool} = falses(nb),
   verbose::Int = 0,
 )
   changed   = false
@@ -224,6 +361,7 @@ function active_set_q_limits!(
   # --- PV -> PQ ------------------------------------------------------------
   @inbounds for bus = 1:nb
     is_pv(bus) || continue
+    pv_to_pq_blocked[bus] && continue
     qreq = get_qreq_pu(bus)
 
     has_q_limits(qmin_pu, qmax_pu, bus) || continue

--- a/src/limits.jl
+++ b/src/limits.jl
@@ -264,19 +264,25 @@ function printFinalLimitValidation(net::Net; q_headroom::Float64 = 0.20, io::IO 
   qmin_pu, qmax_pu = getQLimits_pu(net)
   qrows = Tuple{Int,Float64,Float64,Float64,Float64}[]
   vrows = Tuple{Int,Float64,Float64,Float64}[]
+  qgen_missing = 0
 
   for (bus, node) in enumerate(net.nodeVec)
-    qgen = node._qƩGen / net.baseMVA
-    if bus <= length(qmin_pu) && isfinite(qmin_pu[bus])
+    qgen_pu = isnothing(node._qƩGen) ? nothing : (Float64(node._qƩGen) / net.baseMVA)
+    has_qgen = !isnothing(qgen_pu)
+    if !has_qgen && (((bus <= length(qmin_pu)) && isfinite(qmin_pu[bus])) || ((bus <= length(qmax_pu)) && isfinite(qmax_pu[bus])))
+      qgen_missing += 1
+    end
+
+    if has_qgen && (bus <= length(qmin_pu)) && isfinite(qmin_pu[bus])
       lo = qmin_pu[bus]
-      if qgen < (lo - _qlimit_headroom(lo, q_headroom))
-        push!(qrows, (bus, qgen * net.baseMVA, lo * net.baseMVA, qmax_pu[bus] * net.baseMVA, (lo - qgen) * net.baseMVA))
+      if qgen_pu < (lo - _qlimit_headroom(lo, q_headroom))
+        push!(qrows, (bus, qgen_pu * net.baseMVA, lo * net.baseMVA, qmax_pu[bus] * net.baseMVA, (lo - qgen_pu) * net.baseMVA))
       end
     end
-    if bus <= length(qmax_pu) && isfinite(qmax_pu[bus])
+    if has_qgen && (bus <= length(qmax_pu)) && isfinite(qmax_pu[bus])
       hi = qmax_pu[bus]
-      if qgen > (hi + _qlimit_headroom(hi, q_headroom))
-        push!(qrows, (bus, qgen * net.baseMVA, qmin_pu[bus] * net.baseMVA, hi * net.baseMVA, (qgen - hi) * net.baseMVA))
+      if qgen_pu > (hi + _qlimit_headroom(hi, q_headroom))
+        push!(qrows, (bus, qgen_pu * net.baseMVA, qmin_pu[bus] * net.baseMVA, hi * net.baseMVA, (qgen_pu - hi) * net.baseMVA))
       end
     end
 
@@ -299,6 +305,9 @@ function printFinalLimitValidation(net::Net; q_headroom::Float64 = 0.20, io::IO 
     for (bus, qgen, qmin, qmax, vio) in qrows
       @printf(io, " %4d │ %9.3f │ %9.3f │ %9.3f │ %10.3f\n", bus, qgen, qmin, qmax, vio)
     end
+  end
+  if qgen_missing > 0
+    @printf(io, "  Q-limits: skipped %d bus(es) with finite Q-limits but missing _qƩGen.\n", qgen_missing)
   end
 
   if isempty(vrows)

--- a/src/run_acpflow.jl
+++ b/src/run_acpflow.jl
@@ -42,6 +42,12 @@ function run_acpflow(;
   show_results::Bool = true,
   cooldown_iters::Int = 0,
   q_hyst_pu::Float64 = 0.0,
+  pv_table_rows::Int = 30,
+  check_q_limit_signs::Bool = false,
+  autocorrect_q_limit_signs::Bool = false,
+  validate_limits_after_pf::Bool = false,
+  q_limit_violation_headroom::Float64 = 0.20,
+  lock_pv_to_pq_buses::AbstractVector{Int} = Int[],
 )::Net  
   ext = lowercase(splitext(casefile)[2])
   myNet = nothing              # Initialize myNet variable
@@ -92,7 +98,7 @@ function run_acpflow(;
   # Run power flow
   ite = 0
   etime = @elapsed begin
-    ite, erg = runpf!(myNet, max_ite, tol, verbose; opt_fd = opt_fd, opt_sparse = opt_sparse, method = method, opt_flatstart = opt_flatstart)
+    ite, erg = runpf!(myNet, max_ite, tol, verbose; opt_fd = opt_fd, opt_sparse = opt_sparse, method = method, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, check_q_limit_signs = check_q_limit_signs, autocorrect_q_limit_signs = autocorrect_q_limit_signs, validate_limits_after_pf = validate_limits_after_pf, q_limit_violation_headroom = q_limit_violation_headroom, lock_pv_to_pq_buses = lock_pv_to_pq_buses)
   end
   
   if erg == 0 || printResultAnyCase
@@ -123,12 +129,12 @@ Parameters:
 - printResultToFile: Bool, flag to print results to a file (default: false).
 - printResultAnyCase: Bool, flag to print results even if the power flow fails (default: false).
 """
-function run_net_acpflow(; net::Net, max_ite::Int = 30, tol::Float64 = 1e-6, verbose::Int = 0, printResultToFile::Bool = false, printResultAnyCase::Bool = false, opt_fd::Bool = false, opt_sparse::Bool = false, method::Symbol = :polar_full, show_results::Bool = true)
+function run_net_acpflow(; net::Net, max_ite::Int = 30, tol::Float64 = 1e-6, verbose::Int = 0, printResultToFile::Bool = false, printResultAnyCase::Bool = false, opt_fd::Bool = false, opt_sparse::Bool = false, method::Symbol = :polar_full, show_results::Bool = true, pv_table_rows::Int = 30, check_q_limit_signs::Bool = false, autocorrect_q_limit_signs::Bool = false, validate_limits_after_pf::Bool = false, q_limit_violation_headroom::Float64 = 0.20, lock_pv_to_pq_buses::AbstractVector{Int} = Int[])
 
   # Run power flow
   ite = 0
   etime = @elapsed begin
-    ite, erg = runpf!(net, max_ite, tol, verbose; opt_fd = opt_fd, opt_sparse = opt_sparse, method = method)
+    ite, erg = runpf!(net, max_ite, tol, verbose; opt_fd = opt_fd, opt_sparse = opt_sparse, method = method, pv_table_rows = pv_table_rows, check_q_limit_signs = check_q_limit_signs, autocorrect_q_limit_signs = autocorrect_q_limit_signs, validate_limits_after_pf = validate_limits_after_pf, q_limit_violation_headroom = q_limit_violation_headroom, lock_pv_to_pq_buses = lock_pv_to_pq_buses)
   end
 
   if erg == 0 || printResultAnyCase

--- a/test/test_solver_interface.jl
+++ b/test/test_solver_interface.jl
@@ -93,5 +93,40 @@ end
 function run_solver_interface_tests()
   @testset "Solver interface" begin
     @test test_external_solver_interface() == true
+    @testset "Q-limit reporting and validation options" begin
+      net = createTest3BusNet()
+      Sparlectra.setBusType!(net, 1, "PV")
+      Sparlectra.setBusType!(net, 2, "PV")
+      Sparlectra.setBusType!(net, 3, "PV")
+      empty!(net.qmin_pu)
+      append!(net.qmin_pu, [-0.1, 0.05, -0.2])
+      empty!(net.qmax_pu)
+      append!(net.qmax_pu, [0.2, 0.1, 0.3])
+
+      io = IOBuffer()
+      printPVQLimitsTable(net; io = io, max_rows = 2)
+      printed = String(take!(io))
+      @test occursin("more PV rows omitted", printed)
+
+      res = validate_q_limit_signs!(net.qmin_pu, net.qmax_pu; io = io, autocorrect = true, warn = false)
+      @test res.flagged >= 1
+      @test res.corrected >= 1
+      @test net.qmin_pu[2] <= 0.0
+      @test net.qmax_pu[2] >= 0.0
+    end
+
+    @testset "PV->PQ lock option" begin
+      net_unlocked = createTest3BusNet()
+      setQLimits!(net = net_unlocked, qmin_MVar = -1.0, qmax_MVar = 1.0, busName = "STATION1")
+      _, erg_unlocked = runpf!(net_unlocked, 20, 1e-6, 0; method = :rectangular)
+      @test erg_unlocked == 0
+      @test getNodeType(net_unlocked.nodeVec[2]) == Sparlectra.PQ
+
+      net_locked = createTest3BusNet()
+      setQLimits!(net = net_locked, qmin_MVar = -1.0, qmax_MVar = 1.0, busName = "STATION1")
+      _, erg_locked = runpf!(net_locked, 20, 1e-6, 0; method = :rectangular, lock_pv_to_pq_buses = [2])
+      @test erg_locked == 0
+      @test getNodeType(net_locked.nodeVec[2]) == Sparlectra.PV
+    end
   end
 end

--- a/test/test_solver_interface.jl
+++ b/test/test_solver_interface.jl
@@ -128,5 +128,16 @@ function run_solver_interface_tests()
       @test erg_locked == 0
       @test getNodeType(net_locked.nodeVec[2]) == Sparlectra.PV
     end
+
+    @testset "Final limit validation tolerates missing qgen" begin
+      net = createTest3BusNet()
+      net.nodeVec[3]._qƩGen = nothing
+      io = IOBuffer()
+      res = printFinalLimitValidation(net; q_headroom = 0.20, io = io)
+      out = String(take!(io))
+      @test haskey(res, :q_violations)
+      @test haskey(res, :v_violations)
+      @test occursin("Final limit validation:", out)
+    end
   end
 end


### PR DESCRIPTION
### Motivation
- Improve robustness and user feedback around PV reactive-power limits by adding sign validation and optional autocorrection of Q-limits before running power flows.
- Make PV-limit reporting manageable for large networks by allowing limited rows and add a post-solve validation of Q and voltage limit violations.
- Provide an option to lock selected PV buses from being switched to PQ during active-set Q-limit enforcement and expose these controls through the high-level PF interfaces.

### Description
- Added `validate_q_limit_signs!`, `_qlimit_headroom`, and `printFinalLimitValidation` helpers in `limits.jl` to validate/autocorrect Q-limit sign conventions and to summarize post-PF limit violations; extended `printPVQLimitsTable` with a `max_rows` argument for truncation.
- Added a `pv_to_pq_blocked` / `lock_pv_to_pq_buses` mechanism to prevent PV→PQ switching, threading the option through `run_acpflow`, `run_net_acpflow`, `runpf!`, `runpf_full!`, `runpf_rectangular!`, `run_complex_nr_rectangular_for_net!`, and `calcNewtonRaphson_withPVIdentity!`.
- Added PF reporting/validation options to `runpf!` and `run_acpflow` including `pv_table_rows`, `check_q_limit_signs`, `autocorrect_q_limit_signs`, `validate_limits_after_pf`, and `q_limit_violation_headroom` and wired these options to print behavior and validation calls.
- Small UX tweaks: `printPVQLimitsTable` now truncates output and indicates omitted rows, and `runpf!` will optionally print final limit validation after a successful solve.
- Updated example `examples/matpower_import.jl` to expose and demonstrate the new options and to show how to lock a PV bus in analysis, and updated `Sparlectra.jl` exports to include the new functions.

### Testing
- Added unit tests in `test/test_solver_interface.jl` covering `printPVQLimitsTable` truncation, `validate_q_limit_signs!` behavior with autocorrect, and the `lock_pv_to_pq_buses` option for the rectangular solver, which were run as part of the package test suite.
- Executed the package test suite via `Pkg.test()` and confirmed the new tests and existing solver interface tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce76cd7cfc8330931d3143604e4613)