### PR TITLE
ci: add Matpower import workflow

### DIFF
--- a/.github/workflows/Matpower_import.yaml
+++ b/.github/workflows/Matpower_import.yaml
@@ -1,0 +1,45 @@
+name: Matpower Import Example
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/examples/matpower_import.jl'
+      - 'src/MatpowerIO.jl'
+      - 'src/FetchMatpowerCase.jl'
+      - 'src/createnet_powermat.jl'
+      - '.github/workflows/Matpower_import.yaml'
+      - 'Project.toml'
+      - 'Manifest.toml'
+  pull_request:
+    paths:
+      - 'src/examples/matpower_import.jl'
+      - 'src/MatpowerIO.jl'
+      - 'src/FetchMatpowerCase.jl'
+      - 'src/createnet_powermat.jl'
+      - '.github/workflows/Matpower_import.yaml'
+      - 'Project.toml'
+      - 'Manifest.toml'
+  workflow_dispatch:
+
+jobs:
+  matpower-import:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.12'
+
+      - name: Cache Julia artifacts
+        uses: julia-actions/cache@v2
+
+      - name: Instantiate project
+        run: julia --project=. -e 'using Pkg; Pkg.instantiate()'
+
+      - name: Run matpower import example
+        run: julia --project=. src/examples/matpower_import.jl


### PR DESCRIPTION
### Motivation
- Provide a dedicated GitHub Actions job to run the MATPOWER import example so Matpower-related changes trigger a focused CI run and manual verification via `workflow_dispatch`.

### Description
- Add `.github/workflows/Matpower_import.yaml` which checks out the repository, sets up Julia `1.12`, restores Julia cache, runs `julia --project=. -e 'using Pkg; Pkg.instantiate()'`, and executes `julia --project=. src/examples/matpower_import.jl`, and is triggered on `push`/`pull_request` for Matpower-related paths and via `workflow_dispatch`.

### Testing
- Verified Julia availability with `which julia && julia --version` which succeeded, and ran `julia --project=. -e 'using Pkg; Pkg.instantiate()'` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8eeb35dc8330aea0b921df5c098f)