### PR TITLE
Prefer local matpower_import.yaml for VS Code runs

### DIFF
--- a/src/examples/matpower_import.jl
+++ b/src/examples/matpower_import.jl
@@ -83,7 +83,12 @@ end
 
 function _yaml_path_from_inputs()
   !isempty(ARGS) && return ARGS[1]
-  return get(ENV, "SPARLECTRA_MATPOWER_IMPORT_YAML", "")
+  env_path = get(ENV, "SPARLECTRA_MATPOWER_IMPORT_YAML", "")
+  !isempty(env_path) && return env_path
+
+  local_default = joinpath(@__DIR__, "matpower_import.yaml")
+  isfile(local_default) && return local_default
+  return ""
 end
 # -----------------------------------------------------------------------------
 # Configuration

--- a/src/examples/matpower_import.yaml
+++ b/src/examples/matpower_import.yaml
@@ -2,6 +2,7 @@
 # Example configuration for src/examples/matpower_import.jl
 #
 # Usage:
+#   (VS Code "Run Julia File"): config is loaded automatically from this file
 #   julia --project=. src/examples/matpower_import.jl src/examples/matpower_import.yaml
 # or
 #   SPARLECTRA_MATPOWER_IMPORT_YAML=src/examples/matpower_import.yaml julia --project=. src/examples/matpower_import.jl


### PR DESCRIPTION
### Motivation
- Allow running `src/examples/matpower_import.jl` directly from VS Code without requiring external workflow runners or extra environment configuration by automatically picking up the example YAML when present.

### Description
- Update `_yaml_path_from_inputs()` to prefer the first CLI argument, then the `SPARLECTRA_MATPOWER_IMPORT_YAML` environment variable, and finally a local `src/examples/matpower_import.yaml` found via `joinpath(@__DIR__, "matpower_import.yaml")` when present; and add a short usage note to `src/examples/matpower_import.yaml` documenting VS Code "Run Julia File" behavior.

### Testing
- Verified the Julia executable with `which julia && julia --version`, which succeeded on the environment used for validation. 
- Ran `julia --project=. src/examples/matpower_import.jl`, which started and picked up the local YAML config but then failed due to a network download error: `ERROR: LoadError: RequestError: HTTP/1.1 403 Forbidden (CONNECT tunnel failed, response 403) while requesting https://raw.githubusercontent.com/MATPOWER/matpower/master/data/case141.m`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9101f28c8330a962cedff418e165)