### PR TITLE
Dev/r0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package contains tools for subsequent network calculations. It primarily fe
 - MATPOWER-compatible import/export utilities and local casefile helper workflow.
 - Loss calculations and power flow results reporting.
 - Network Modeling: 
-    - Buses (PQ, PV, Slack)
+    - Buses with prosumer-derived PF typing (PQ, PV, Slack)
     - Transmission lines
     - Transformers (2-winding and 3-winding)
     - Generators and loads
@@ -75,6 +75,17 @@ end
 ### Network Creation
 This package supports the import and export of Matpower .m files, although currently it only reads bus, generator, and branch data from these files. Please note that additional Matlab functions within the .m file are not supported. Additionally, you can modify the imported Matpower files or you can create your own network using easy-to-use functions provided by the package.
 
+### Bus typing in power flow
+
+`addBus!` defines the electrical node data (`busName`, `vn_kV`, optional `vm_pu`, `va_deg`).
+The operational PF bus type is resolved from attached prosumers:
+
+- Slack: at least one slack-defining prosumer (`referencePri` set, e.g. `EXTERNALNETWORKINJECTION`).
+- PV: at least one regulating generator prosumer (`isRegulated = true`, or controller metadata, or generator with `vm_pu` setpoint).
+- PQ: default fallback (loads only, non-regulating generation, or mixed non-regulating injections).
+
+The legacy `busType` argument in `addBus!` is still accepted for compatibility, but ignored for PF typing.
+
 ### Release status of State Estimation
 
 The current State Estimation functionality should be considered **experimental**.
@@ -103,7 +114,6 @@ data while still allowing reproducible experiments and benchmarks.
 ### License
 This project is licensed under the Apache License, Version 2.0.
 [The license file](https://github.com/welthulk/Sparlectra.jl/blob/main/LICENSE) contains the complete licensing information.
-
 
 
 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -400,7 +400,7 @@ version = "1.2.2"
 deps = ["BenchmarkTools", "DataFrames", "Dates", "Downloads", "InlineStrings", "LinearAlgebra", "Logging", "Printf", "Random", "SHA", "SparseArrays"]
 path = "c:\\Users\\scud\\.julia\\dev\\Sparlectra\\docs\\.."
 uuid = "31ce9bba-fd9d-44a1-b005-f5f509afda38"
-version = "0.6.1"
+version = "0.6.2"
 
 [[deps.SparseArrays]]
 deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -4,7 +4,8 @@
 * adding sign validation and optional autocorrection of Q-limits before running power flows.
 * Provide an option to lock selected PV buses from being switched to PQ 
 * Added pre-run PV Q-limit preview logging in MVAr for easier diagnostics before the PF iteration loop.
-* 
+* Added `:adjust_vset` controller-based Q-limit handling at PV buses (adaptive Vset steps before optional PV→PQ fallback).
+* Power-flow bus typing is now derived from attached prosumers (Slack > PV > PQ); `addBus!(busType=...)` is legacy-only and no longer defines operational PF type.
 ## Version 0.6.1 – 2026-03-24
 ### New Features
 * Bad Data Detection (BDD) and Statistical Diagnostics for State Estimation (SE)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -11,7 +11,7 @@ This package contains tools for subsequent network calculations. It primarily fe
 - MATPOWER-compatible import/export utilities and local casefile helper workflow.
 - Loss calculations and power flow results reporting.
 - Network Modeling: 
-    - Buses (PQ, PV, Slack)
+    - Buses with prosumer-derived PF typing (PQ, PV, Slack)
     - Transmission lines
     - Transformers (2-winding and 3-winding)
     - Generators and loads

--- a/docs/src/netreports.md
+++ b/docs/src/netreports.md
@@ -10,10 +10,10 @@ using Sparlectra
 
 net = Net(name = "report_demo", baseMVA = 100.0)
 
-addBus!(net = net, busName = "B1", busType = "SLACK", vn_kV = 110.0)
-addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)
-addBus!(net = net, busName = "B4", busType = "PQ", vn_kV = 110.0)
+addBus!(net = net, busName = "B1", vn_kV = 110.0)
+addBus!(net = net, busName = "B2", vn_kV = 110.0)
+addBus!(net = net, busName = "B3", vn_kV = 110.0)
+addBus!(net = net, busName = "B4", vn_kV = 110.0)
 
 addACLine!(net = net, fromBus = "B1", toBus = "B2", length = 5.0, r = 0.05, x = 0.5)
 addACLine!(net = net, fromBus = "B3", toBus = "B4", length = 20.0, r = 0.05, x = 0.5)

--- a/docs/src/powerlimits.md
+++ b/docs/src/powerlimits.md
@@ -196,3 +196,39 @@ step, not only a post-processing label.
 
 For the numerical solver details behind this equation system, see
 [Solver Guide](solver.md).
+
+---
+
+## Alternative to immediate PV→PQ switching: `qlimit_mode = :adjust_vset`
+
+In addition to the default `:switch_to_pq` behavior, Sparlectra supports a
+controller-based strategy for the **rectangular** solver:
+
+```julia
+runpf!(net, 40, 1e-8, 1; method = :rectangular, qlimit_mode = :adjust_vset)
+```
+
+### What it does
+
+When a PV bus reaches a reactive limit, Sparlectra can first try to change the
+voltage setpoint (`vm_pu`) in configured steps (`vstep_pu`) before converting
+the bus to PQ. This can avoid unnecessary PV→PQ switching in operating points
+where a small voltage correction is enough to keep Q inside limits.
+
+### Required controller data
+
+At least one regulating generator prosumer at the PV bus must provide:
+
+* `vstep_pu` (step size),
+* optional `tap_steps_down` / `tap_steps_up` (max number of downward/upward
+  adjustments),
+* and only **one** controller definition per bus is allowed.
+
+If no valid controller is configured (or limits on adjustment steps are
+exhausted), Sparlectra falls back to standard PV→PQ switching.
+
+### Important scope note
+
+`qlimit_mode = :adjust_vset` is currently only supported with
+`method = :rectangular`. For other methods, Sparlectra warns and uses
+`:switch_to_pq` behavior.

--- a/docs/src/state_estimation.md
+++ b/docs/src/state_estimation.md
@@ -212,9 +212,9 @@ println("Converged: ", se.converged, ", iterations: ", se.iterations)
 using Sparlectra
 
 net = Net(name = "se_measurement_driven", baseMVA = 100.0)
-addBus!(net = net, busName = "B1", busType = "Slack", vn_kV = 110.0)
-addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)
+addBus!(net = net, busName = "B1", vn_kV = 110.0)
+addBus!(net = net, busName = "B2", vn_kV = 110.0)
+addBus!(net = net, busName = "B3", vn_kV = 110.0)
 addPIModelACLine!(net = net, fromBus = "B1", toBus = "B2", r_pu = 0.01, x_pu = 0.08, b_pu = 0.0)
 addPIModelACLine!(net = net, fromBus = "B2", toBus = "B3", r_pu = 0.01, x_pu = 0.08, b_pu = 0.0)
 addPIModelACLine!(net = net, fromBus = "B3", toBus = "B1", r_pu = 0.01, x_pu = 0.08, b_pu = 0.0)
@@ -249,9 +249,9 @@ references for you:
 using Sparlectra
 
 net = Net(name = "se_helpers", baseMVA = 100.0)
-addBus!(net = net, busName = "B1", busType = "Slack", vn_kV = 110.0)
-addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)
+addBus!(net = net, busName = "B1", vn_kV = 110.0)
+addBus!(net = net, busName = "B2", vn_kV = 110.0)
+addBus!(net = net, busName = "B3", vn_kV = 110.0)
 addPIModelACLine!(net = net, fromBus = "B1", toBus = "B2", r_pu = 0.01, x_pu = 0.08, b_pu = 0.0)
 addPIModelACLine!(net = net, fromBus = "B2", toBus = "B3", r_pu = 0.01, x_pu = 0.08, b_pu = 0.0)
 addPIModelACLine!(net = net, fromBus = "B3", toBus = "B1", r_pu = 0.01, x_pu = 0.08, b_pu = 0.0)

--- a/docs/src/workshop.md
+++ b/docs/src/workshop.md
@@ -3,6 +3,10 @@
 This workshop guides you through the basic steps of using Sparlectra.jl to
 create, manipulate, and solve power system networks.
 
+> **Note:** `addBus!` creates electrical nodes. The operational PF bus type
+> (Slack/PV/PQ) is derived from attached prosumers. The legacy `busType` input
+> is still accepted for compatibility, but does not define PF behavior.
+
 ## Loading data from a file
 
 ```julia
@@ -43,11 +47,11 @@ net = Net(name = "example_network", baseMVA = 100.0)
 ### Add buses
 
 ```julia
-addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
-addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
-addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
-addBus!(net = net, busName = "B4", busType = "PQ", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
-addBus!(net = net, busName = "B5", busType = "Slack", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+addBus!(net = net, busName = "B1", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+addBus!(net = net, busName = "B2", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+addBus!(net = net, busName = "B3", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+addBus!(net = net, busName = "B4", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+addBus!(net = net, busName = "B5", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
 ```
 
 ### Add AC lines and transformers
@@ -177,11 +181,11 @@ print_results = true
 
 net = Net(name = "workshop_case5", baseMVA = 100.0)
 
-addBus!(net = net, busName = "B1", busType = "PQ",    vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
-addBus!(net = net, busName = "B2", busType = "PQ",    vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
-addBus!(net = net, busName = "B3", busType = "PQ",    vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
-addBus!(net = net, busName = "B4", busType = "PQ",    vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
-addBus!(net = net, busName = "B5", busType = "Slack", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+addBus!(net = net, busName = "B1",    vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+addBus!(net = net, busName = "B2",    vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+addBus!(net = net, busName = "B3",    vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+addBus!(net = net, busName = "B4",    vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+addBus!(net = net, busName = "B5", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
 
 addACLine!(net = net, fromBus = "B1", toBus = "B2", length = 25.0, r = 0.2, x = 0.39)
 addACLine!(net = net, fromBus = "B1", toBus = "B3", length = 25.0, r = 0.2, x = 0.39)
@@ -315,10 +319,10 @@ using Sparlectra
 
 net = Net(name = "workshop_links", baseMVA = 100.0)
 
-addBus!(net = net, busName = "Bus1",  busType = "PQ",    vn_kV = 110.0)
-addBus!(net = net, busName = "Bus1a", busType = "PQ",    vn_kV = 110.0)
-addBus!(net = net, busName = "Bus4",  busType = "PQ",    vn_kV = 110.0)
-addBus!(net = net, busName = "Bus5",  busType = "Slack", vn_kV = 110.0)
+addBus!(net = net, busName = "Bus1",    vn_kV = 110.0)
+addBus!(net = net, busName = "Bus1a",    vn_kV = 110.0)
+addBus!(net = net, busName = "Bus4",    vn_kV = 110.0)
+addBus!(net = net, busName = "Bus5", vn_kV = 110.0)
 
 addPIModelACLine!(net = net, fromBus = "Bus1",  toBus = "Bus4", r_pu = 0.010, x_pu = 0.080, b_pu = 0.0)
 addPIModelACLine!(net = net, fromBus = "Bus1a", toBus = "Bus4", r_pu = 0.009, x_pu = 0.070, b_pu = 0.0)
@@ -377,11 +381,17 @@ Use an existing network or build one as shown above.
 
 ### 2. Define PV buses and Q-limits
 
-Make sure generator buses are of type `PV` and define reactive power limits.
+Define a slack prosumer and a regulating generator (PV behavior), then set Q-limits.
 
 ```julia
-setBusType!(net, "B5", "Slack")
-setBusType!(net, "B1", "PV")
+addProsumer!(
+    net = net,
+    busName = "B5",
+    type = "EXTERNALNETWORKINJECTION",
+    referencePri = "B5",
+    vm_pu = 1.0,
+    va_deg = 0.0,
+)
 
 addProsumer!(
     net = net,
@@ -390,6 +400,7 @@ addProsumer!(
     p = 10.0,
     q = 10.0,
     vm_pu = 1.03,
+    isRegulated = true,
     va_deg = 0.0,
     qMax = 50.0,
     qMin = -50.0,
@@ -473,9 +484,9 @@ using Random
 # 1) Build a simple 7-bus network
 net = Net(name = "workshop_se_7bus", baseMVA = 100.0)
 
-addBus!(net = net, busName = "B1", busType = "Slack", vn_kV = 110.0, vm_pu = 1.02, va_deg = 0.0)
+addBus!(net = net, busName = "B1", vn_kV = 110.0, vm_pu = 1.02, va_deg = 0.0)
 for i in 2:7
-    addBus!(net = net, busName = "B\$(i)", busType = "PQ", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+    addBus!(net = net, busName = "B\$(i)", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
 end
 
 # Ring + cross-connections

--- a/src/Sparlectra.jl
+++ b/src/Sparlectra.jl
@@ -96,10 +96,10 @@ export
   # ACLineSegment
   get_line_parameters, isLinePIModel, getLineRXBG, getLineRXBG_pu,
   # ProSumer
-  isSlack, isGenerator, isAPUNode, setQGenReplacement!, getQGenReplacement, toProSumptionType, updatePQ!, getPosumerBusIndex, setPQResult!,
+  isSlack, isGenerator, isAPUNode, isRegulating, setQGenReplacement!, getQGenReplacement, toProSumptionType, updatePQ!, getPosumerBusIndex, setPQResult!,
   # Network
   addBus!, addShunt!, addACLine!, addPIModelACLine!, add2WTrafo!, addPIModelTrafo!, addProsumer!, lockNet!, validate!, hasBusInNet, addBusGenPower!, addBusLoadPower!, addBusShuntPower!, setNodeVoltage!, setNodeAngle!,
-  getNetOrigBusIdx, geNetBusIdx, setNetBranchStatus!, getNetBranch, getNetBranchNumberVec, setTotalLosses!, getTotalLosses, getBusType, get_bus_vn_kV, get_vn_kV, updateBranchParameters!, hasShunt!, 
+  getNetOrigBusIdx, geNetBusIdx, setNetBranchStatus!, getNetBranch, getNetBranchNumberVec, setTotalLosses!, getTotalLosses, getBusType, getEffectiveBusType, getBusProsumers, refreshBusTypesFromProsumers!, get_bus_vn_kV, get_vn_kV, updateBranchParameters!, hasShunt!, 
   getShunt!, markIsolatedBuses!,setTotalBusPower!, setPVBusVset!, setQLimits!, getNodeVm,distributeBusResults!, getTotalBusPower, getTotalLosses, buildVoltageVector,initialVrect, buildComplexSVec,addShuntMatpower!,
   add2WTPIModelTrafo!, add3WTPiModelTrafo!,showNet, buildQLimits!,updateShuntPowers!, addLink!, setNetLinkStatus!, getNetLinks, calcLinkFlowsKCL!,
   # remove_functions.jl

--- a/src/busdata.jl
+++ b/src/busdata.jl
@@ -43,7 +43,10 @@ function Base.show(io::IO, bus::BusData)
   print(io, "BusData($(bus.idx), $(bus.vm_pu), $(va_deg)°), $(bus.pƩ), $(bus.qƩ), $(bus._pRes), $(bus._qRes), $(bus.type))")
 end
 
-function getBusData(nodes::Vector{Node}, Sbase_MVA::Float64, flatStart)
+function getBusData(nodes::Vector{Node}, Sbase_MVA::Float64, flatStart; net::Union{Nothing,Net} = nothing)
+  if !isnothing(net)
+    refreshBusTypesFromProsumers!(net)
+  end
   busVec = Vector{BusData}()
 
   slackIdx = 0

--- a/src/createnet_powermat.jl
+++ b/src/createnet_powermat.jl
@@ -69,6 +69,10 @@ function createNetFromMatPowerCase(; mpc, log::Bool=false, flatstart::Bool=false
 
   # --- Legacy-compatible dicts (same as your old importer) ---
   busDict, genDict, branchDict = _createDict()
+  mp_bus_type = Dict{Int,Int}()
+  for row in eachrow(busData)
+    mp_bus_type[Int(row[busDict["bus"]])] = Int(row[busDict["type"]])
+  end
 
   if log
     @info "Creating new Net: $(name) with baseMVA=$(baseMVA), flatstart=$(flatstart)"
@@ -116,7 +120,6 @@ function createNetFromMatPowerCase(; mpc, log::Bool=false, flatstart::Bool=false
     addBus!(
       net = myNet,
       busName = busName,
-      busType = toString(toNodeType(btype)),
       vn_kV = vn_kv,
       vm_pu = vm_pu,
       va_deg = va_deg,
@@ -231,6 +234,7 @@ function createNetFromMatPowerCase(; mpc, log::Bool=false, flatstart::Bool=false
     pMin = Float64(row[genDict["Pmin"]])
     vm_pu = Float64(row[genDict["Vg"]])
     mBase = Float64(row[genDict["mBase"]])
+    btype = get(mp_bus_type, Int(row[genDict["bus"]]), 1)
 
     referencePri = (slackIdx == Int(row[genDict["bus"]])) ? bus : nothing
     (mBase != baseMVA) && @debug "generator $(bus) has different mBase than network baseMVA (allowed in MATPOWER)" bus mBase baseMVA
@@ -239,7 +243,7 @@ function createNetFromMatPowerCase(; mpc, log::Bool=false, flatstart::Bool=false
       net = myNet,
       busName = bus,
       type = "GENERATOR",
-      vm_pu = vm_pu,
+      vm_pu = (btype == 2 || btype == 3) ? vm_pu : nothing,
       referencePri = referencePri,
       p = pGen,
       q = qGen,
@@ -247,6 +251,7 @@ function createNetFromMatPowerCase(; mpc, log::Bool=false, flatstart::Bool=false
       pMin = pMin,
       qMax = qMax,
       qMin = qMin,
+      isRegulated = (btype == 2),
     )
   end
 

--- a/src/examples/example_q_limit_voltage_adjustment.jl
+++ b/src/examples/example_q_limit_voltage_adjustment.jl
@@ -2,9 +2,9 @@ using Sparlectra
 
 function build_case(; qmin = -15.0, qmax = 15.0)
   net = Net(name = "q_limit_adjust_demo", baseMVA = 100.0)
-  addBus!(net = net, busName = "SLACK", busType = "SLACK", vn_kV = 20.0)
-  addBus!(net = net, busName = "PV1", busType = "PV", vn_kV = 20.0)
-  addBus!(net = net, busName = "PQ1", busType = "PQ", vn_kV = 20.0)
+  addBus!(net = net, busName = "SLACK", vn_kV = 20.0)
+  addBus!(net = net, busName = "PV1", vn_kV = 20.0)
+  addBus!(net = net, busName = "PQ1", vn_kV = 20.0)
 
   addACLine!(net = net, fromBus = "SLACK", toBus = "PV1", length = 5.0, r = 0.1, x = 0.2, c_nf_per_km = 8.5, tanδ = 0.0)
   addACLine!(net = net, fromBus = "PV1", toBus = "PQ1", length = 8.0, r = 0.1, x = 0.2, c_nf_per_km = 8.5, tanδ = 0.0)

--- a/src/examples/matpower_import.jl
+++ b/src/examples/matpower_import.jl
@@ -138,6 +138,7 @@ function bench_config_for_case(case_name::AbstractString, yaml_cfg::Dict{String,
     seconds = 2.0,
     samples = 50,
     show_once = true,
+    trace_legacy_bus_type_warnings = false,
   )
   case_override = get(CASE_BENCH_OVERRIDES, String(case_name), (;))
   yaml_override = (;)
@@ -159,6 +160,7 @@ function bench_config_for_case(case_name::AbstractString, yaml_cfg::Dict{String,
       seconds = Float64(get(yaml_cfg, "seconds", base.seconds)),
       samples = Int(get(yaml_cfg, "samples", base.samples)),
       show_once = Bool(get(yaml_cfg, "show_once", base.show_once)),
+      trace_legacy_bus_type_warnings = Bool(get(yaml_cfg, "trace_legacy_bus_type_warnings", base.trace_legacy_bus_type_warnings)),
     )
   end
   return merge(base, case_override, yaml_override)
@@ -316,6 +318,10 @@ function main()
   end
 
   cfg = bench_config_for_case(case, yaml_cfg)
+  if cfg.trace_legacy_bus_type_warnings
+    ENV["SPARLECTRA_TRACE_LEGACY_BUSTYPE"] = "1"
+    println("legacy trace     = enabled (SPARLECTRA_TRACE_LEGACY_BUSTYPE=1)")
+  end
   lock_pv_to_pq_buses = cfg.lock_pv_to_pq_buses
   if cfg.ignore_q_limits
     lock_pv_to_pq_buses = _mpc_pv_bus_ids(mpc)

--- a/src/examples/matpower_import.yaml.example
+++ b/src/examples/matpower_import.yaml.example
@@ -32,6 +32,12 @@ tol_va: 0.5
 # - If true, all PV buses are locked against PV->PQ switching.
 #   This effectively ignores reactive-power limits during the solve.
 ignore_q_limits: false
+
+# Legacy warning tracing:
+# - If true, legacy busType warnings include caller=<file>:<line>.
+# - Helpful to identify remaining code paths that still call addBus!(... busType=...)
+#   or setBusType! during import/solver runs.
+trace_legacy_bus_type_warnings: true
 # - Fine-grained manual locks (MATPOWER/original bus IDs). Applied when ignore_q_limits=false.
 lock_pv_to_pq_buses: []
 

--- a/src/examples/network_analyzer.jl
+++ b/src/examples/network_analyzer.jl
@@ -100,12 +100,12 @@ function test_debug()
   net = Net(name = "remove_test", baseMVA = 100.0)
 
   # Add buses
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B4", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B5", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net, busName = "B6", busType = "PV", vn_kV = 20.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)
+  addBus!(net = net, busName = "B4", vn_kV = 110.0)
+  addBus!(net = net, busName = "B5", vn_kV = 110.0)
+  addBus!(net = net, busName = "B6", vn_kV = 20.0)
 
   # Add lines
   addACLine!(net = net, fromBus = "B1", toBus = "B2", length = 10.0, r = 0.01, x = 0.1, c_nf_per_km = 10.0, tanδ = 0.0, ratedS = 100.0)

--- a/src/examples/state_estimation_manual_measurements.jl
+++ b/src/examples/state_estimation_manual_measurements.jl
@@ -27,9 +27,9 @@ using Random
 function build_manual_measurement_example_net()
   net = Net(name = "se_manual_measurements", baseMVA = 100.0)
 
-  addBus!(net = net, busName = "B1", busType = "Slack", vn_kV = 110.0, vm_pu = 1.02, va_deg = 0.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
-  addBus!(net = net, busName = "B3", busType = "PV", vn_kV = 110.0, vm_pu = 1.01, va_deg = 0.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0, vm_pu = 1.02, va_deg = 0.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0, vm_pu = 1.0, va_deg = 0.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0, vm_pu = 1.01, va_deg = 0.0)
 
   addPIModelACLine!(net = net, fromBus = "B1", toBus = "B2", r_pu = 0.010, x_pu = 0.080, b_pu = 0.0, status = 1)
   addPIModelACLine!(net = net, fromBus = "B2", toBus = "B3", r_pu = 0.012, x_pu = 0.090, b_pu = 0.0, status = 1)

--- a/src/examples/state_estimation_passive_bus_zib_comparison.jl
+++ b/src/examples/state_estimation_passive_bus_zib_comparison.jl
@@ -23,9 +23,9 @@ using Random
 function build_passive_transit_example_net()
   net = Net(name = "se_passive_transit_example", baseMVA = 100.0)
 
-  addBus!(net = net, busName = "Slack", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net, busName = "Transit", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "Load", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "Slack", vn_kV = 110.0)
+  addBus!(net = net, busName = "Transit", vn_kV = 110.0)
+  addBus!(net = net, busName = "Load", vn_kV = 110.0)
 
   addACLine!(net = net, fromBus = "Slack", toBus = "Transit", length = 10.0, r = 0.02, x = 0.2, c_nf_per_km = 0.0, tanδ = 0.0)
   addACLine!(net = net, fromBus = "Transit", toBus = "Load", length = 8.0, r = 0.02, x = 0.2, c_nf_per_km = 0.0, tanδ = 0.0)

--- a/src/examples/usage_state_estimation_diagnostics.jl
+++ b/src/examples/usage_state_estimation_diagnostics.jl
@@ -28,9 +28,9 @@ using Printf
 function _create_demo_net()
   net = Net(name = "se_diagnostics_demo", baseMVA = 100.0)
 
-  addBus!(net = net, busName = "Slack", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net, busName = "LoadA", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "LoadB", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "Slack", vn_kV = 110.0)
+  addBus!(net = net, busName = "LoadA", vn_kV = 110.0)
+  addBus!(net = net, busName = "LoadB", vn_kV = 110.0)
 
   addACLine!(net = net, fromBus = "Slack", toBus = "LoadA", length = 12.0, r = 0.02, x = 0.2, c_nf_per_km = 0.0, tanδ = 0.0)
   addACLine!(net = net, fromBus = "LoadA", toBus = "LoadB", length = 9.0, r = 0.02, x = 0.2, c_nf_per_km = 0.0, tanδ = 0.0)

--- a/src/examples/using_links.jl
+++ b/src/examples/using_links.jl
@@ -51,12 +51,12 @@ function build_link_demo_net(; link_closed::Bool)
   net = Net(name = link_closed ? "using_links_closed" : "using_links_open", baseMVA = 100.0)
 
   # Buses: five base buses + additional Bus1a.
-  addBus!(net = net, busName = "Bus1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "Bus1a", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "Bus2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "Bus3", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "Bus4", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "Bus5", busType = "Slack", vn_kV = 110.0)
+  addBus!(net = net, busName = "Bus1", vn_kV = 110.0)
+  addBus!(net = net, busName = "Bus1a", vn_kV = 110.0)
+  addBus!(net = net, busName = "Bus2", vn_kV = 110.0)
+  addBus!(net = net, busName = "Bus3", vn_kV = 110.0)
+  addBus!(net = net, busName = "Bus4", vn_kV = 110.0)
+  addBus!(net = net, busName = "Bus5", vn_kV = 110.0)
 
   # Requested branches.
   addPIModelACLine!(net = net, fromBus = "Bus1", toBus = "Bus3", r_pu = 0.010, x_pu = 0.080, b_pu = 0.0, status = 1)

--- a/src/examples/using_netreports.jl
+++ b/src/examples/using_netreports.jl
@@ -31,10 +31,10 @@ This example demonstrates:
 function main()
   net = Net(name = "netreport_demo", baseMVA = 100.0)
 
-  addBus!(net = net, busName = "B1", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B4", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)
+  addBus!(net = net, busName = "B4", vn_kV = 110.0)
 
   addACLine!(net = net, fromBus = "B1", toBus = "B2", length = 5.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)
   addACLine!(net = net, fromBus = "B3", toBus = "B4", length = 20.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)

--- a/src/examples/visul_chaos.jl
+++ b/src/examples/visul_chaos.jl
@@ -116,9 +116,9 @@ function create_base_network()
   net = Net(name = "BaseNetwork", baseMVA = 100.0, vmin_pu = 0.1, vmax_pu = 2.0)
   base_r, base_x = 0.02, 0.08
 
-  addBus!(net = net, busName = "B1", busType = "Slack", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B3", busType = "PV", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)
 
   addACLine!(net = net, fromBus = "B1", toBus = "B2", length = 15.0, r = base_r, x = base_x, b = 0.0, ratedS = 100.0)
   addACLine!(net = net, fromBus = "B2", toBus = "B3", length = 20.0, r = (base_r + 0.01), x = (base_x + 0.02), b = 0.0, ratedS = 100.0)
@@ -133,9 +133,9 @@ end
 function create_variable_network(; resistance_factor = 1.0, load_factor = 1.0, impedance_factor = 1.0)
   net = Net(name = "VarNet_R$(resistance_factor)_L$(load_factor)_X$(impedance_factor)", baseMVA = 100.0, vmin_pu = 0.1, vmax_pu = 2.0)
 
-  addBus!(net = net, busName = "B1", busType = "Slack", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B3", busType = "PV", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)
 
   base_r, base_x = 0.02, 0.08
   r_mult = resistance_factor

--- a/src/jacobian_complex.jl
+++ b/src/jacobian_complex.jl
@@ -921,9 +921,9 @@ function run_complex_nr_rectangular_for_net!(net::Net; maxiter::Int = 20, tol::F
   # --- mirror bus_types back into Net/node types (PV->PQ switching) ---
   @inbounds for k = 1:n
     if bus_types[k] == :PQ
-      setBusType!(net, k, "PQ")
+      setNodeType!(net.nodeVec[k], "PQ")
     elseif bus_types[k] == :PV
-      setBusType!(net, k, "PV")
+      setNodeType!(net.nodeVec[k], "PV")
     end
   end
   update_net_voltages_from_complex!(net, V)

--- a/src/jacobian_complex.jl
+++ b/src/jacobian_complex.jl
@@ -1141,6 +1141,7 @@ where `status == 0` indicates convergence.
 """
 function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; method::Symbol = :rectangular, opt_fd::Bool = false, opt_sparse::Bool = true, opt_flatstart::Bool = net.flatstart, damp = 1.0, pv_table_rows::Int = 30, validate_limits_after_pf::Bool = false, q_limit_violation_headroom::Float64 = 0.0, lock_pv_to_pq_buses::AbstractVector{Int} = Int[], qlimit_mode::Symbol = :switch_to_pq, qlimit_max_outer::Int = 30)
   wnet, reps, has_merges = _merged_pf_net(net)
+  refreshBusTypesFromProsumers!(wnet)
 
   function _sync_merged_results_to_original!()
     for i in eachindex(net.nodeVec)

--- a/src/network.jl
+++ b/src/network.jl
@@ -248,6 +248,22 @@ end
 end
 
 const _setbus_bus_type_warned = Ref(false)
+const _legacy_bus_type_trace_keys = ("1", "true", "yes", "on")
+
+@inline function _trace_legacy_bus_type_warnings()::Bool
+  return lowercase(get(ENV, "SPARLECTRA_TRACE_LEGACY_BUSTYPE", "0")) in _legacy_bus_type_trace_keys
+end
+
+function _legacy_bus_type_caller_hint()::String
+  bt = stacktrace()
+  for fr in bt
+    f = String(fr.file)
+    if !occursin("src/network.jl", f)
+      return "$(basename(f)):$(fr.line)"
+    end
+  end
+  return "unknown"
+end
 
 """
 Sets the type of a bus in the network.
@@ -259,7 +275,11 @@ Sets the type of a bus in the network.
 """
 function setBusType!(net::Net, bus::Int, busType::String)
   if !_setbus_bus_type_warned[]
-    @warn "setBusType! only updates the static node label. Power-flow bus typing is derived from attached prosumers."
+    msg = "setBusType! only updates the static node label. Power-flow bus typing is derived from attached prosumers."
+    if _trace_legacy_bus_type_warnings()
+      msg *= " caller=" * _legacy_bus_type_caller_hint()
+    end
+    @warn msg
     _setbus_bus_type_warned[] = true
   end
   @assert 1 <= bus <= length(net.nodeVec) "The $bus index is invalid. It must be between 1 and $(length(net.nodeVec))."
@@ -421,7 +441,11 @@ function addBus!(;
   if !isnothing(busType)
     @assert busType in ["Slack", "SLACK", "PQ", "PV"] "Invalid bus type: $busType"
     if !_addbus_bus_type_warned[]
-      @warn "addBus!: `busType` is a legacy input. Power-flow bus typing is derived from attached prosumers."
+      msg = "addBus!: `busType` is a legacy input. Power-flow bus typing is derived from attached prosumers."
+      if _trace_legacy_bus_type_warnings()
+        msg *= " caller=" * _legacy_bus_type_caller_hint()
+      end
+      @warn msg
       _addbus_bus_type_warned[] = true
     end
   end

--- a/src/network.jl
+++ b/src/network.jl
@@ -364,9 +364,6 @@ function getEffectiveBusType(net::Net, busIdx::Int)::NodeType
 
   for ps in getBusProsumers(net, busIdx)
     if isSlack(ps)
-      if has_slack
-        error("Multiple slack-defining prosumers at bus index $busIdx are not supported.")
-      end
       has_slack = true
     end
     if isGenerator(ps) && isRegulating(ps)
@@ -860,7 +857,7 @@ function add3WTPiModelTrafo!(; net::Net, HBBus::String, MBBus::String, LVBus::St
 
   # --- create AUX bus if missing ---
   if !hasBusInNet(net = net, busName = aux_bus)
-    addBus!(net = net, busName = aux_bus, busType = "PQ", vn_kV = U_aux_kV, isAux = true)
+    addBus!(net = net, busName = aux_bus, vn_kV = U_aux_kV, isAux = true)
   end
 
   # --- define ratios for each branch AUX->side ---

--- a/src/network.jl
+++ b/src/network.jl
@@ -247,6 +247,8 @@ end
   return v
 end
 
+const _setbus_bus_type_warned = Ref(false)
+
 """
 Sets the type of a bus in the network.
 
@@ -256,6 +258,10 @@ Sets the type of a bus in the network.
 - `busType::String`: Type of the bus (e.g., "Slack", "PQ", "PV")
 """
 function setBusType!(net::Net, bus::Int, busType::String)
+  if !_setbus_bus_type_warned[]
+    @warn "setBusType! only updates the static node label. Power-flow bus typing is derived from attached prosumers."
+    _setbus_bus_type_warned[] = true
+  end
   @assert 1 <= bus <= length(net.nodeVec) "The $bus index is invalid. It must be between 1 and $(length(net.nodeVec))."
   node  = net.nodeVec[bus]
   oldTy = getfield(node, :_nodeType)
@@ -322,14 +328,69 @@ function getNetOrigBusIdx(; net::Net, busName::String)::Int
   return net.busOrigIdxDict[id]
 end
 
+function getBusProsumers(net::Net, busIdx::Int)::Vector{ProSumer}
+  bus_ps = ProSumer[]
+  for ps in net.prosumpsVec
+    if getPosumerBusIndex(ps) == busIdx
+      push!(bus_ps, ps)
+    end
+  end
+  return bus_ps
+end
+
+function getEffectiveBusType(net::Net, busIdx::Int)::NodeType
+  has_slack = false
+  has_regulating = false
+
+  for ps in getBusProsumers(net, busIdx)
+    if isSlack(ps)
+      if has_slack
+        error("Multiple slack-defining prosumers at bus index $busIdx are not supported.")
+      end
+      has_slack = true
+    end
+    if isGenerator(ps) && isRegulating(ps)
+      has_regulating = true
+    end
+  end
+
+  if has_slack
+    return Slack
+  elseif has_regulating
+    return PV
+  else
+    return PQ
+  end
+end
+
+function getEffectiveBusType(; net::Net, busName::String)::NodeType
+  busIdx = geNetBusIdx(net = net, busName = busName)
+  return getEffectiveBusType(net, busIdx)
+end
+
+function refreshBusTypesFromProsumers!(net::Net)
+  empty!(net.slackVec)
+  for busIdx in eachindex(net.nodeVec)
+    if net.nodeVec[busIdx]._nodeType == Isolated
+      continue
+    end
+    node_type = getEffectiveBusType(net, busIdx)
+    net.nodeVec[busIdx]._nodeType = node_type
+    if node_type == Slack
+      push!(net.slackVec, busIdx)
+    end
+  end
+  return nothing
+end
+
 """
 addBus!: Adds a bus to the network.
 
 Parameters:
 - `net::Net`: Network object.
 - `busName::String`: Name of the bus.
-- `busType::String`: Type of the bus (e.g., "Slack", "PQ", "PV").
 - `vn_kV::Float64`: Nominal voltage of the bus in kV.
+- `busType::Union{Nothing,String} = nothing`: Legacy static bus label (deprecated, ignored for PF typing).
 - `vm_pu::Float64 = 1.0`: Voltage magnitude of the bus in per unit (default is 1.0).
 - `va_deg::Float64 = 0.0`: Voltage angle of the bus in degrees (default is 0.0).
 - `vmin_pu::Union{Nothing,Float64} = nothing`: Minimum voltage limit in per unit (default is network's vmin_pu).
@@ -340,11 +401,13 @@ Parameters:
 - `area::Union{Nothing,Int} = nothing`: Area index (default is nothing).
 - `ratedS::Union{Nothing,Float64} = nothing`: Rated power of the bus in MVA (default is nothing).
 """
+const _addbus_bus_type_warned = Ref(false)
+
 function addBus!(;
   net::Net,
   busName::String,
-  busType::String,
   vn_kV::Float64,
+  busType::Union{Nothing,String} = nothing,
   vm_pu::Float64 = 1.0,
   va_deg::Float64 = 0.0,
   vmin_pu::Union{Nothing,Float64} = nothing,
@@ -355,7 +418,13 @@ function addBus!(;
   area::Union{Nothing,Int} = nothing,
   ratedS::Union{Nothing,Float64} = nothing,
 )
-  @assert busType in ["Slack", "SLACK", "PQ", "PV"] "Invalid bus type: $busType"
+  if !isnothing(busType)
+    @assert busType in ["Slack", "SLACK", "PQ", "PV"] "Invalid bus type: $busType"
+    if !_addbus_bus_type_warned[]
+      @warn "addBus!: `busType` is a legacy input. Power-flow bus typing is derived from attached prosumers."
+      _addbus_bus_type_warned[] = true
+    end
+  end
 
   if net._locked
     @error "Network is locked"
@@ -377,11 +446,12 @@ function addBus!(;
     end
   end
 
-  if (uppercase(busType) == "SLACK") || (uppercase(busType) == "Slack ")
+  static_bus_type = isnothing(busType) ? "PQ" : busType
+  if uppercase(static_bus_type) == "SLACK"
     push!(net.slackVec, busIdx)
   end
 
-  node = Node(busIdx = busIdx, vn_kV = vn_kV, nodeType = toNodeType(busType), vm_pu = vm_pu, va_deg = va_deg, vmin_pu = vmin_pu, vmax_pu = vmax_pu, isAux = isAux, oBusIdx = oBusIdx, zone = zone, area = area, ratedS = ratedS)
+  node = Node(busIdx = busIdx, vn_kV = vn_kV, nodeType = toNodeType(static_bus_type), vm_pu = vm_pu, va_deg = va_deg, vmin_pu = vmin_pu, vmax_pu = vmax_pu, isAux = isAux, oBusIdx = oBusIdx, zone = zone, area = area, ratedS = ratedS)
   push!(net.nodeVec, node)
 end
 
@@ -870,6 +940,7 @@ Add a prosumer (combination of a producer and consumer) to the network.
 - `referencePri::Union{Nothing, String}`: Reference bus for the prosumer. Default is `nothing`.
 - `vm_pu::Union{Nothing, Float64}`: Voltage magnitude setpoint. Default is `nothing`.
 - `va_deg::Union{Nothing, Float64}`: Voltage angle setpoint. Default is `nothing`.
+- `isRegulated::Bool`: Marks a prosumer as voltage-regulating for PV bus resolution. Default is `false`.
 """
 function addProsumer!(;
   net::Net,
@@ -887,6 +958,7 @@ function addProsumer!(;
   vstep_pu::Union{Nothing,Float64} = nothing,
   tap_steps_down::Union{Nothing,Int} = nothing,
   tap_steps_up::Union{Nothing,Int} = nothing,
+  isRegulated::Bool = false,
 )
   busIdx = geNetBusIdx(net = net, busName = busName)
   idProsSum = length(net.prosumpsVec) + 1
@@ -904,7 +976,8 @@ function addProsumer!(;
   proTy = toProSumptionType(type)
   refPriIdx = isnothing(referencePri) ? nothing : geNetBusIdx(net = net, busName = referencePri)
   vn_kV = getNodeVn(net.nodeVec[busIdx])
-  ps = ProSumer(vn_kv = vn_kV, busIdx = busIdx, oID = idProsSum, type = proTy, p = p, q = q, minP = pMin, maxP = pMax, minQ = qMin, maxQ = qMax, referencePri = refPriIdx, vm_pu = vm_pu, va_deg = va_deg, vstep_pu = vstep_pu, tap_steps_down = tap_steps_down, tap_steps_up = tap_steps_up, isAPUNode = isAPUNode)
+  auto_regulated = isRegulated || (isGenerator(proTy) && !isnothing(vm_pu))
+  ps = ProSumer(vn_kv = vn_kV, busIdx = busIdx, oID = idProsSum, type = proTy, p = p, q = q, minP = pMin, maxP = pMax, minQ = qMin, maxQ = qMax, referencePri = refPriIdx, vm_pu = vm_pu, va_deg = va_deg, vstep_pu = vstep_pu, tap_steps_down = tap_steps_down, tap_steps_up = tap_steps_up, isRegulated = auto_regulated, isAPUNode = isAPUNode)
   push!(net.prosumpsVec, ps)
   node = net.nodeVec[busIdx]
   if (isGenerator(proTy))
@@ -913,6 +986,7 @@ function addProsumer!(;
     addLoadPower!(node = node, p = p, q = q)
   end
 
+  refreshBusTypesFromProsumers!(net)
   _buildQLimits!(net)
 end
 
@@ -1224,8 +1298,7 @@ Get the type of a specific bus in the network.
 The type of the specified bus.
 """
 function getBusType(; net::Net, busName::String)
-  busIdx = geNetBusIdx(net = net, busName = busName)
-  return net.nodeVec[busIdx]._nodeType
+  return getEffectiveBusType(net = net, busName = busName)
 end
 
 """

--- a/src/prosumer.jl
+++ b/src/prosumer.jl
@@ -60,6 +60,7 @@ mutable struct ProSumer
   vstep_pu::Union{Nothing,Float64}
   tap_steps_down::Union{Nothing,Int}
   tap_steps_up::Union{Nothing,Int}
+  isRegulated::Bool
   proSumptionType::ProSumptionType
   isAPUNode::Bool
   qGenRepl::Union{Nothing,Float64}
@@ -87,6 +88,7 @@ mutable struct ProSumer
     vstep_pu::Union{Nothing,Float64} = nothing,
     tap_steps_down::Union{Nothing,Int} = nothing,
     tap_steps_up::Union{Nothing,Int} = nothing,
+    isRegulated::Bool = false,
     isAPUNode::Bool = false,
   )
     comp = getProSumPGMComp(vn_kv, busIdx, isGenerator(type), oID)
@@ -99,7 +101,7 @@ mutable struct ProSumer
       va_deg = 0.0
     end
 
-    new(comp, ratedS, ratedU, qPercent, p, q, maxP, minP, maxQ, minQ, ratedPowerFactor, referencePri, vm_pu, va_deg, vstep_pu, tap_steps_down, tap_steps_up, type, isAPUNode, nothing, nothing, nothing)
+    new(comp, ratedS, ratedU, qPercent, p, q, maxP, minP, maxQ, minQ, ratedPowerFactor, referencePri, vm_pu, va_deg, vstep_pu, tap_steps_down, tap_steps_up, isRegulated, type, isAPUNode, nothing, nothing, nothing)
   end
 
   function Base.show(io::IO, prosumption::ProSumer)
@@ -165,6 +167,9 @@ mutable struct ProSumer
     end
     if (!isnothing(prosumption.tap_steps_up))
       print(io, "tap_steps_up: ", prosumption.tap_steps_up, ", ")
+    end
+    if prosumption.isRegulated
+      print(io, "isRegulated: true, ")
     end
 
     if (!isnothing(prosumption.qGenRepl))
@@ -243,6 +248,11 @@ function isSlack(o::ProSumer)
   else
     return false
   end
+end
+
+function isRegulating(o::ProSumer)::Bool
+  has_controller = !isnothing(o.vstep_pu) || !isnothing(o.tap_steps_down) || !isnothing(o.tap_steps_up)
+  return o.isRegulated || has_controller
 end
 
 function toProSumptionType(o::ComponentTyp)::ProSumptionType

--- a/src/remove_functions.jl
+++ b/src/remove_functions.jl
@@ -431,6 +431,8 @@ function removeProsumer!(; net::Net, busName::String, type::String = "")::Bool
     node._qƩLoad = 0.0
   end
 
+  refreshBusTypesFromProsumers!(net)
+  _buildQLimits!(net)
   return true
 end
 

--- a/src/solver_core.jl
+++ b/src/solver_core.jl
@@ -93,6 +93,7 @@ end
 bus_types uses :Slack/:PV/:PQ, Vset is vm setpoint (PV) or current vm default.
 """
 function extract_bus_types_and_vset(net::Net)
+  refreshBusTypesFromProsumers!(net)
   n         = length(net.nodeVec)
   bus_types = Vector{Symbol}(undef, n)
   Vset      = Vector{Float64}(undef, n)

--- a/src/solver_interface.jl
+++ b/src/solver_interface.jl
@@ -149,7 +149,7 @@ end
     buildPfModel(net; opt_sparse=true, flatstart=net.flatstart, include_limits=true, verbose=0) -> PFModel
 
 Build a canonical PF model from `net`:
-- active buses are defined via `getBusData(net.nodeVec, net.baseMVA, flatstart)`,
+- active buses are defined via `getBusData(net.nodeVec, net.baseMVA, flatstart; net=net)`,
   which excludes isolated buses and sorts by bus index. :contentReference[oaicite:5]{index=5}
 - Ybus is built via `createYBUS(net=net, sparse=opt_sparse, ...)` and is consistent
   with the same isolated-bus compression. :contentReference[oaicite:6]{index=6}
@@ -164,7 +164,7 @@ function buildPfModel(
   verbose::Int = 0,
 )
   # 1) BusData provides canonical active-bus ordering (skip iso, sort by idx)
-  busVec, slackNum = getBusData(net.nodeVec, net.baseMVA, flatstart)
+  busVec, slackNum = getBusData(net.nodeVec, net.baseMVA, flatstart; net = net)
   n = length(busVec)
   n == 0 && error("buildPfModel: empty busVec (no active buses).")
 

--- a/test/test_solver_interface.jl
+++ b/test/test_solver_interface.jl
@@ -95,9 +95,9 @@ function run_solver_interface_tests()
     @test test_external_solver_interface() == true
     @testset "Q-limit reporting and validation options" begin
       net = createTest3BusNet()
-      Sparlectra.setBusType!(net, 1, "PV")
-      Sparlectra.setBusType!(net, 2, "PV")
-      Sparlectra.setBusType!(net, 3, "PV")
+      net.nodeVec[1]._nodeType = Sparlectra.PV
+      net.nodeVec[2]._nodeType = Sparlectra.PV
+      net.nodeVec[3]._nodeType = Sparlectra.PV
       empty!(net.qmin_pu)
       append!(net.qmin_pu, [-0.1, 0.05, -0.2])
       empty!(net.qmax_pu)

--- a/test/test_state_estimation.jl
+++ b/test/test_state_estimation.jl
@@ -206,9 +206,9 @@ end
 function create_state_estimation_passive_transit_net()::Net
   net = Net(name = "se_passive_transit", baseMVA = 100.0)
 
-  addBus!(net = net, busName = "Slack", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net, busName = "Transit", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "Load", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "Slack", vn_kV = 110.0)
+  addBus!(net = net, busName = "Transit", vn_kV = 110.0)
+  addBus!(net = net, busName = "Load", vn_kV = 110.0)
 
   addACLine!(net = net, fromBus = "Slack", toBus = "Transit", length = 10.0, r = 0.02, x = 0.2, c_nf_per_km = 0.0, tanδ = 0.0)
   addACLine!(net = net, fromBus = "Transit", toBus = "Load", length = 8.0, r = 0.02, x = 0.2, c_nf_per_km = 0.0, tanδ = 0.0)

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -1459,29 +1459,21 @@ function test_bus_type_resolution_from_prosumers()::Bool
   return ok_types && pv_regulation_ok && genpq_regulation_ok
 end
 
-function test_regulated_generator_bus_targets_include_unregulated_generators()::Bool
-  net = Net(name = "regulated_generator_bus_targets", baseMVA = 100.0)
-  addBus!(net = net, busName = "Slack", vn_kV = 110.0)
-  addBus!(net = net, busName = "PVBus", vn_kV = 110.0)
+function test_multiple_slack_prosumers_same_bus_supported()::Bool
+  net = Net(name = "multi_slack_same_bus", baseMVA = 100.0)
+  addBus!(net = net, busName = "SlackBus", vn_kV = 110.0)
+  addBus!(net = net, busName = "LoadBus", vn_kV = 110.0)
 
-  addProsumer!(net = net, busName = "Slack", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "Slack")
+  addProsumer!(net = net, busName = "SlackBus", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "SlackBus")
+  # Second in-service generator at the same slack bus (MATPOWER-like multi-gen slack bus case).
+  addProsumer!(net = net, busName = "SlackBus", type = "GENERATOR", p = 15.0, q = 2.0, referencePri = "SlackBus")
+  addProsumer!(net = net, busName = "LoadBus", type = "ENERGYCONSUMER", p = 10.0, q = 3.0)
 
-  # Regulated generator defines PV behavior at the bus.
-  addProsumer!(net = net, busName = "PVBus", type = "SYNCHRONOUSMACHINE", p = 20.0, q = 3.0, vm_pu = 1.02, isRegulated = true, qMin = -30.0, qMax = 40.0)
-  # Additional unregulated generator at the same bus.
-  addProsumer!(net = net, busName = "PVBus", type = "SYNCHRONOUSMACHINE", p = 7.5, q = 1.0, qMin = -10.0, qMax = 15.0)
-
-  pv_bus = geNetBusIdx(net = net, busName = "PVBus")
-  node = net.nodeVec[pv_bus]
-  qmin_pu, qmax_pu = getQLimits_pu(net)
-
-  p_target_ok = isapprox(node._pƩGen, 27.5; atol = 1e-9, rtol = 0.0)
-  q_target_ok = isapprox(node._qƩGen, 4.0; atol = 1e-9, rtol = 0.0)
-  q_limit_ok = isapprox(qmin_pu[pv_bus], -0.4; atol = 1e-9, rtol = 0.0) &&
-               isapprox(qmax_pu[pv_bus], 0.55; atol = 1e-9, rtol = 0.0)
-  bus_type_ok = getEffectiveBusType(net = net, busName = "PVBus") == Sparlectra.PV
-
-  return p_target_ok && q_target_ok && q_limit_ok && bus_type_ok
+  slack_bus = geNetBusIdx(net = net, busName = "SlackBus")
+  load_bus = geNetBusIdx(net = net, busName = "LoadBus")
+  return getEffectiveBusType(net, slack_bus) == Sparlectra.Slack &&
+         getEffectiveBusType(net, load_bus) == Sparlectra.PQ &&
+         count(isSlack, getBusProsumers(net, slack_bus)) == 2
 end
 
 function test_regulated_generator_bus_targets_include_unregulated_generators()::Bool
@@ -1545,6 +1537,7 @@ function run_grid_tests()
       @test test_q_limit_adjust_vset_multigen_single_controller() == true
       @test test_q_limit_default_behavior_unchanged() == true
       @test test_bus_type_resolution_from_prosumers() == true
+      @test test_multiple_slack_prosumers_same_bus_supported() == true
       @test test_regulated_generator_bus_targets_include_unregulated_generators() == true
     end
 

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -1454,6 +1454,31 @@ function test_bus_type_resolution_from_prosumers()::Bool
   return ok_types
 end
 
+function test_regulated_generator_bus_targets_include_unregulated_generators()::Bool
+  net = Net(name = "regulated_generator_bus_targets", baseMVA = 100.0)
+  addBus!(net = net, busName = "Slack", vn_kV = 110.0)
+  addBus!(net = net, busName = "PVBus", vn_kV = 110.0)
+
+  addProsumer!(net = net, busName = "Slack", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "Slack")
+
+  # Regulated generator defines PV behavior at the bus.
+  addProsumer!(net = net, busName = "PVBus", type = "SYNCHRONOUSMACHINE", p = 20.0, q = 3.0, vm_pu = 1.02, isRegulated = true, qMin = -30.0, qMax = 40.0)
+  # Additional unregulated generator at the same bus.
+  addProsumer!(net = net, busName = "PVBus", type = "SYNCHRONOUSMACHINE", p = 7.5, q = 1.0, qMin = -10.0, qMax = 15.0)
+
+  pv_bus = geNetBusIdx(net = net, busName = "PVBus")
+  node = net.nodeVec[pv_bus]
+  qmin_pu, qmax_pu = getQLimits_pu(net)
+
+  p_target_ok = isapprox(node._pƩGen, 27.5; atol = 1e-9, rtol = 0.0)
+  q_target_ok = isapprox(node._qƩGen, 4.0; atol = 1e-9, rtol = 0.0)
+  q_limit_ok = isapprox(qmin_pu[pv_bus], -0.4; atol = 1e-9, rtol = 0.0) &&
+               isapprox(qmax_pu[pv_bus], 0.55; atol = 1e-9, rtol = 0.0)
+  bus_type_ok = getEffectiveBusType(net = net, busName = "PVBus") == Sparlectra.PV
+
+  return p_target_ok && q_target_ok && q_limit_ok && bus_type_ok
+end
+
 function run_grid_tests()
   @testset "Grid and power-flow regression tests" begin
     @testset "Transformer and network validation" begin
@@ -1490,6 +1515,7 @@ function run_grid_tests()
       @test test_q_limit_adjust_vset_multigen_single_controller() == true
       @test test_q_limit_default_behavior_unchanged() == true
       @test test_bus_type_resolution_from_prosumers() == true
+      @test test_regulated_generator_bus_targets_include_unregulated_generators() == true
     end
 
     @testset "Link behaviour and reporting" begin

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -1395,6 +1395,34 @@ function test_q_limit_default_behavior_unchanged()::Bool
   return erg_default == 0 && erg_explicit == 0 && same_type && same_vm
 end
 
+function test_bus_type_resolution_from_prosumers()::Bool
+  net = Net(name = "bus_type_resolution", baseMVA = 100.0)
+  addBus!(net = net, busName = "LoadBus", vn_kV = 110.0)
+  addBus!(net = net, busName = "PVBus", vn_kV = 110.0)
+  addBus!(net = net, busName = "GenPQBus", vn_kV = 110.0)
+  addBus!(net = net, busName = "MixBus", vn_kV = 110.0)
+  addBus!(net = net, busName = "SlackBus", vn_kV = 110.0)
+  addBus!(net = net, busName = "LegacyBus", busType = "PV", vn_kV = 110.0)
+
+  addProsumer!(net = net, busName = "LoadBus", type = "ENERGYCONSUMER", p = 10.0, q = 3.0)
+  addProsumer!(net = net, busName = "PVBus", type = "SYNCHRONOUSMACHINE", p = 20.0, vm_pu = 1.02, isRegulated = true)
+  addProsumer!(net = net, busName = "GenPQBus", type = "SYNCHRONOUSMACHINE", p = 15.0, q = 2.0)
+  addProsumer!(net = net, busName = "MixBus", type = "SYNCHRONOUSMACHINE", p = 12.0, q = 1.0)
+  addProsumer!(net = net, busName = "MixBus", type = "SYNCHRONOUSMACHINE", p = 8.0, vm_pu = 1.01, isRegulated = true)
+  addProsumer!(net = net, busName = "SlackBus", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "SlackBus")
+  addProsumer!(net = net, busName = "LegacyBus", type = "ENERGYCONSUMER", p = 5.0, q = 1.0)
+
+  ok_types =
+    getEffectiveBusType(net = net, busName = "LoadBus") == Sparlectra.PQ &&
+    getEffectiveBusType(net = net, busName = "PVBus") == Sparlectra.PV &&
+    getEffectiveBusType(net = net, busName = "GenPQBus") == Sparlectra.PQ &&
+    getEffectiveBusType(net = net, busName = "MixBus") == Sparlectra.PV &&
+    getEffectiveBusType(net = net, busName = "SlackBus") == Sparlectra.Slack &&
+    getEffectiveBusType(net = net, busName = "LegacyBus") == Sparlectra.PQ
+
+  return ok_types
+end
+
 function run_grid_tests()
   @testset "Grid and power-flow regression tests" begin
     @testset "Transformer and network validation" begin
@@ -1429,6 +1457,7 @@ function run_grid_tests()
       @test test_q_limit_adjust_vset_step_exhaustion_fallback() == true
       @test test_q_limit_adjust_vset_multigen_single_controller() == true
       @test test_q_limit_default_behavior_unchanged() == true
+      @test test_bus_type_resolution_from_prosumers() == true
     end
 
     @testset "Link behaviour and reporting" begin

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -24,8 +24,8 @@ function test_2WTPITrafo()
   netName = "trafo_2W_PIT"
   net = Net(name = netName, baseMVA = Sbase_MVA)
   @debug "Creating $netName test network"
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 220.0)
-  addBus!(net = net, busName = "B2", busType = "SLACK", vn_kV = 20.0)
+  addBus!(net = net, busName = "B1", vn_kV = 220.0)
+  addBus!(net = net, busName = "B2", vn_kV = 20.0)
 
   add2WTPIModelTrafo!(net = net, fromBus = "B1", toBus = "B2", r = 0.0, x = 0.4, ratedU = 220.0, ratedS = 1000.0)
   addProsumer!(net = net, busName = "B2", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "B1")
@@ -52,11 +52,11 @@ function test_3WTPITrafo(verbose::Int = 0; method::Symbol = :rectangular, opt_fd
   @debug "Creating $netName test network"
 
   # --- buses ---
-  addBus!(net = net, busName = "B1", busType = "SLACK", vn_kV = 380.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 380.0)  # HV side of 3W trafo
-  addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)  # MV side
-  addBus!(net = net, busName = "B4", busType = "PQ", vn_kV = 20.0)   # LV side (shunt bus)
-  addBus!(net = net, busName = "B5", busType = "PQ", vn_kV = 110.0)  # load bus at 110kV
+  addBus!(net = net, busName = "B1", vn_kV = 380.0)
+  addBus!(net = net, busName = "B2", vn_kV = 380.0)  # HV side of 3W trafo
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)  # MV side
+  addBus!(net = net, busName = "B4", vn_kV = 20.0)   # LV side (shunt bus)
+  addBus!(net = net, busName = "B5", vn_kV = 110.0)  # load bus at 110kV
 
   # --- slack injection ---
   addProsumer!(net = net, busName = "B1", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "B1")
@@ -379,11 +379,11 @@ function testISOBusses()
   netName = "isobus"
   net = Net(name = netName, baseMVA = Sbase_MVA)
   @debug "Creating $netName test network"
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 220.0)
-  addBus!(net = net, busName = "B2", busType = "PV", vn_kV = 220.0)
-  addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 220.0)
-  addBus!(net = net, busName = "B4", busType = "PQ", vn_kV = 220.0)
-  addBus!(net = net, busName = "B5", busType = "SLACK", vn_kV = 220.0)
+  addBus!(net = net, busName = "B1", vn_kV = 220.0)
+  addBus!(net = net, busName = "B2", vn_kV = 220.0)
+  addBus!(net = net, busName = "B3", vn_kV = 220.0)
+  addBus!(net = net, busName = "B4", vn_kV = 220.0)
+  addBus!(net = net, busName = "B5", vn_kV = 220.0)
 
   addACLine!(net = net, fromBus = "B1", toBus = "B2", length = 100.0, r = 0.0653, x = 0.398, c_nf_per_km = 9.08, tanδ = 0.0, ratedS = 250.0, status = 1)
   addACLine!(net = net, fromBus = "B1", toBus = "B3", length = 100.0, r = 0.0653, x = 0.398, c_nf_per_km = 9.08, tanδ = 0.0, ratedS = 250.0, status = 1)
@@ -444,33 +444,33 @@ function createCIGRE(lLine_6a6b = 0.01)::Net
   @debug "Creating $netName test network"
   # A R E A 1
   # Bus 1, 220kV  
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 220.0)
+  addBus!(net = net, busName = "B1", vn_kV = 220.0)
   # Bus 9, 22kV  
-  addBus!(net = net, busName = "B9", busType = "Slack", vn_kV = 22.0)
+  addBus!(net = net, busName = "B9", vn_kV = 22.0)
   # Bus 7, 22kV  
-  addBus!(net = net, busName = "B7", busType = "PQ", vn_kV = 380.0)
+  addBus!(net = net, busName = "B7", vn_kV = 380.0)
   # Bus 2, 220kV  
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 220.0)
+  addBus!(net = net, busName = "B2", vn_kV = 220.0)
   # Bus 10, 22kV  
-  addBus!(net = net, busName = "B10", busType = "PV", vn_kV = 22.0)
+  addBus!(net = net, busName = "B10", vn_kV = 22.0)
   # A R E A 2
   # B6a, 220kV  
-  addBus!(net = net, busName = "B6a", busType = "PQ", vn_kV = 220.0)
+  addBus!(net = net, busName = "B6a", vn_kV = 220.0)
   # B6b, 220kV   
-  addBus!(net = net, busName = "B6b", busType = "PQ", vn_kV = 220.0)
+  addBus!(net = net, busName = "B6b", vn_kV = 220.0)
   # Bus 12, 22kV  
-  addBus!(net = net, busName = "B12", busType = "PV", vn_kV = 22.0)
+  addBus!(net = net, busName = "B12", vn_kV = 22.0)
   # A R E A 3
   # Bus 5, 220kV  
-  addBus!(net = net, busName = "B5", busType = "PQ", vn_kV = 220.0)
+  addBus!(net = net, busName = "B5", vn_kV = 220.0)
   # Bus 4, 220kV  
-  addBus!(net = net, busName = "B4", busType = "PQ", vn_kV = 220.0)
+  addBus!(net = net, busName = "B4", vn_kV = 220.0)
   # Bus 3, 220kV
-  addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 220.0)
+  addBus!(net = net, busName = "B3", vn_kV = 220.0)
   # Bus 8, 380kV  
-  addBus!(net = net, busName = "B8", busType = "PQ", vn_kV = 380.0)
+  addBus!(net = net, busName = "B8", vn_kV = 380.0)
   # Bus 11, 22kV  
-  addBus!(net = net, busName = "B11", busType = "PV", vn_kV = 22.0)
+  addBus!(net = net, busName = "B11", vn_kV = 22.0)
 
   ##### Shunt    
   addShunt!(net = net, busName = "B6a", pShunt = 0.0, qShunt = 180.0)
@@ -548,20 +548,14 @@ function createTest5BusNet(; cooldown = 0, hyst_pu = 0.0, qlim_min = nothing, ql
   c_nf_per_km = 10.0
   tanδ = 0.0
 
-  if pq_only
-    busTypeBus3 = "PQ"
-  else
-    busTypeBus3 = "PV"
-  end
-
   @debug "Creating $netName test network with qlim_min=$qlim_min, qlim_max=$qlim_max, pq_only=$pq_only"
 
   Bus5Net = Net(name = netName, baseMVA = Sbase_MVA, cooldown_iters = cooldown, q_hyst_pu = hyst_pu)
-  addBus!(net = Bus5Net, busName = "B1", busType = "Slack", vn_kV = 110.0)
-  addBus!(net = Bus5Net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = Bus5Net, busName = "B3", busType = busTypeBus3, vn_kV = 110.0)
-  addBus!(net = Bus5Net, busName = "B4", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = Bus5Net, busName = "B5", busType = busTypeBus3, vn_kV = 110.0)
+  addBus!(net = Bus5Net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = Bus5Net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = Bus5Net, busName = "B3", vn_kV = 110.0)
+  addBus!(net = Bus5Net, busName = "B4", vn_kV = 110.0)
+  addBus!(net = Bus5Net, busName = "B5", vn_kV = 110.0)
 
   addACLine!(net = Bus5Net, fromBus = "B1", toBus = "B3", length = 20.0, r = r, x = x, c_nf_per_km = c_nf_per_km, tanδ = tanδ)
   addACLine!(net = Bus5Net, fromBus = "B3", toBus = "B5", length = 50.0, r = r, x = x, c_nf_per_km = c_nf_per_km, tanδ = tanδ)
@@ -574,8 +568,9 @@ function createTest5BusNet(; cooldown = 0, hyst_pu = 0.0, qlim_min = nothing, ql
   if mul_gens
     addProsumer!(net = Bus5Net, busName = "B2", type = "ENERGYCONSUMER", p = 25.0, q = 8.0)
     addProsumer!(net = Bus5Net, busName = "B2", type = "ENERGYCONSUMER", p = 25.0, q = 7.0)
-    addProsumer!(net = Bus5Net, busName = "B3", type = "SYNCHRONOUSMACHINE", p = 20.0, q = 15.0, vm_pu = 1.03, va_deg = 0.0, qMax = 0.6 * qlim_max, qMin = 0.6 * qlim_min)
-    addProsumer!(net = Bus5Net, busName = "B3", type = "SYNCHRONOUSMACHINE", p = 10.0, q = 10.0, vm_pu = 1.03, va_deg = 0.0, qMax = 0.4 * qlim_max, qMin = 0.4 * qlim_min)
+    vm_b3 = pq_only ? nothing : 1.03
+    addProsumer!(net = Bus5Net, busName = "B3", type = "SYNCHRONOUSMACHINE", p = 20.0, q = 15.0, vm_pu = vm_b3, va_deg = 0.0, qMax = 0.6 * qlim_max, qMin = 0.6 * qlim_min)
+    addProsumer!(net = Bus5Net, busName = "B3", type = "SYNCHRONOUSMACHINE", p = 10.0, q = 10.0, vm_pu = vm_b3, va_deg = 0.0, qMax = 0.4 * qlim_max, qMin = 0.4 * qlim_min)
     addProsumer!(net = Bus5Net, busName = "B4", type = "ENERGYCONSUMER", p = 25.0, q = 7.0)
     addProsumer!(net = Bus5Net, busName = "B4", type = "ENERGYCONSUMER", p = 25.0, q = 8.0)
     addProsumer!(net = Bus5Net, busName = "B5", type = "ENERGYCONSUMER", p = 10.0, q = 5.0)
@@ -585,7 +580,8 @@ function createTest5BusNet(; cooldown = 0, hyst_pu = 0.0, qlim_min = nothing, ql
     end
   else
     addProsumer!(net = Bus5Net, busName = "B2", type = "ENERGYCONSUMER", p = 50.0, q = 15.0)
-    addProsumer!(net = Bus5Net, busName = "B3", type = "SYNCHRONOUSMACHINE", p = 30.0, q = 25.0, vm_pu = 1.0, va_deg = 0.0, qMax = qlim_max, qMin = qlim_min)
+    vm_b3 = pq_only ? nothing : 1.0
+    addProsumer!(net = Bus5Net, busName = "B3", type = "SYNCHRONOUSMACHINE", p = 30.0, q = 25.0, vm_pu = vm_b3, va_deg = 0.0, qMax = qlim_max, qMin = qlim_min)
     addProsumer!(net = Bus5Net, busName = "B4", type = "ENERGYCONSUMER", p = 50.0, q = 15.0)
     addProsumer!(net = Bus5Net, busName = "B5", type = "ENERGYCONSUMER", p = 25.0, q = 10.0)
   end
@@ -618,9 +614,9 @@ function createTest3BusNet(; cooldown = 0, hyst_pu = 0.0, qlim_min = nothing, ql
 
   Bus3Net = Net(name = netName, baseMVA = Sbase_MVA, cooldown_iters = cooldown, q_hyst_pu = hyst_pu)
 
-  addBus!(net = Bus3Net, busName = "ASTADT", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = Bus3Net, busName = "STATION1", busType = "PV", vn_kV = 110.0)
-  addBus!(net = Bus3Net, busName = "VERBUND", busType = "SLACK", vn_kV = 110.0)
+  addBus!(net = Bus3Net, busName = "ASTADT", vn_kV = 110.0)
+  addBus!(net = Bus3Net, busName = "STATION1", vn_kV = 110.0)
+  addBus!(net = Bus3Net, busName = "VERBUND", vn_kV = 110.0)
 
   addACLine!(net = Bus3Net, fromBus = "ASTADT", toBus = "STATION1", length = s, r = r, x = x, c_nf_per_km = c_nf_per_km, tanδ = tanδ)
   addACLine!(net = Bus3Net, fromBus = "ASTADT", toBus = "VERBUND", length = s, r = r, x = x, c_nf_per_km = c_nf_per_km, tanδ = tanδ)
@@ -648,8 +644,8 @@ function createTest2BusNet(; cooldown = 0, hyst_pu = 0.0, qlim_min = nothing, ql
   @debug "Creating $netName test network with qlim_min=$qlim_min, qlim_max=$qlim_max"
 
   Bus2Net = Net(name = netName, baseMVA = Sbase_MVA, cooldown_iters = cooldown, q_hyst_pu = hyst_pu)
-  addBus!(net = Bus2Net, busName = "B1", busType = "Slack", vn_kV = 110.0)
-  addBus!(net = Bus2Net, busName = "B2", busType = "PV", vn_kV = 110.0)
+  addBus!(net = Bus2Net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = Bus2Net, busName = "B2", vn_kV = 110.0)
 
   addACLine!(net = Bus2Net, fromBus = "B1", toBus = "B2", length = 20.0, r = r, x = x, c_nf_per_km = c_nf_per_km, tanδ = tanδ)
 
@@ -820,9 +816,9 @@ function test_mp_inline_vs_manual_shunt(verbose::Int = 0; method::Symbol = :rect
   # -------------------------
   netName = "case3_manual_vs_mp_shunt"
   net_man = Net(name = netName, baseMVA = 100.0)
-  addBus!(net = net_man, busName = "B1", busType = "SLACK", vn_kV = 110.0, vm_pu = 1.06, va_deg = 0.0)
-  addBus!(net = net_man, busName = "B2", busType = "PV", vn_kV = 110.0, vm_pu = 1.03, va_deg = 0.0)
-  addBus!(net = net_man, busName = "B3", busType = "PQ", vn_kV = 110.0, vm_pu = 1.00, va_deg = 0.0)
+  addBus!(net = net_man, busName = "B1", vn_kV = 110.0, vm_pu = 1.06, va_deg = 0.0)
+  addBus!(net = net_man, busName = "B2", vn_kV = 110.0, vm_pu = 1.03, va_deg = 0.0)
+  addBus!(net = net_man, busName = "B3", vn_kV = 110.0, vm_pu = 1.00, va_deg = 0.0)
   # Lines without line charging, so only bus shunts differ/drive this check.
   addACLine!(net = net_man, fromBus = "B1", toBus = "B2", length = 1.0, r = 0.02, x = 0.06)
   addACLine!(net = net_man, fromBus = "B1", toBus = "B3", length = 1.0, r = 0.08, x = 0.24)
@@ -911,8 +907,8 @@ end
 
 function test_link_kcl_simple()
   net = Net(name = "link_kcl", baseMVA = 100.0)
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
 
   addBusGenPower!(net = net, busName = "B1", p = 10.0, q = 2.0)
   addBusLoadPower!(net = net, busName = "B2", p = 10.0, q = 2.0)
@@ -927,8 +923,8 @@ end
 
 function test_link_component_type()
   net = Net(name = "link_component", baseMVA = 100.0)
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
   addLink!(net = net, fromBus = "B1", toBus = "B2", status = 1)
 
   l = net.linkVec[1]
@@ -937,8 +933,10 @@ end
 
 function test_link_rejects_slack_connection()
   net = Net(name = "link_slack_reject", baseMVA = 100.0)
-  addBus!(net = net, busName = "B1", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addProsumer!(net = net, busName = "B1", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "B1")
+  addProsumer!(net = net, busName = "B2", type = "ENERGYCONSUMER", p = 5.0, q = 1.0)
 
   try
     addLink!(net = net, fromBus = "B1", toBus = "B2", status = 1)
@@ -950,8 +948,10 @@ end
 
 function test_link_rejects_mixed_bus_types()
   net = Net(name = "link_type_reject", baseMVA = 100.0)
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PV", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addProsumer!(net = net, busName = "B1", type = "SYNCHRONOUSMACHINE", p = 10.0, vm_pu = 1.02)
+  addProsumer!(net = net, busName = "B2", type = "ENERGYCONSUMER", p = 5.0, q = 1.0)
 
   try
     addLink!(net = net, fromBus = "B1", toBus = "B2", status = 1)
@@ -966,10 +966,10 @@ function test_link_bus_merge_pf()
   maxIte = 30
 
   net_link = Net(name = "link_merge_pf", baseMVA = 100.0)
-  addBus!(net = net_link, busName = "B0", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net_link, busName = "B1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net_link, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net_link, busName = "B3", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net_link, busName = "B0", vn_kV = 110.0)
+  addBus!(net = net_link, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net_link, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net_link, busName = "B3", vn_kV = 110.0)
 
   addACLine!(net = net_link, fromBus = "B0", toBus = "B1", length = 5.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)
   addACLine!(net = net_link, fromBus = "B2", toBus = "B3", length = 20.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)
@@ -1000,9 +1000,9 @@ function test_link_bus_merge_pf()
   end
 
   net_eq = Net(name = "merge_reference", baseMVA = 100.0)
-  addBus!(net = net_eq, busName = "B0", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net_eq, busName = "B12", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net_eq, busName = "B3", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net_eq, busName = "B0", vn_kV = 110.0)
+  addBus!(net = net_eq, busName = "B12", vn_kV = 110.0)
+  addBus!(net = net_eq, busName = "B3", vn_kV = 110.0)
 
   addACLine!(net = net_eq, fromBus = "B0", toBus = "B12", length = 5.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)
   addACLine!(net = net_eq, fromBus = "B12", toBus = "B3", length = 20.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)
@@ -1034,10 +1034,10 @@ end
 
 function test_link_closed_keeps_shunt_reporting_on_original_bus()
   net = Net(name = "link_shunt_reporting", baseMVA = 100.0)
-  addBus!(net = net, busName = "B0", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "B0", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)
 
   addACLine!(net = net, fromBus = "B0", toBus = "B1", length = 5.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)
   addACLine!(net = net, fromBus = "B2", toBus = "B3", length = 20.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)
@@ -1063,9 +1063,9 @@ end
 function test_link_kcl_ring_allocation()
   net = Net(name = "link_kcl_ring", baseMVA = 100.0)
   # 3 busses
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)
 
   # Zero-Bilance: + 15 -10 -5 = 0;   +6 -4 -2 = 0
   addBusGenPower!(net = net, busName = "B1", p = 15.0, q = 6.0)
@@ -1103,9 +1103,9 @@ end
 
 function test_link_kcl_ring_allocation_with_shunt()
   net = Net(name = "link_kcl_ring_shunt", baseMVA = 100.0)
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)
 
   addBusGenPower!(net = net, busName = "B1", p = 15.0, q = 12.0)
   addBusLoadPower!(net = net, busName = "B2", p = 10.0, q = 4.0)
@@ -1144,10 +1144,10 @@ function test_link_ring_pf_stability()
   # Build a mixed grid: radial AC lines from slack plus a meshed 3-link ring
   # among PQ buses where link flows are recovered via KCL.
   net = Net(name = "link_ring_pf_stability", baseMVA = 100.0)
-  addBus!(net = net, busName = "B0", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "B0", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)
 
   # Two physical AC branches feed the ring from the slack side.
   addACLine!(net = net, fromBus = "B0", toBus = "B1", length = 10.0, r = 0.05, x = 0.4, c_nf_per_km = 10.0, tanδ = 0.0)
@@ -1258,9 +1258,9 @@ end
 
 function test_report_uses_user_bus_names_and_pf_node_count()
   net = Net(name = "report_link_names", baseMVA = 100.0)
-  addBus!(net = net, busName = "Slack", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net, busName = "Bus1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "Bus1a", busType = "PQ", vn_kV = 110.0)
+  addBus!(net = net, busName = "Slack", vn_kV = 110.0)
+  addBus!(net = net, busName = "Bus1", vn_kV = 110.0)
+  addBus!(net = net, busName = "Bus1a", vn_kV = 110.0)
 
   addACLine!(net = net, fromBus = "Slack", toBus = "Bus1", length = 5.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)
   addLink!(net = net, fromBus = "Bus1", toBus = "Bus1a", status = 1)
@@ -1433,7 +1433,7 @@ function test_bus_type_resolution_from_prosumers()::Bool
   addBus!(net = net, busName = "GenPQBus", vn_kV = 110.0)
   addBus!(net = net, busName = "MixBus", vn_kV = 110.0)
   addBus!(net = net, busName = "SlackBus", vn_kV = 110.0)
-  addBus!(net = net, busName = "LegacyBus", busType = "PV", vn_kV = 110.0)
+  addBus!(net = net, busName = "NoProsumerBus", vn_kV = 110.0)
 
   addProsumer!(net = net, busName = "LoadBus", type = "ENERGYCONSUMER", p = 10.0, q = 3.0)
   addProsumer!(net = net, busName = "PVBus", type = "SYNCHRONOUSMACHINE", p = 20.0, vm_pu = 1.02, isRegulated = true)
@@ -1441,7 +1441,12 @@ function test_bus_type_resolution_from_prosumers()::Bool
   addProsumer!(net = net, busName = "MixBus", type = "SYNCHRONOUSMACHINE", p = 12.0, q = 1.0)
   addProsumer!(net = net, busName = "MixBus", type = "SYNCHRONOUSMACHINE", p = 8.0, vm_pu = 1.01, isRegulated = true)
   addProsumer!(net = net, busName = "SlackBus", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "SlackBus")
-  addProsumer!(net = net, busName = "LegacyBus", type = "ENERGYCONSUMER", p = 5.0, q = 1.0)
+  addProsumer!(net = net, busName = "NoProsumerBus", type = "ENERGYCONSUMER", p = 5.0, q = 1.0)
+
+  pv_bus = geNetBusIdx(net = net, busName = "PVBus")
+  genpq_bus = geNetBusIdx(net = net, busName = "GenPQBus")
+  pv_regulation_ok = any(isGenerator(ps) && isRegulating(ps) for ps in getBusProsumers(net, pv_bus))
+  genpq_regulation_ok = all(!(isGenerator(ps) && isRegulating(ps)) for ps in getBusProsumers(net, genpq_bus))
 
   ok_types =
     getEffectiveBusType(net = net, busName = "LoadBus") == Sparlectra.PQ &&
@@ -1449,9 +1454,34 @@ function test_bus_type_resolution_from_prosumers()::Bool
     getEffectiveBusType(net = net, busName = "GenPQBus") == Sparlectra.PQ &&
     getEffectiveBusType(net = net, busName = "MixBus") == Sparlectra.PV &&
     getEffectiveBusType(net = net, busName = "SlackBus") == Sparlectra.Slack &&
-    getEffectiveBusType(net = net, busName = "LegacyBus") == Sparlectra.PQ
+    getEffectiveBusType(net = net, busName = "NoProsumerBus") == Sparlectra.PQ
 
-  return ok_types
+  return ok_types && pv_regulation_ok && genpq_regulation_ok
+end
+
+function test_regulated_generator_bus_targets_include_unregulated_generators()::Bool
+  net = Net(name = "regulated_generator_bus_targets", baseMVA = 100.0)
+  addBus!(net = net, busName = "Slack", vn_kV = 110.0)
+  addBus!(net = net, busName = "PVBus", vn_kV = 110.0)
+
+  addProsumer!(net = net, busName = "Slack", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "Slack")
+
+  # Regulated generator defines PV behavior at the bus.
+  addProsumer!(net = net, busName = "PVBus", type = "SYNCHRONOUSMACHINE", p = 20.0, q = 3.0, vm_pu = 1.02, isRegulated = true, qMin = -30.0, qMax = 40.0)
+  # Additional unregulated generator at the same bus.
+  addProsumer!(net = net, busName = "PVBus", type = "SYNCHRONOUSMACHINE", p = 7.5, q = 1.0, qMin = -10.0, qMax = 15.0)
+
+  pv_bus = geNetBusIdx(net = net, busName = "PVBus")
+  node = net.nodeVec[pv_bus]
+  qmin_pu, qmax_pu = getQLimits_pu(net)
+
+  p_target_ok = isapprox(node._pƩGen, 27.5; atol = 1e-9, rtol = 0.0)
+  q_target_ok = isapprox(node._qƩGen, 4.0; atol = 1e-9, rtol = 0.0)
+  q_limit_ok = isapprox(qmin_pu[pv_bus], -0.4; atol = 1e-9, rtol = 0.0) &&
+               isapprox(qmax_pu[pv_bus], 0.55; atol = 1e-9, rtol = 0.0)
+  bus_type_ok = getEffectiveBusType(net = net, busName = "PVBus") == Sparlectra.PV
+
+  return p_target_ok && q_target_ok && q_limit_ok && bus_type_ok
 end
 
 function test_regulated_generator_bus_targets_include_unregulated_generators()::Bool

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -295,6 +295,37 @@ function test_matpower_import_defaults_no_reenable()::Bool
   return true
 end
 
+function test_matpower_import_uses_bus_type_for_regulation()::Bool
+  mpc = (
+    name = "case_bus_type_controls_regulation",
+    baseMVA = 100.0,
+    bus = [
+      1 3 0.0 0.0 0.0 0.0 1 1.0 0.0 110.0 1 1.1 0.9
+      2 1 0.0 0.0 0.0 0.0 1 1.0 0.0 110.0 1 1.1 0.9
+      3 2 0.0 0.0 0.0 0.0 1 1.02 0.0 110.0 1 1.1 0.9
+    ],
+    gen = [
+      1 10.0 0.0 999.0 -999.0 1.0 100.0 1 999.0 0.0 0 0 0 0 0 0 0 0 0 0 0
+      2 30.0 0.0 999.0 -999.0 1.01 100.0 1 999.0 0.0 0 0 0 0 0 0 0 0 0 0 0
+      3 40.0 0.0 999.0 -999.0 1.02 100.0 1 999.0 0.0 0 0 0 0 0 0 0 0 0 0 0
+    ],
+    branch = [
+      1 2 0.01 0.05 0.0 9999.0 0.0 0.0 0.0 0.0 1 -60.0 60.0
+      2 3 0.01 0.05 0.0 9999.0 0.0 0.0 0.0 0.0 1 -60.0 60.0
+    ],
+    gencost = nothing,
+    bus_name = nothing,
+  )
+
+  net = Sparlectra.createNetFromMatPowerCase(mpc = mpc, log = false, flatstart = false)
+
+  b2 = geNetBusIdx(net = net, busName = "2")
+  b3 = geNetBusIdx(net = net, busName = "3")
+
+  return getNodeType(net.nodeVec[b2]) == Sparlectra.PQ &&
+         getNodeType(net.nodeVec[b3]) == Sparlectra.PV
+end
+
 function test_matpower_vmva_selfcheck_noncontiguous_bus_numbers()::Bool
   mpc = Sparlectra.MatpowerIO.MatpowerCase(
     "case_noncontig",
@@ -1436,6 +1467,7 @@ function run_grid_tests()
     @testset "MATPOWER import/export" begin
       @test testImportMatpower() == true
       @test test_matpower_import_defaults_no_reenable() == true
+      @test test_matpower_import_uses_bus_type_for_regulation() == true
       @test test_matpower_vmva_selfcheck_noncontiguous_bus_numbers() == true
       @test test_matpower_vmva_selfcheck_ignores_slack_pq_spec() == true
       @test test_mp_inline_vs_manual_shunt() == true

--- a/test/testremove.jl
+++ b/test/testremove.jl
@@ -33,12 +33,12 @@ function createTestNetwork()::Net
   net = Net(name = "remove_test", baseMVA = 100.0)
 
   # Add buses
-  addBus!(net = net, busName = "B1", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B2", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B3", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B4", busType = "PQ", vn_kV = 110.0)
-  addBus!(net = net, busName = "B5", busType = "SLACK", vn_kV = 110.0)
-  addBus!(net = net, busName = "B6", busType = "PV", vn_kV = 20.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)
+  addBus!(net = net, busName = "B4", vn_kV = 110.0)
+  addBus!(net = net, busName = "B5", vn_kV = 110.0)
+  addBus!(net = net, busName = "B6", vn_kV = 20.0)
 
   # Add lines
   addACLine!(net = net, fromBus = "B1", toBus = "B2", length = 10.0, r = 0.01, x = 0.1, c_nf_per_km = 10.0, tanδ = 0.0, ratedS = 100.0)


### PR DESCRIPTION
Title
Document :adjust_vset Q-limit behavior, align tests with prosumer-based bus typing, and add regulated/unregulated generator aggregation coverage

Motivation
These changes make Q-limit handling and bus-typing behavior clearer and more robust:

Document qlimit_mode = :adjust_vset as an alternative to immediate PV→PQ switching.

Fully align tests with the current model where bus types are derived from attached prosumers (instead of legacy busType in addBus!).

Add/extend validation for mixed regulated + unregulated generators connected to the same bus.

Description
1) Documentation update (powerlimits.md)
Added a dedicated section for qlimit_mode = :adjust_vset:

usage with method = :rectangular

behavior (attempt voltage setpoint adjustments first, then PV→PQ fallback)

required controller data (vstep_pu, optional tap_steps_down / tap_steps_up)

scope/fallback note for non-rectangular methods. 

2) Test suite alignment with implicit bus typing
Updated test/testgrid.jl to remove reliance on legacy busType in addBus! and rely on prosumer-derived bus-type resolution instead. 

In createTest5BusNet, PV/PQ behavior is now controlled via prosumer configuration (vm_pu), with vm_pu = nothing when pq_only=true to avoid implicit PV regulation. 

Updated link rejection tests so Slack/mixed-type conditions are created through prosumers (matching runtime behavior). 

3) Regulation and aggregation validation improvements
Enhanced test_bus_type_resolution_from_prosumers with explicit checks for regulator detection (isRegulating) for PV vs non-regulating generator cases. 

Added test_regulated_generator_bus_targets_include_unregulated_generators to verify:

aggregated _pƩGen / _qƩGen

aggregated qmin_pu / qmax_pu

correct PV classification at the bus. 

4) Remaining legacy busType usage removed in other tests
Removed direct addBus!(... busType=...) usage in:

test/testremove.jl

test/test_state_estimation.jl

Testing
julia --project=. test/runtests.jl

Result: 182 / 182 tests passed.

Notes
Legacy busType warnings may still appear from other code paths/test data loaded during the suite; direct usage in the updated test constructors has been removed.

