### PR TITLE
Dev/r0.6.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test/test_experment.jl
 julia-*.tar.gz
 src/examples/matpower_import.yaml
 src/examples/matpower_import.yaml
+src/examples/MergeRequeste.md

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sparlectra"
 uuid = "31ce9bba-fd9d-44a1-b005-f5f509afda38"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Udo Schmitz"]
 description = "load flow calculation using newton-raphson"
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package contains tools for subsequent network calculations. It primarily fe
 
 ## Features
 
-- AC power flow with multiple internal Newton-Raphson formulations (`:polar_full`, `:rectangular`, `:classic`) and many options.
+- AC power flow with rectangular complex-state Newton-Raphson as default (`:rectangular`); legacy `:polar_full` / `:classic` are deprecated.
 - State Estimation (WLS) as an **experimental** feature
 - Canonical external solver interface (`PFModel`/`PFSolution`) to integrate third-party solvers.
 - PV-to-PQ bus switching.
@@ -114,7 +114,6 @@ data while still allowing reproducible experiments and benchmarks.
 ### License
 This project is licensed under the Apache License, Version 2.0.
 [The license file](https://github.com/welthulk/Sparlectra.jl/blob/main/LICENSE) contains the complete licensing information.
-
 
 
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,4 +1,15 @@
 # Change Log
+## Version 0.6.4 – 2026-04-12
+### Changes
+* Marked legacy Jacobian solvers as deprecated:
+  * `runpf_full!` / `method = :polar_full`
+  * `runpf_classic!` / `method = :classic`
+  Both now emit a deprecation warning when used.
+* Set rectangular complex Jacobian (`method = :rectangular`) as the default for:
+  * `run_acpflow`
+  * `run_net_acpflow`
+* Updated examples and user documentation to use `:rectangular` as the recommended/default solver method.
+
 ## Version 0.6.3 – 2026-04-11
 ### New Features
 * Added `:adjust_vset` controller-based Q-limit handling at PV buses (adaptive Vset steps before optional PV→PQ fallback).

--- a/docs/src/feature_matrix.md
+++ b/docs/src/feature_matrix.md
@@ -13,7 +13,7 @@ Legend:
 
 | Feature | Load Flow (`runpf!`) | State Estimation (`runse!`) | Notes |
 |---|:---:|:---:|---|
-| AC power flow (NR) | ✅ | — | Main PF entry point is `runpf!` (polar full / rectangular). |
+| AC power flow (NR) | ✅ | — | Main PF entry point is `runpf!` with rectangular complex Jacobian by default; `:polar_full` / `:classic` are deprecated. |
 | AC state estimation (WLS) | — | ✅ | Main SE entry point is `runse!` (experimental status). |
 | Topological bus links (`addLink!`) | ✅ | ⚠️ | Links are fully integrated in PF workflow/reporting; in SE they are part of network topology context and should be used with care in measurement design. |
 | 2-winding transformer | ✅ | ✅ | Supported in network model and usable in both workflows. |
@@ -26,7 +26,7 @@ Legend:
 
 | Feature | Load Flow (`runpf!`) | State Estimation (`runse!`) | Notes |
 |---|:---:|:---:|---|
-| Polar full NR solver | ✅ | ⚠️ | PF has dedicated solver mode; SE uses its own WLS iteration and Jacobian evaluation. |
+| Polar full NR solver (deprecated) | ✅ | ⚠️ | Legacy PF mode (deprecated); SE uses its own WLS iteration and Jacobian evaluation. |
 | Rectangular NR solver | ✅ | ❌ | Available for PF, not as separate SE formulation. |
 | Finite-difference Jacobian option (`opt_fd`) | ✅ | ❌ | In PF this toggles FD Jacobian vs analytic Jacobian (not fast-decoupled); not exposed as an SE user option. |
 | Sparse Jacobian option (`opt_sparse`) | ✅ | ⚠️ | PF supports explicit sparse option; SE internally builds Jacobians for WLS. |
@@ -67,4 +67,3 @@ Legend:
 * [Network Reports](netreports.md)
 * [Workshop](workshop.md)
 * [Changelog](changelog.md)
-

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ This package contains tools for subsequent network calculations. It primarily fe
 
 ## Features
 
-- AC power flow with multiple internal Newton-Raphson formulations (`:polar_full`, `:rectangular`, `:classic`) and many options.
+- AC power flow with rectangular complex-state Newton-Raphson as default (`:rectangular`); legacy `:polar_full` / `:classic` are deprecated.
 - State Estimation (WLS) as an **experimental** feature 
 - Canonical external solver interface (`PFModel`/`PFSolution`) to integrate third-party solvers.
 - PV-to-PQ bus switching.

--- a/docs/src/netreports.md
+++ b/docs/src/netreports.md
@@ -30,7 +30,7 @@ ite, erg, etime = run_net_acpflow(
   net = net,
   max_ite = 40,
   tol = 1e-10,
-  method = :polar_full,
+  method = :rectangular,
   opt_sparse = true,
   show_results = false,
 )
@@ -41,7 +41,7 @@ report = buildACPFlowReport(
   ite = ite,
   tol = 1e-10,
   converged = (erg == 0),
-  solver = :polar_full,
+  solver = :rectangular,
 )
 ```
 

--- a/docs/src/workshop.md
+++ b/docs/src/workshop.md
@@ -127,7 +127,7 @@ model. After convergence, call `calcLinkFlowsKCL!` to allocate and report the
 link exchange on the original topology.
 
 ```julia
-ite, erg = runpf!(net, 25; method = :polar_full)
+ite, erg = runpf!(net, 25; method = :rectangular)
 if erg == 0
     calcNetLosses!(net)
     calcLinkFlowsKCL!(net)
@@ -338,7 +338,7 @@ ite, status, etime = run_net_acpflow(
     net = net,
     max_ite = 25,
     tol = 1e-8,
-    method = :polar_full,
+    method = :rectangular,
     opt_sparse = true,
     show_results = false,
 )
@@ -349,7 +349,7 @@ ite2, status2, etime2 = run_net_acpflow(
     net = net,
     max_ite = 25,
     tol = 1e-8,
-    method = :polar_full,
+    method = :rectangular,
     opt_sparse = true,
     show_results = false,
 )
@@ -360,7 +360,7 @@ report = buildACPFlowReport(
     ite = ite2,
     tol = 1e-8,
     converged = (status2 == 0),
-    solver = :polar_full,
+    solver = :rectangular,
 )
 
 println(report)
@@ -513,7 +513,7 @@ ok, msg = validate!(net = net)
 ok || error("Validation failed: \$msg")
 
 # 2) Solve reference power flow
-ite_pf, status_pf = runpf!(net, 40, 1e-10, 0; method = :polar_full, opt_sparse = true)
+ite_pf, status_pf = runpf!(net, 40, 1e-10, 0; method = :rectangular, opt_sparse = true)
 status_pf == 0 || error("Power flow did not converge")
 
 # 3) Build synthetic measurements (with light noise)

--- a/src/Sparlectra.jl
+++ b/src/Sparlectra.jl
@@ -31,7 +31,7 @@ const MPOWER_DIR = normpath(joinpath(pkgdir(@__MODULE__), "data", "mpower"))
 
 # resource data types for working with Sparlectra
 const Wurzel3 = 1.7320508075688772
-const SparlectraVersion = v"0.6.3"
+const SparlectraVersion = v"0.6.4"
 version() = SparlectraVersion
 abstract type AbstractBranch end
 

--- a/src/examples/export_solution.jl
+++ b/src/examples/export_solution.jl
@@ -92,7 +92,7 @@ case = "case14.m"          # or "case14.jl"
 flatstart = false
 opt_sparse = true
 opt_fd = true
-method = :polar_full        # internal solver method (run_acpflow)
+method = :rectangular       # internal solver method (run_acpflow, recommended)
 max_iter = 25               # only used if you switch to runpf!(...) manually
 tol = 1e-8                  # convergence tolerance for mismatchInf
 

--- a/src/examples/matpower_import.jl
+++ b/src/examples/matpower_import.jl
@@ -96,8 +96,8 @@ end
 # Configuration
 # -----------------------------------------------------------------------------
 const DEFAULT_CASE = "case141.m"
-const DEFAULT_METHODS = [:polar_full, :rectangular, :classic]
-const METHODS = [:polar_full, :rectangular, :classic]
+const DEFAULT_METHODS = [:rectangular]
+const METHODS = [:rectangular]
 
 # -----------------------------------------------------------------------------
 # Output redirection (write verbose output to git-ignored file)

--- a/src/examples/matpower_import.yaml.example
+++ b/src/examples/matpower_import.yaml.example
@@ -11,7 +11,7 @@
 #
 
 case: case141.m
-methods: [polar_full, rectangular, classic]
+methods: [rectangular]
 
 # Solver/NR options
 opt_fd: false

--- a/src/examples/state_estimation_manual_measurements.jl
+++ b/src/examples/state_estimation_manual_measurements.jl
@@ -46,7 +46,7 @@ function build_manual_measurement_example_net()
 end
 
 function build_manual_measurements(net::Net; rng::AbstractRNG = MersenneTwister(42))
-  ite_pf, status_pf = runpf!(net, 40, 1e-10, 0; method = :polar_full, opt_sparse = true)
+  ite_pf, status_pf = runpf!(net, 40, 1e-10, 0; method = :rectangular, opt_sparse = true)
   status_pf == 0 || error("Power flow did not converge")
 
   std = measurementStdDevs(vm = 1e-3, pinj = 0.8, qinj = 0.8, pflow = 0.5, qflow = 0.5)

--- a/src/examples/state_estimation_observability.jl
+++ b/src/examples/state_estimation_observability.jl
@@ -374,7 +374,7 @@ function run_state_estimation_observability_example(io::IO)
   end
 
   net = createNetFromMatPowerFile(filename = case_path)
-  _, erg_pf = runpf!(net, 40, 1e-10, 0; method = :polar_full, opt_sparse = true)
+  _, erg_pf = runpf!(net, 40, 1e-10, 0; method = :rectangular, opt_sparse = true)
   erg_pf == 0 || error("Power flow did not converge")
 
   std = measurementStdDevs(vm = 0.1, pinj = 1.5, qinj = 1.5, pflow = 0.7, qflow = 0.9)

--- a/src/examples/state_estimation_passive_bus_zib_comparison.jl
+++ b/src/examples/state_estimation_passive_bus_zib_comparison.jl
@@ -49,7 +49,7 @@ function _reset_non_slack_buses!(net::Net)
 end
 
 function build_sparse_measurements_for_zib_demo(net::Net; rng::AbstractRNG = MersenneTwister(7))
-  ite_pf, status_pf = runpf!(net, 40, 1e-10, 0; method = :polar_full, opt_sparse = true)
+  ite_pf, status_pf = runpf!(net, 40, 1e-10, 0; method = :rectangular, opt_sparse = true)
   status_pf == 0 || error("Power flow did not converge")
 
   std = measurementStdDevs(vm = 1e-5, pinj = 1e-5, qinj = 1e-5, pflow = 1e-5, qflow = 1e-5)

--- a/src/examples/state_estimation_wls.jl
+++ b/src/examples/state_estimation_wls.jl
@@ -57,7 +57,7 @@ function _run_state_estimation_example(io::IO)
 
   # Build net from the case file and solve the AC power flow.
   net = createNetFromMatPowerFile(filename = case_path)
-  it_pf, erg_pf = runpf!(net, 40, 1e-10, 0; method = :polar_full, opt_sparse = true)
+  it_pf, erg_pf = runpf!(net, 40, 1e-10, 0; method = :rectangular, opt_sparse = true)
   erg_pf == 0 || error("Power flow did not converge")
 
   # Keep PF voltages as "ground truth" for the synthetic measurement study.

--- a/src/examples/usage_state_estimation_diagnostics.jl
+++ b/src/examples/usage_state_estimation_diagnostics.jl
@@ -46,7 +46,7 @@ end
 function run_usage_state_estimation_diagnostics()
   net = _create_demo_net()
 
-  ite_pf, erg_pf = runpf!(net, 40, 1e-10, 0; method = :polar_full, opt_sparse = true)
+  ite_pf, erg_pf = runpf!(net, 40, 1e-10, 0; method = :rectangular, opt_sparse = true)
   erg_pf == 0 || error("Power flow did not converge")
 
   std = measurementStdDevs(vm = 0.01, pinj = 1.0, qinj = 1.0, pflow = 1.0, qflow = 1.0)

--- a/src/examples/using_links.jl
+++ b/src/examples/using_links.jl
@@ -92,7 +92,7 @@ function run_link_demo(; link_closed::Bool)
 
   println("\n================================================================================")
   println("Scenario: ", link_closed ? "Link CLOSED (Bus1-Bus1a)" : "Link OPEN (Bus1-Bus1a)")
-  iterations, status, _ = run_net_acpflow(net = net, max_ite = 25, tol = 1e-8, method = :polar_full, opt_sparse = true, opt_fd = false)
+  iterations, status, _ = run_net_acpflow(net = net, max_ite = 25, tol = 1e-8, method = :rectangular, opt_sparse = true, opt_fd = false)
   println("Converged: ", status == 0, " (status=", status, ", iterations=", iterations, ")")
   status == 0 || return net
 

--- a/src/examples/using_netreports.jl
+++ b/src/examples/using_netreports.jl
@@ -47,9 +47,9 @@ function main()
   addProsumer!(net = net, busName = "B3", type = "ENERGYCONSUMER", p = 15.0, q = 5.0)
   addProsumer!(net = net, busName = "B4", type = "ENERGYCONSUMER", p = 25.0, q = 10.0)
 
-  ite, erg, etime = run_net_acpflow(net = net, max_ite = 40, tol = 1e-10, method = :polar_full, opt_sparse = true, show_results = false)
+  ite, erg, etime = run_net_acpflow(net = net, max_ite = 40, tol = 1e-10, method = :rectangular, opt_sparse = true, show_results = false)
 
-  report = buildACPFlowReport(net; ct = etime, ite = ite, tol = 1e-10, converged = (erg == 0), solver = :polar_full)
+  report = buildACPFlowReport(net; ct = etime, ite = ite, tol = 1e-10, converged = (erg == 0), solver = :rectangular)
 
   println("\n--- ACPFlowReport summary ---")
   println(report)

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -576,7 +576,13 @@ A tuple containing the number of iterations and the result of the calculation:
 - `2`: Unsolvable system of equations.
 - `3`: Error.
 """
+const _warned_classic_solver_deprecated = Ref(false)
+
 function runpf_classic!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0, opt_sparse::Bool = false, opt_flatstart::Bool = net.flatstart)
+  if !_warned_classic_solver_deprecated[]
+    @warn "runpf_classic! / method=:classic is deprecated and will be removed in a future release. Please use method=:rectangular (complex Jacobian)."
+    _warned_classic_solver_deprecated[] = true
+  end
   if length(net.nodeVec) == 0
     @error "No nodes found in the network."
     return

--- a/src/jacobian_complex.jl
+++ b/src/jacobian_complex.jl
@@ -1118,7 +1118,7 @@ function _merged_pf_net(net::Net)
 end
 
 """
-    runpf!(net, maxIte, tolerance=1e-6, verbose=0; method=:polar_full)
+    runpf!(net, maxIte, tolerance=1e-6, verbose=0; method=:rectangular)
 
 Unified AC power flow interface.
 
@@ -1127,7 +1127,7 @@ Arguments:
 - `maxIte::Int`: maximum iterations
 - `tolerance::Float64`: mismatch tolerance
 - `verbose::Int`: verbosity level
-- `method::Symbol`: `:polar_full`, `:rectangular`, or `:classic`
+- `method::Symbol`: `:rectangular` (recommended), `:polar_full` (deprecated), or `:classic` (deprecated)
 
 Notes:
 - Link-flow recovery (`calcLinkFlowsKCL!`) is method-agnostic and uses solved PF results.
@@ -1194,6 +1194,6 @@ function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int =
     end
     return iters, erg
   else
-    error("runpf!: unknown method $(method). Use :polar_full or :rectangular.")
+    error("runpf!: unknown method $(method). Use :rectangular (recommended), :polar_full (deprecated), or :classic (deprecated).")
   end
 end

--- a/src/jacobian_full.jl
+++ b/src/jacobian_full.jl
@@ -412,7 +412,13 @@ end
 # ------------------------------
 # Convenience wrapper similar to runpf!, but for the full system
 # ------------------------------
+const _warned_full_solver_deprecated = Ref(false)
+
 function runpf_full!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; opt_sparse::Bool = false, opt_flatstart::Bool = net.flatstart, pv_table_rows::Int = 30, lock_pv_to_pq_buses::AbstractVector{Int} = Int[])
+  if !_warned_full_solver_deprecated[]
+    @warn "runpf_full! / method=:polar_full is deprecated and will be removed in a future release. Please use method=:rectangular (complex Jacobian)."
+    _warned_full_solver_deprecated[] = true
+  end
   printYBus = (length(net.nodeVec) < 20) && (verbose > 1)
   Y = createYBUS(net = net, sparse = opt_sparse, printYBUS = printYBus)
   if verbose > 1

--- a/src/network.jl
+++ b/src/network.jl
@@ -997,7 +997,9 @@ function addProsumer!(;
   proTy = toProSumptionType(type)
   refPriIdx = isnothing(referencePri) ? nothing : geNetBusIdx(net = net, busName = referencePri)
   vn_kV = getNodeVn(net.nodeVec[busIdx])
-  auto_regulated = isRegulated || (isGenerator(proTy) && !isnothing(vm_pu))
+  has_vm_setpoint = !isnothing(vm_pu)
+  has_vstep_with_taps = !isnothing(vstep_pu) && (!isnothing(tap_steps_down) || !isnothing(tap_steps_up))
+  auto_regulated = isRegulated || has_vm_setpoint || has_vstep_with_taps
   ps = ProSumer(vn_kv = vn_kV, busIdx = busIdx, oID = idProsSum, type = proTy, p = p, q = q, minP = pMin, maxP = pMax, minQ = qMin, maxQ = qMax, referencePri = refPriIdx, vm_pu = vm_pu, va_deg = va_deg, vstep_pu = vstep_pu, tap_steps_down = tap_steps_down, tap_steps_up = tap_steps_up, isRegulated = auto_regulated, isAPUNode = isAPUNode)
   push!(net.prosumpsVec, ps)
   node = net.nodeVec[busIdx]

--- a/src/run_acpflow.jl
+++ b/src/run_acpflow.jl
@@ -37,7 +37,7 @@ function run_acpflow(;
   printResultAnyCase::Bool = false,
   opt_fd::Bool = false,
   opt_sparse::Bool = false,
-  method::Symbol = :polar_full,
+  method::Symbol = :rectangular,
   opt_flatstart::Bool = false,
   show_results::Bool = true,
   cooldown_iters::Int = 0,
@@ -149,7 +149,7 @@ Parameters:
 - printResultToFile: Bool, flag to print results to a file (default: false).
 - printResultAnyCase: Bool, flag to print results even if the power flow fails (default: false).
 """
-function run_net_acpflow(; net::Net, max_ite::Int = 30, tol::Float64 = 1e-6, verbose::Int = 0, printResultToFile::Bool = false, printResultAnyCase::Bool = false, opt_fd::Bool = false, opt_sparse::Bool = false, method::Symbol = :polar_full, show_results::Bool = true, lock_pv_to_pq_buses::AbstractVector{Int} = Int[])
+function run_net_acpflow(; net::Net, max_ite::Int = 30, tol::Float64 = 1e-6, verbose::Int = 0, printResultToFile::Bool = false, printResultAnyCase::Bool = false, opt_fd::Bool = false, opt_sparse::Bool = false, method::Symbol = :rectangular, show_results::Bool = true, lock_pv_to_pq_buses::AbstractVector{Int} = Int[])
 
   # Run power flow
   ite = 0

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -1501,6 +1501,31 @@ function test_regulated_generator_bus_targets_include_unregulated_generators()::
   return p_target_ok && q_target_ok && q_limit_ok && bus_type_ok
 end
 
+function test_addprosumer_auto_regulated_flags()::Bool
+  net = Net(name = "addprosumer_auto_regulated_flags", baseMVA = 100.0)
+  addBus!(net = net, busName = "Slack", vn_kV = 110.0)
+  addBus!(net = net, busName = "PVVm", vn_kV = 110.0)
+  addBus!(net = net, busName = "PVTap", vn_kV = 110.0)
+  addBus!(net = net, busName = "PQ", vn_kV = 110.0)
+
+  addProsumer!(net = net, busName = "Slack", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "Slack")
+  addProsumer!(net = net, busName = "PVVm", type = "SYNCHRONOUSMACHINE", p = 10.0, vm_pu = 1.01)
+  addProsumer!(net = net, busName = "PVTap", type = "SYNCHRONOUSMACHINE", p = 8.0, vstep_pu = 0.005, tap_steps_down = 2, tap_steps_up = 2)
+  addProsumer!(net = net, busName = "PQ", type = "SYNCHRONOUSMACHINE", p = 6.0, q = 1.5)
+
+  ps_vm = only(getBusProsumers(net, geNetBusIdx(net = net, busName = "PVVm")))
+  ps_tap = only(getBusProsumers(net, geNetBusIdx(net = net, busName = "PVTap")))
+  ps_pq = only(getBusProsumers(net, geNetBusIdx(net = net, busName = "PQ")))
+
+  flags_ok = ps_vm.isRegulated && ps_tap.isRegulated && !ps_pq.isRegulated
+  bus_types_ok =
+    getEffectiveBusType(net = net, busName = "PVVm") == Sparlectra.PV &&
+    getEffectiveBusType(net = net, busName = "PVTap") == Sparlectra.PV &&
+    getEffectiveBusType(net = net, busName = "PQ") == Sparlectra.PQ
+
+  return flags_ok && bus_types_ok
+end
+
 function run_grid_tests()
   @testset "Grid and power-flow regression tests" begin
     @testset "Transformer and network validation" begin
@@ -1539,6 +1564,7 @@ function run_grid_tests()
       @test test_bus_type_resolution_from_prosumers() == true
       @test test_multiple_slack_prosumers_same_bus_supported() == true
       @test test_regulated_generator_bus_targets_include_unregulated_generators() == true
+      @test test_addprosumer_auto_regulated_flags() == true
     end
 
     @testset "Link behaviour and reporting" begin


### PR DESCRIPTION
* Marked legacy Jacobian solvers as deprecated:
  * `runpf_full!` / `method = :polar_full`
  * `runpf_classic!` / `method = :classic`
  Both now emit a deprecation warning when used.
* Set rectangular complex Jacobian (`method = :rectangular`) as the default for:
  * `run_acpflow`
  * `run_net_acpflow`
* Updated examples and user documentation to use `:rectangular` as the recommended/default solver method.