### PR TITLE
Dev/r0.7.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,47 +1,151 @@
-# Contributing to Sparlectra.jl
+# Contributing to Sparlectra.jl (Strict Governance Model + QA Requirements)
 
-Thank you for your interest in contributing to **Sparlectra.jl**. Contributions that improve reliability, performance, documentation, and usability are welcome.
+Thank you for your interest in contributing to **Sparlectra.jl**.
+
+This project is primarily a **research and educational effort** with limited maintainer capacity.  
+To keep the codebase consistent and maintainable, contributions follow a stricter process.
+
+---
+
+## ⚠️ Mandatory Proposal First Policy
+
+**All non-trivial contributions require prior discussion.**
+
+Before writing code, you MUST:
+
+1. Open an Issue or Discussion
+2. Describe your idea clearly
+3. Wait for maintainer feedback and alignment
+
+➡️ Pull Requests without prior agreement are typically not reviewed.
+
+---
+
+## Contribution Scope
+
+Sparlectra prioritizes:
+
+- numerical robustness  
+- deterministic behavior  
+- conceptual clarity  
+- minimal complexity  
+
+---
 
 ## Development Workflow
 
-1. Fork the repository
-2. Create a feature branch
-3. Implement your changes
-4. Open a Pull Request
+1. Fork the repository  
+2. Create a feature branch  
+3. Implement agreed changes  
+4. Open a Pull Request  
 
-Small and focused Pull Requests are preferred.
+---
 
 ## Coding Guidelines
 
-Please follow general Julia best practices:
+- clear and structured code  
+- descriptive naming  
+- minimal dependencies  
+- deterministic algorithms  
 
-* Write clear, readable, and well-structured code
-* Use descriptive function and variable names
-* Avoid unnecessary dependencies
-* Keep algorithms deterministic and numerically robust
+All comments and docstrings must be in **English**.
 
-All code comments and docstrings should be written in **English**.
+---
 
-## Numerical Code
+## Numerical Code Requirements
 
-Sparlectra focuses on **power flow algorithms and electrical network modeling**.
-When modifying numerical or solver-related code:
+- preserve numerical stability  
+- avoid performance regressions  
+- document mathematical changes clearly  
+- justify algorithmic decisions  
 
-* maintain numerical stability
-* avoid performance regressions
-* document algorithmic changes clearly
+---
 
-## Pull Requests
+## Testing Requirements (Mandatory)
 
-Please ensure that:
+- Every change MUST include **dedicated unit tests**
+- Tests must be **deterministic**
+- Edge cases must be covered where relevant
+- Tests must be part of the repository (not only described in PR)
 
-* the purpose of the change is clearly described
-* the scope of the Pull Request is focused
+---
 
-Large architectural changes should be discussed in an Issue first.
+## Coverage Requirements
 
-## Project Scope and Maintainer Availability
+- New code should include **test coverage**
+- Contributions should not significantly reduce overall coverage
+- Critical numerical paths must be explicitly tested
 
-Sparlectra.jl is primarily developed as a **research and educational project**, and the maintainer community is currently small.
+(Optional but recommended)
+- Contributors may include coverage reports (e.g. via CI)
 
-Contributions are welcome, but response times for issues or pull requests may vary, and immediate feedback cannot always be guaranteed. Thank you for your patience.
+---
+
+## Benchmark Requirements (for Solver / Numerical Changes)
+
+For any change affecting:
+
+- solver behavior  
+- numerical routines  
+- performance-critical code  
+
+the contributor MUST provide:
+
+- a **before/after benchmark**
+- description of the test case (network size, type)
+- comparison of:
+  - runtime  
+  - iteration count  
+  - convergence behavior  
+
+Benchmarks must be:
+
+- reproducible  
+- documented  
+- runnable by the maintainer  
+
+---
+
+## Test & Validation Documentation
+
+Each contribution must include:
+
+- how to run tests  
+- expected results  
+- assumptions / limitations  
+
+PR-only descriptions are NOT sufficient.
+
+---
+
+## Pull Request Acceptance Policy
+
+A PR may be rejected if:
+
+- no prior discussion  
+- missing tests  
+- missing benchmarks (if required)  
+- insufficient documentation  
+- increased complexity without benefit  
+
+---
+
+## Maintainer Availability
+
+- Reviews are best-effort  
+- Response times may vary  
+- Not all PRs will be accepted  
+
+---
+
+## Summary
+
+- Discuss first  
+- Provide tests  
+- Provide benchmarks (if relevant)  
+- Document clearly  
+- Keep changes minimal  
+
+This ensures long-term maintainability.
+
+Thank you for your understanding.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sparlectra"
 uuid = "31ce9bba-fd9d-44a1-b005-f5f509afda38"
-version = "0.6.4"
+version = "0.7.0"
 authors = ["Udo Schmitz"]
 description = "load flow calculation using newton-raphson"
 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -400,7 +400,7 @@ version = "1.2.2"
 deps = ["BenchmarkTools", "DataFrames", "Dates", "Downloads", "InlineStrings", "LinearAlgebra", "Logging", "Printf", "Random", "SHA", "SparseArrays"]
 path = "c:\\Users\\scud\\.julia\\dev\\Sparlectra\\docs\\.."
 uuid = "31ce9bba-fd9d-44a1-b005-f5f509afda38"
-version = "0.6.2"
+version = "0.7.0"
 
 [[deps.SparseArrays]]
 deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,7 +17,7 @@ makedocs(
   doctest = true,
   checkdocs = :none,
   format = Documenter.HTML(; assets = ["assets/tablestyle.css"], prettyurls = get(ENV, "CI", "false") == "true", collapselevel = 1, canonical = "https://welthulk.github.io/Sparlectra.jl"),
-  pages = ["index.md", "feature_matrix.md", "changelog.md", "branchmodel.md", "external_solvers.md", "import.md", "links.md", "netreports.md", "powerlimits.md", "solver.md", "state_estimation.md", "workshop.md", raw"API" => ["reference.md"]],
+  pages = ["index.md", "feature_matrix.md", "changelog.md", "branchmodel.md", "external_solvers.md", "import.md", "links.md", "netreports.md", "powerlimits.md", "solver.md", "voltage_dependent_control.md", "state_estimation.md", "workshop.md", raw"API" => ["reference.md"]],
 )
 
 deploydocs(; repo = "github.com/welthulk/Sparlectra.jl", devbranch = "main", push_preview = true)

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,6 +1,10 @@
 # Change Log
+## Version 0.7.0 – 2026-04-XX
+### New Features
+* Added support for P(U) and Q(U) controller models in power flow calculations
+
 ## Version 0.6.4 – 2026-04-12
-### Changes
+### New Features
 * Marked legacy Jacobian solvers as deprecated:
   * `runpf_full!` / `method = :polar_full`
   * `runpf_classic!` / `method = :classic`
@@ -9,6 +13,8 @@
   * `run_acpflow`
   * `run_net_acpflow`
 * Updated examples and user documentation to use `:rectangular` as the recommended/default solver method.
+### Bugfixes
+* For backwards compatibility, if vm is set, the coresponding bus type is set to PV
 
 ## Version 0.6.3 – 2026-04-11
 ### New Features

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,8 +1,10 @@
 # Change Log
-## Version 0.7.0 – 2026-04-XX
+## Version 0.7.0 – 2026-04-14
 ### New Features
 * Added support for P(U) and Q(U) controller models in power flow calculations
-
+* Added supprt for controler for non pv generators
+* Added documentation and examples for new controller features
+  
 ## Version 0.6.4 – 2026-04-12
 ### New Features
 * Marked legacy Jacobian solvers as deprecated:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,6 +62,7 @@ end
 - **[Function Reference](reference.md)**: Complete API documentation
 - **[Powerlimit Guide](powerlimits.md)**: Handling of power limits
 - **[Solver Guide](solver.md)**: Numerical solver formulations and FD Jacobians
+- **[Voltage-dependent Control](voltage_dependent_control.md)**: Q(U)/P(U) formulation, Jacobian terms, and API usage
 
 
 ### Network Creation

--- a/docs/src/solver.md
+++ b/docs/src/solver.md
@@ -255,3 +255,15 @@ In the rectangular solver this is represented through the `bus_types` vector.
 
 For the operational / data-model side of Q-limit handling, see
 [Powerlimits Guide](powerlimits.md).
+
+---
+
+## Voltage-dependent P(U)/Q(U) controls
+
+The rectangular solver also supports state-dependent specified injections via
+`PUController` and `QUController` attached to prosumers. In that case, the
+specified power vector is re-evaluated each Newton iteration as a function of
+local `|V|`, and local chain-rule terms are added to the Jacobian.
+
+For full derivation, formulas, API usage, and output semantics (`Type` vs
+`Control`), see [Voltage-dependent Control](voltage_dependent_control.md).

--- a/docs/src/voltage_dependent_control.md
+++ b/docs/src/voltage_dependent_control.md
@@ -1,0 +1,173 @@
+# Voltage-dependent prosumer control: Q(U) and P(U) (rectangular solver)
+
+This page documents voltage-dependent active/reactive power control for prosumers:
+
+- `QUController`: `Q = f_Q(|V|)`
+- `PUController`: `P = f_P(|V|)`
+
+These are **soft controls** (state-dependent injections), not hard PV equality constraints.
+The structural bus type (`Slack`, `PV`, `PQ`) remains unchanged.
+
+## Physical interpretation
+
+A controlled prosumer changes its setpoint according to local voltage magnitude.
+Examples:
+
+- `Q(U)` droop-like behavior for volt/var support.
+- `P(U)` behavior for curtailed generation or voltage-sensitive active injection.
+
+In Sparlectra this is attached to the prosumer (injection element), not to bus typing.
+
+## Rectangular state and voltage magnitude
+
+The rectangular state is
+
+```math
+V_i = e_i + j f_i, \qquad |V_i| = \sqrt{e_i^2 + f_i^2}.
+```
+
+For `|V_i| > 0`,
+
+```math
+\frac{\partial |V_i|}{\partial e_i} = \frac{e_i}{|V_i|},
+\qquad
+\frac{\partial |V_i|}{\partial f_i} = \frac{f_i}{|V_i|}.
+```
+
+Numerical safeguard: the implementation uses
+
+```math
+|V_i|_\varepsilon = \max(|V_i|, \varepsilon),\quad \varepsilon = 10^{-9}
+```
+
+in these derivatives to avoid division by zero near a collapsed voltage.
+
+## Controlled specified injections
+
+For a controlled prosumer at bus `i`:
+
+```math
+Q_i^{\mathrm{spec}} = f_Q(|V_i|),
+\qquad
+P_i^{\mathrm{spec}} = f_P(|V_i|).
+```
+
+If multiple prosumers share one bus, specified injections are aggregated by summation
+(with sign convention: generation positive, load negative):
+
+```math
+P_i^{\mathrm{spec,tot}} = \sum_{k\in\mathcal{D}_i} P_{i,k}^{\mathrm{spec}},
+\qquad
+Q_i^{\mathrm{spec,tot}} = \sum_{k\in\mathcal{D}_i} Q_{i,k}^{\mathrm{spec}}.
+```
+
+## Mismatch equations in rectangular NR
+
+The rectangular solver uses (for each non-slack bus):
+
+- PQ bus:
+
+```math
+\Delta P_i = P_i^{\mathrm{calc}}(e,f) - P_i^{\mathrm{spec,tot}}(|V_i|),
+\qquad
+\Delta Q_i = Q_i^{\mathrm{calc}}(e,f) - Q_i^{\mathrm{spec,tot}}(|V_i|).
+```
+
+- PV bus:
+
+```math
+\Delta P_i = P_i^{\mathrm{calc}}(e,f) - P_i^{\mathrm{spec,tot}}(|V_i|),
+\qquad
+\Delta V_i = |V_i| - V_i^{\mathrm{set}}.
+```
+
+So only the specified injection part becomes state-dependent.
+
+## Jacobian extension by chain rule (local terms)
+
+Because `P_spec` / `Q_spec` depend only on local `|V_i|`, extra Jacobian terms are local
+(bus `i` row, bus `i` state columns only).
+
+For active-power mismatch row:
+
+```math
+\frac{\partial \Delta P_i}{\partial e_i}
+= \frac{\partial P_i^{\mathrm{calc}}}{\partial e_i}
+- \frac{dP_i^{\mathrm{spec}}}{d|V_i|}\,\frac{e_i}{|V_i|},
+```
+
+```math
+\frac{\partial \Delta P_i}{\partial f_i}
+= \frac{\partial P_i^{\mathrm{calc}}}{\partial f_i}
+- \frac{dP_i^{\mathrm{spec}}}{d|V_i|}\,\frac{f_i}{|V_i|}.
+```
+
+For reactive-power mismatch row (PQ buses):
+
+```math
+\frac{\partial \Delta Q_i}{\partial e_i}
+= \frac{\partial Q_i^{\mathrm{calc}}}{\partial e_i}
+- \frac{dQ_i^{\mathrm{spec}}}{d|V_i|}\,\frac{e_i}{|V_i|},
+```
+
+```math
+\frac{\partial \Delta Q_i}{\partial f_i}
+= \frac{\partial Q_i^{\mathrm{calc}}}{\partial f_i}
+- \frac{dQ_i^{\mathrm{spec}}}{d|V_i|}\,\frac{f_i}{|V_i|}.
+```
+
+For PV second rows (`ΔV`) no `Q(U)` term is added because that row is voltage magnitude mismatch.
+
+## Piecewise linear characteristic and derivative
+
+Controllers use ordered points `(u_k, y_k)` in p.u.
+
+Inside segment `[u_k, u_{k+1}]`:
+
+```math
+y(u) = y_k + \frac{y_{k+1}-y_k}{u_{k+1}-u_k}(u-u_k),
+\qquad
+\frac{dy}{du} = \frac{y_{k+1}-y_k}{u_{k+1}-u_k}.
+```
+
+Behavior conventions:
+
+- Below first point: clamp to first value, derivative `0`.
+- Above last point: clamp to last value, derivative `0`.
+- At breakpoints: segment-wise evaluation (continuous value; slope is side-dependent).
+- If explicit min/max saturation is hit, output is clamped and derivative forced to `0`.
+
+## API usage
+
+```julia
+using Sparlectra
+
+qu = QUController(make_characteristic([(0.95, 0.3), (1.0, 0.0), (1.05, -0.2)]), -0.5, 0.5)
+pu = PUController(make_characteristic([(0.95, 0.2), (1.0, 0.1), (1.05, 0.0)]), 0.0, 0.5)
+
+addProsumer!(
+    net = net,
+    busName = "B2",
+    type = "SYNCHRONOUSMACHINE",
+    p = 10.0,
+    q = 0.0,
+    qu_controller = qu,
+    pu_controller = pu,
+)
+
+runpf!(net, 30, 1e-8, 0; method = :rectangular)
+```
+
+## Solver support and limitation
+
+- Supported: `method = :rectangular`.
+- Unsupported: legacy/deprecated `:polar_full` and `:classic` (clear runtime error if used with these controllers).
+
+## Result printout semantics (`Type` vs `Control`)
+
+Detailed result output has separate columns:
+
+- `Type`: structural bus class (`Slack`, `PV`, `PQ`), unchanged semantics.
+- `Control`: additional voltage-dependent behavior (`Q(U)`, `P(U)`, `Q(U), P(U)`, or `-`).
+
+This avoids overloading bus type strings and keeps existing workflows stable.

--- a/docs/src/voltage_dependent_control.md
+++ b/docs/src/voltage_dependent_control.md
@@ -120,7 +120,13 @@ For PV second rows (`ΔV`) no `Q(U)` term is added because that row is voltage m
 
 ## Piecewise linear characteristic and derivative
 
-Controllers use ordered points `(u_k, y_k)` in p.u.
+Controllers use ordered points `(u_k, y_k)` internally in p.u.
+
+You can now provide characteristic points either:
+
+- directly in p.u. (`voltage_unit=:pu`, `value_unit=:pu`), or
+- in physical units (`voltage_unit=:kV`, `value_unit=:MW`/`:MVAr`) with
+  conversion metadata (`vn_kV`, `sbase_MVA`).
 
 Inside segment `[u_k, u_{k+1}]`:
 
@@ -142,8 +148,23 @@ Behavior conventions:
 ```julia
 using Sparlectra
 
-qu = QUController(make_characteristic([(0.95, 0.3), (1.0, 0.0), (1.05, -0.2)]), -0.5, 0.5)
-pu = PUController(make_characteristic([(0.95, 0.2), (1.0, 0.1), (1.05, 0.0)]), 0.0, 0.5)
+qu = QUController(
+    make_characteristic([(104.5, 30.0), (110.0, 0.0), (115.5, -20.0)];
+                        voltage_unit = :kV, value_unit = :MVAr,
+                        vn_kV = 110.0, sbase_MVA = 100.0);
+    qmin_MVAr = -50.0,
+    qmax_MVAr = 50.0,
+    sbase_MVA = 100.0,
+)
+
+pu = PUController(
+    make_characteristic([(104.5, 20.0), (110.0, 10.0), (115.5, 0.0)];
+                        voltage_unit = :kV, value_unit = :MW,
+                        vn_kV = 110.0, sbase_MVA = 100.0);
+    pmin_MW = 0.0,
+    pmax_MW = 50.0,
+    sbase_MVA = 100.0,
+)
 
 addProsumer!(
     net = net,
@@ -157,6 +178,11 @@ addProsumer!(
 
 runpf!(net, 30, 1e-8, 0; method = :rectangular)
 ```
+
+Notes:
+
+- Existing p.u.-based calls remain fully supported.
+- Controller evaluation and Jacobian assembly still operate in p.u. internally.
 
 ## Solver support and limitation
 

--- a/docs/src/voltage_dependent_control.md
+++ b/docs/src/voltage_dependent_control.md
@@ -195,5 +195,8 @@ Detailed result output has separate columns:
 
 - `Type`: structural bus class (`Slack`, `PV`, `PQ`), unchanged semantics.
 - `Control`: additional voltage-dependent behavior (`Q(U)`, `P(U)`, `Q(U), P(U)`, or `-`).
+- `Pg/Qg/Pl/Ql`: effective solved bus power components; for prosumers with
+  `Q(U)`/`P(U)` this reflects the controller-evaluated setpoints at the solved
+  bus voltage (not only initial static `p`/`q` inputs).
 
 This avoids overloading bus type strings and keeps existing workflows stable.

--- a/docs/src/voltage_dependent_control.md
+++ b/docs/src/voltage_dependent_control.md
@@ -183,6 +183,9 @@ Notes:
 
 - Existing p.u.-based calls remain fully supported.
 - Controller evaluation and Jacobian assembly still operate in p.u. internally.
+- MATPOWER import: if a generator is connected to a `PQ` bus (`BUS_TYPE = 1`),
+  Sparlectra maps `Pmin/Pmax/Qmin/Qmax` to constant `P(U)`/`Q(U)` controllers
+  (fixed characteristic with limits) and emits an import log message.
 
 ## Solver support and limitation
 

--- a/src/Sparlectra.jl
+++ b/src/Sparlectra.jl
@@ -31,7 +31,7 @@ const MPOWER_DIR = normpath(joinpath(pkgdir(@__MODULE__), "data", "mpower"))
 
 # resource data types for working with Sparlectra
 const Wurzel3 = 1.7320508075688772
-const SparlectraVersion = v"0.6.4"
+const SparlectraVersion = v"0.7.0"
 version() = SparlectraVersion
 abstract type AbstractBranch end
 

--- a/src/Sparlectra.jl
+++ b/src/Sparlectra.jl
@@ -64,7 +64,7 @@ export
   # Trafo
   TrafoTyp, PowerTransformerTaps,  PowerTransformerWinding,  PowerTransformer, TransformerModelParameters,
   # ProSumer
-  ProSumer,
+  ProSumer, AbstractVoltageDependentController, PiecewiseLinearCharacteristic, QUController, PUController,
   # Branch
   AbstractBranch, Branch, BranchModel, BranchFlow, getBranchFlow, setBranchFlow!, getBranchNumber, getBranchLosses, setBranchLosses!, setBranchStatus!,
   # Link
@@ -96,11 +96,11 @@ export
   # ACLineSegment
   get_line_parameters, isLinePIModel, getLineRXBG, getLineRXBG_pu,
   # ProSumer
-  isSlack, isGenerator, isAPUNode, isRegulating, setQGenReplacement!, getQGenReplacement, toProSumptionType, updatePQ!, getPosumerBusIndex, setPQResult!,
+  isSlack, isGenerator, isAPUNode, isRegulating, setQGenReplacement!, getQGenReplacement, toProSumptionType, updatePQ!, getPosumerBusIndex, setPQResult!, evaluate_characteristic, evaluate_controller, make_characteristic, has_qu_controller, has_pu_controller,
   # Network
   addBus!, addShunt!, addACLine!, addPIModelACLine!, add2WTrafo!, addPIModelTrafo!, addProsumer!, lockNet!, validate!, hasBusInNet, addBusGenPower!, addBusLoadPower!, addBusShuntPower!, setNodeVoltage!, setNodeAngle!,
   getNetOrigBusIdx, geNetBusIdx, setNetBranchStatus!, getNetBranch, getNetBranchNumberVec, setTotalLosses!, getTotalLosses, getBusType, getEffectiveBusType, getBusProsumers, refreshBusTypesFromProsumers!, get_bus_vn_kV, get_vn_kV, updateBranchParameters!, hasShunt!, 
-  getShunt!, markIsolatedBuses!,setTotalBusPower!, setPVBusVset!, setQLimits!, getNodeVm,distributeBusResults!, getTotalBusPower, getTotalLosses, buildVoltageVector,initialVrect, buildComplexSVec,addShuntMatpower!,
+  getShunt!, markIsolatedBuses!,setTotalBusPower!, setPVBusVset!, setQLimits!, getNodeVm,distributeBusResults!, getTotalBusPower, getTotalLosses, buildVoltageVector,initialVrect, buildComplexSVec, buildControlledSVec, has_voltage_dependent_control, addShuntMatpower!,
   add2WTPIModelTrafo!, add3WTPiModelTrafo!,showNet, buildQLimits!,updateShuntPowers!, addLink!, setNetLinkStatus!, getNetLinks, calcLinkFlowsKCL!,
   # remove_functions.jl
   removeBus!, removeBranch!, removeACLine!, removeTrafo!, removeShunt!, removeProsumer!, clearIsolatedBuses!,apply_mp_isolated_buses!,

--- a/src/createnet_powermat.jl
+++ b/src/createnet_powermat.jl
@@ -239,6 +239,16 @@ function createNetFromMatPowerCase(; mpc, log::Bool=false, flatstart::Bool=false
     referencePri = (slackIdx == Int(row[genDict["bus"]])) ? bus : nothing
     (mBase != baseMVA) && @debug "generator $(bus) has different mBase than network baseMVA (allowed in MATPOWER)" bus mBase baseMVA
 
+    pu_controller = nothing
+    qu_controller = nothing
+    if btype == 1
+      p_pu = pGen / baseMVA
+      q_pu = qGen / baseMVA
+      pu_controller = PUController(make_characteristic([(0.0, p_pu), (2.0, p_pu)]); pmin_MW = pMin, pmax_MW = pMax, sbase_MVA = baseMVA)
+      qu_controller = QUController(make_characteristic([(0.0, q_pu), (2.0, q_pu)]); qmin_MVAr = qMin, qmax_MVAr = qMax, sbase_MVA = baseMVA)
+      @info "MATPOWER import: PQ generator limits mapped to constant P(U)/Q(U) controllers" bus = bus pMin = pMin pMax = pMax qMin = qMin qMax = qMax
+    end
+
     addProsumer!(
       net = myNet,
       busName = bus,
@@ -251,6 +261,8 @@ function createNetFromMatPowerCase(; mpc, log::Bool=false, flatstart::Bool=false
       pMin = pMin,
       qMax = qMax,
       qMin = qMin,
+      qu_controller = qu_controller,
+      pu_controller = pu_controller,
       isRegulated = (btype == 2),
     )
   end

--- a/src/examples/example_matpower_pv_vs_controller_pq.jl
+++ b/src/examples/example_matpower_pv_vs_controller_pq.jl
@@ -1,0 +1,134 @@
+# Example: MATPOWER generator handling as PV vs constant P(U)/Q(U)-controlled PQ.
+#
+# Goal:
+# - Case A: keep MATPOWER BUS_TYPE for generator buses (classic PV behavior)
+# - Case B: force non-slack generator buses to PQ (BUS_TYPE=1), which maps
+#           MATPOWER generator limits to constant P(U)/Q(U) controllers.
+#
+# This demonstrates how the importer treats generators that are not specified
+# as PV buses.
+
+using Sparlectra
+using Printf
+using Logging
+
+const MPOWER_DIR = normpath(joinpath(@__DIR__, "..", "..", "data", "mpower"))
+
+function ensure_case_available!(case::AbstractString; overwrite::Bool = false)
+  mkpath(MPOWER_DIR)
+  local_m = joinpath(MPOWER_DIR, case)
+  if !isfile(local_m) || overwrite
+    try
+      url = "https://raw.githubusercontent.com/MATPOWER/matpower/master/data/$(case)"
+      Sparlectra.FetchMatpowerCase.ensure_matpower_case(url = url, outdir = MPOWER_DIR, to_jl = false, overwrite = overwrite)
+    catch err
+      @warn "Could not download $(case). Falling back to inline case9 data." error = err
+      return nothing
+    end
+  end
+  return local_m
+end
+
+function case9_inline()
+  bus = Float64[
+    1 3 0 0 0 0 1 1 0 345 1 1.1 0.9
+    2 2 0 0 0 0 1 1 0 345 1 1.1 0.9
+    3 2 0 0 0 0 1 1 0 345 1 1.1 0.9
+    4 1 0 0 0 0 1 1 0 345 1 1.1 0.9
+    5 1 90 30 0 0 1 1 0 345 1 1.1 0.9
+    6 1 0 0 0 0 1 1 0 345 1 1.1 0.9
+    7 1 100 35 0 0 1 1 0 345 1 1.1 0.9
+    8 1 0 0 0 0 1 1 0 345 1 1.1 0.9
+    9 1 125 50 0 0 1 1 0 345 1 1.1 0.9
+  ]
+  gen = Float64[
+    1 72.3 27.03 300 -300 1 100 1 250 10 0 0 0 0 0 0 0 0 0 0 0
+    2 163.0 6.54 300 -300 1 100 1 300 10 0 0 0 0 0 0 0 0 0 0 0
+    3 85.0 -10.95 300 -300 1 100 1 270 10 0 0 0 0 0 0 0 0 0 0 0
+  ]
+  branch = Float64[
+    1 4 0 0.0576 0 250 250 250 0 0 1 -360 360
+    4 5 0.017 0.092 0.158 250 250 250 0 0 1 -360 360
+    5 6 0.039 0.17 0.358 150 150 150 0 0 1 -360 360
+    3 6 0 0.0586 0 300 300 300 0 0 1 -360 360
+    6 7 0.0119 0.1008 0.209 150 150 150 0 0 1 -360 360
+    7 8 0.0085 0.072 0.149 250 250 250 0 0 1 -360 360
+    8 2 0 0.0625 0 250 250 250 0 0 1 -360 360
+    8 9 0.032 0.161 0.306 250 250 250 0 0 1 -360 360
+    9 4 0.01 0.085 0.176 250 250 250 0 0 1 -360 360
+  ]
+  return (name = "case9_inline", baseMVA = 100.0, bus = bus, gen = gen, branch = branch)
+end
+
+function generator_summary(net::Net)
+  println("Generator setup:")
+  println(" bus | regulated(PV) | has P(U) | has Q(U) | P [MW] | Q [MVAr] | Vm set")
+  println("-----+---------------+----------+----------+--------+----------+-------")
+  for ps in net.prosumpsVec
+    isGenerator(ps) || continue
+    bidx = getPosumerBusIndex(ps)
+    @printf(" %3d | %13s | %8s | %8s | %6.2f | %8.2f | %5s\n", bidx, string(ps.isRegulated), string(has_pu_controller(ps)), string(has_qu_controller(ps)), isnothing(ps.pVal) ? 0.0 : ps.pVal, isnothing(ps.qVal) ? 0.0 : ps.qVal, isnothing(ps.vm_pu) ? "-" : @sprintf("%.3f", ps.vm_pu),)
+  end
+  println("")
+end
+
+function force_generator_buses_to_pq!(mpc)
+  gen_buses = unique(Int(row[1]) for row in eachrow(mpc.gen) if Int(row[8]) == 1)
+  for row in eachrow(mpc.bus)
+    bus_i = Int(row[1])   # BUS_I
+    btype = Int(row[2])   # BUS_TYPE
+    if bus_i in gen_buses && btype != 3
+      row[2] = 1.0
+    end
+  end
+  return mpc
+end
+
+function run_case(case_name::String, mpc; verbose::Int = 0, show_generator_setup::Bool = false)
+  net = with_logger(NullLogger()) do
+    Sparlectra.createNetFromMatPowerCase(mpc = mpc, log = false, flatstart = false)
+  end
+  ite, erg, etime = run_net_acpflow(net = net, max_ite = 30, tol = 1e-8, verbose = verbose, opt_sparse = true, method = :rectangular, show_results = false)
+  println("=== $case_name ===")
+  println("Converged: ", erg == 0, " (iterations: ", ite, ")")
+  if show_generator_setup
+    generator_summary(net)
+  end
+  printACPFlowResults(net, etime, ite, 1e-8; converged = (erg == 0), solver = :rectangular)
+  println("")
+  return net
+end
+
+function run_example_matpower_pv_vs_controller_pq(; verbose::Int = 0, show_generator_setup::Bool = false)
+  casefile = "case9.m"
+  filename = ensure_case_available!(casefile)
+  if isnothing(filename)
+    println("Using inline MATPOWER case9 data")
+    mpc_pv = case9_inline()
+  else
+    println("Using MATPOWER case: $filename")
+    mpc_pv = Sparlectra.MatpowerIO.read_case(filename; legacy_compat = true)
+  end
+
+  net_pv = run_case("Case A: MATPOWER generator buses as PV", mpc_pv; verbose = verbose, show_generator_setup = show_generator_setup)
+
+  mpc_pq = deepcopy(mpc_pv)
+  force_generator_buses_to_pq!(mpc_pq)
+  net_pq = run_case("Case B: non-slack generators as PQ + constant P(U)/Q(U)", mpc_pq; verbose = verbose, show_generator_setup = show_generator_setup)
+
+  println("=== Delta table (Case B - Case A) at generator buses ===")
+  gen_buses = sort(unique(getPosumerBusIndex(ps) for ps in net_pv.prosumpsVec if isGenerator(ps)))
+  println(" bus | Vm PV-case | Vm PQ-case | ΔVm     | Va PV-case | Va PQ-case | ΔVa [deg]")
+  println("-----+------------+------------+---------+------------+------------+----------")
+  for bus in gen_buses
+    vm_pv = net_pv.nodeVec[bus]._vm_pu
+    vm_pq = net_pq.nodeVec[bus]._vm_pu
+    va_pv = net_pv.nodeVec[bus]._va_deg
+    va_pq = net_pq.nodeVec[bus]._va_deg
+    @printf(" %3d | %10.5f | %10.5f | %+0.5f | %10.4f | %10.4f | %+0.4f\n", bus, vm_pv, vm_pq, vm_pq - vm_pv, va_pv, va_pq, va_pq - va_pv)
+  end
+
+  return nothing
+end
+
+_ = Base.invokelatest(run_example_matpower_pv_vs_controller_pq)

--- a/src/examples/example_voltage_dependent_control_rectangular.jl
+++ b/src/examples/example_voltage_dependent_control_rectangular.jl
@@ -16,15 +16,7 @@ function run_example_voltage_dependent_control_rectangular(; verbose::Int = 1)
   qu_curve = make_characteristic([(103.4, 35.0), (110.0, 0.0), (116.6, -25.0)]; voltage_unit = :kV, value_unit = :MVAr, vn_kV = 110.0, sbase_MVA = net.baseMVA)
   pu_curve = make_characteristic([(103.4, 25.0), (110.0, 10.0), (116.6, 0.0)]; voltage_unit = :kV, value_unit = :MW, vn_kV = 110.0, sbase_MVA = net.baseMVA)
 
-  addProsumer!(
-    net = net,
-    busName = "Prosumer",
-    type = "SYNCHRONOUSMACHINE",
-    p = 10.0,
-    q = 0.0,
-    qu_controller = QUController(qu_curve; qmin_MVAr = -50.0, qmax_MVAr = 50.0, sbase_MVA = net.baseMVA),
-    pu_controller = PUController(pu_curve; pmin_MW = 0.0, pmax_MW = 50.0, sbase_MVA = net.baseMVA),
-  )
+  addProsumer!(net = net, busName = "Prosumer", type = "SYNCHRONOUSMACHINE", p = 10.0, q = 0.0, qu_controller = QUController(qu_curve; qmin_MVAr = -50.0, qmax_MVAr = 50.0, sbase_MVA = net.baseMVA), pu_controller = PUController(pu_curve; pmin_MW = 0.0, pmax_MW = 50.0, sbase_MVA = net.baseMVA))
 
   addProsumer!(net = net, busName = "Prosumer", type = "ENERGYCONSUMER", p = 45.0, q = 18.0)
 
@@ -44,7 +36,7 @@ function run_example_voltage_dependent_control_rectangular(; verbose::Int = 1)
     @printf("Bus %-10s |V| = %.5f pu, angle = %.3f deg\n", "Prosumer", abs(V[2]), rad2deg(angle(V[2])))
     @printf("Controlled prosumer setpoints at Vm=%.5f pu: P=%.3f MW, Q=%.3f MVar\n", vm, p_ctrl_pu * net.baseMVA, q_ctrl_pu * net.baseMVA)
     @printf("Net specified injection at Prosumer bus: P=%.3f MW, Q=%.3f MVar\n", real(Sspec[2]) * net.baseMVA, imag(Sspec[2]) * net.baseMVA)
-
+    println("\nDetailed results:")
     printACPFlowResults(net, 0.0, ite, 1e-9; converged = true, solver = :rectangular)
   else
     println("Power flow did not converge.")

--- a/src/examples/example_voltage_dependent_control_rectangular.jl
+++ b/src/examples/example_voltage_dependent_control_rectangular.jl
@@ -16,7 +16,15 @@ function run_example_voltage_dependent_control_rectangular(; verbose::Int = 1)
   qu_curve = make_characteristic([(103.4, 35.0), (110.0, 0.0), (116.6, -25.0)]; voltage_unit = :kV, value_unit = :MVAr, vn_kV = 110.0, sbase_MVA = net.baseMVA)
   pu_curve = make_characteristic([(103.4, 25.0), (110.0, 10.0), (116.6, 0.0)]; voltage_unit = :kV, value_unit = :MW, vn_kV = 110.0, sbase_MVA = net.baseMVA)
 
-  addProsumer!(net = net, busName = "Prosumer", type = "SYNCHRONOUSMACHINE", p = 10.0, q = 0.0, qu_controller = QUController(qu_curve; qmin_MVAr = -50.0, qmax_MVAr = 50.0, sbase_MVA = net.baseMVA), pu_controller = PUController(pu_curve; pmin_MW = 0.0, pmax_MW = 50.0, sbase_MVA = net.baseMVA))
+  addProsumer!(
+    net = net,
+    busName = "Prosumer",
+    type = "SYNCHRONOUSMACHINE",
+    p = 10.0,
+    q = 0.0,
+    qu_controller = QUController(qu_curve; qmin_MVAr = -50.0, qmax_MVAr = 50.0, sbase_MVA = net.baseMVA),
+    pu_controller = PUController(pu_curve; pmin_MW = 0.0, pmax_MW = 50.0, sbase_MVA = net.baseMVA),
+  )
 
   addProsumer!(net = net, busName = "Prosumer", type = "ENERGYCONSUMER", p = 45.0, q = 18.0)
 

--- a/src/examples/example_voltage_dependent_control_rectangular.jl
+++ b/src/examples/example_voltage_dependent_control_rectangular.jl
@@ -13,8 +13,8 @@ function run_example_voltage_dependent_control_rectangular(; verbose::Int = 1)
 
   addProsumer!(net = net, busName = "Slack", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "Slack")
 
-  qu_curve = make_characteristic([(0.94, 0.35), (1.00, 0.00), (1.06, -0.25)])
-  pu_curve = make_characteristic([(0.94, 0.25), (1.00, 0.10), (1.06, 0.00)])
+  qu_curve = make_characteristic([(103.4, 35.0), (110.0, 0.0), (116.6, -25.0)]; voltage_unit = :kV, value_unit = :MVAr, vn_kV = 110.0, sbase_MVA = net.baseMVA)
+  pu_curve = make_characteristic([(103.4, 25.0), (110.0, 10.0), (116.6, 0.0)]; voltage_unit = :kV, value_unit = :MW, vn_kV = 110.0, sbase_MVA = net.baseMVA)
 
   addProsumer!(
     net = net,
@@ -22,8 +22,8 @@ function run_example_voltage_dependent_control_rectangular(; verbose::Int = 1)
     type = "SYNCHRONOUSMACHINE",
     p = 10.0,
     q = 0.0,
-    qu_controller = QUController(qu_curve, -0.50, 0.50),
-    pu_controller = PUController(pu_curve, 0.0, 0.50),
+    qu_controller = QUController(qu_curve; qmin_MVAr = -50.0, qmax_MVAr = 50.0, sbase_MVA = net.baseMVA),
+    pu_controller = PUController(pu_curve; pmin_MW = 0.0, pmax_MW = 50.0, sbase_MVA = net.baseMVA),
   )
 
   addProsumer!(net = net, busName = "Prosumer", type = "ENERGYCONSUMER", p = 45.0, q = 18.0)

--- a/src/examples/example_voltage_dependent_control_rectangular.jl
+++ b/src/examples/example_voltage_dependent_control_rectangular.jl
@@ -1,0 +1,56 @@
+# Example: Voltage-dependent Q(U) and P(U) control in the rectangular solver.
+
+using Sparlectra
+using Printf
+
+function run_example_voltage_dependent_control_rectangular(; verbose::Int = 1)
+  net = Net(name = "voltage_dependent_control", baseMVA = 100.0)
+
+  addBus!(net = net, busName = "Slack", vn_kV = 110.0)
+  addBus!(net = net, busName = "Prosumer", vn_kV = 110.0)
+
+  addACLine!(net = net, fromBus = "Slack", toBus = "Prosumer", length = 30.0, r = 0.05, x = 0.45)
+
+  addProsumer!(net = net, busName = "Slack", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "Slack")
+
+  qu_curve = make_characteristic([(0.94, 0.35), (1.00, 0.00), (1.06, -0.25)])
+  pu_curve = make_characteristic([(0.94, 0.25), (1.00, 0.10), (1.06, 0.00)])
+
+  addProsumer!(
+    net = net,
+    busName = "Prosumer",
+    type = "SYNCHRONOUSMACHINE",
+    p = 10.0,
+    q = 0.0,
+    qu_controller = QUController(qu_curve, -0.50, 0.50),
+    pu_controller = PUController(pu_curve, 0.0, 0.50),
+  )
+
+  addProsumer!(net = net, busName = "Prosumer", type = "ENERGYCONSUMER", p = 45.0, q = 18.0)
+
+  ite, erg = runpf!(net, 40, 1e-9, verbose; method = :rectangular, opt_sparse = true)
+  converged = (erg == 0)
+
+  if converged
+    V = buildVoltageVector(net)
+    Sspec, _, _ = buildControlledSVec(net, V)
+
+    vm = abs(V[2])
+    p_ctrl_pu, _ = evaluate_controller(net.prosumpsVec[2].puController, vm)
+    q_ctrl_pu, _ = evaluate_controller(net.prosumpsVec[2].quController, vm)
+
+    println("\nConverged in $ite iterations")
+    @printf("Bus %-10s |V| = %.5f pu, angle = %.3f deg\n", "Slack", abs(V[1]), rad2deg(angle(V[1])))
+    @printf("Bus %-10s |V| = %.5f pu, angle = %.3f deg\n", "Prosumer", abs(V[2]), rad2deg(angle(V[2])))
+    @printf("Controlled prosumer setpoints at Vm=%.5f pu: P=%.3f MW, Q=%.3f MVar\n", vm, p_ctrl_pu * net.baseMVA, q_ctrl_pu * net.baseMVA)
+    @printf("Net specified injection at Prosumer bus: P=%.3f MW, Q=%.3f MVar\n", real(Sspec[2]) * net.baseMVA, imag(Sspec[2]) * net.baseMVA)
+
+    printACPFlowResults(net, 0.0, ite, 1e-9; converged = true, solver = :rectangular)
+  else
+    println("Power flow did not converge.")
+  end
+
+  return net
+end
+
+Base.invokelatest(run_example_voltage_dependent_control_rectangular)

--- a/src/jacobian_complex.jl
+++ b/src/jacobian_complex.jl
@@ -1232,7 +1232,7 @@ function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int =
     if qlimit_mode != :switch_to_pq
       @warn "runpf!: qlimit_mode=$(qlimit_mode) is only supported for method=:rectangular. Falling back to :switch_to_pq behavior."
     end
-    iters, erg = runpf_full!(wnet, maxIte, tolerance, verbose; opt_sparse = opt_sparse, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, lock_pv_to_pq_buses = lock_pv_to_pq_buses)
+    iters, erg = runpf_full!(wnet, maxIte, tolerance, verbose; opt_sparse = opt_sparse, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, lock_pv_to_pq_buses = lock_pv_to_pq_buses, warn_deprecated = true)
     if erg == 0 && has_merges
       _sync_merged_results_to_original!()
     end
@@ -1246,7 +1246,7 @@ function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int =
       if verbose > 0
         @warn "runpf!: rectangular solver does not support internal Isolated buses from active-link merges; falling back to :polar_full"
       end
-      iters, erg = runpf_full!(wnet, maxIte, tolerance, verbose; opt_sparse = opt_sparse, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, lock_pv_to_pq_buses = lock_pv_to_pq_buses)
+      iters, erg = runpf_full!(wnet, maxIte, tolerance, verbose; opt_sparse = opt_sparse, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, lock_pv_to_pq_buses = lock_pv_to_pq_buses, warn_deprecated = false)
     else
       iters, erg = runpf_rectangular!(wnet, maxIte, tolerance, verbose; opt_fd = opt_fd, opt_sparse = opt_sparse, damp = damp, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, lock_pv_to_pq_buses = lock_pv_to_pq_buses, qlimit_mode = qlimit_mode, qlimit_max_outer = qlimit_max_outer)
     end

--- a/src/jacobian_complex.jl
+++ b/src/jacobian_complex.jl
@@ -111,11 +111,13 @@ For each non-slack bus i:
 
 F is stacked as [ΔP_2, ΔQ/ΔV_2, ..., ΔP_n, ΔQ/ΔV_n] over all non-slack buses.
 """
-function mismatch_rectangular(Ybus, V::Vector{ComplexF64}, S::Vector{ComplexF64}, bus_types::Vector{Symbol}, Vset::Vector{Float64}, slack_idx::Int)
+function mismatch_rectangular(Ybus, V::Vector{ComplexF64}, S::Vector{ComplexF64}, bus_types::Vector{Symbol}, Vset::Vector{Float64}, slack_idx::Int; dPinj_dVm::Vector{Float64} = zeros(Float64, length(V)), dQinj_dVm::Vector{Float64} = zeros(Float64, length(V)))
   n = length(V)
   @assert length(S) == n
   @assert length(bus_types) == n
   @assert length(Vset) == n
+  @assert length(dPinj_dVm) == n
+  @assert length(dQinj_dVm) == n
 
   # Network-based injections for the current state
   S_calc = calc_injections(Ybus, V)
@@ -158,12 +160,12 @@ function mismatch_rectangular(Ybus, V::Vector{ComplexF64}, S::Vector{ComplexF64}
   return F
 end
 
-function run_complex_nr_rectangular(Ybus, V0, S; slack_idx::Int = 1, maxiter::Int = 20, tol::Float64 = 1e-8, verbose::Bool = false, damp::Float64 = 1.0, bus_types::Vector{Symbol}, Vset::Vector{Float64}, use_fd::Bool = false, use_sparse::Bool = false)
+function run_complex_nr_rectangular(Ybus, V0, S; slack_idx::Int = 1, maxiter::Int = 20, tol::Float64 = 1e-8, verbose::Bool = false, damp::Float64 = 1.0, bus_types::Vector{Symbol}, Vset::Vector{Float64}, use_fd::Bool = false, use_sparse::Bool = false, dPinj_dVm::Vector{Float64} = zeros(Float64, length(V0)), dQinj_dVm::Vector{Float64} = zeros(Float64, length(V0)))
   V = copy(V0)
   history = Float64[]
 
   for iter = 1:maxiter
-    F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx)
+    F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
     max_mis = maximum(abs.(F))
     push!(history, max_mis)
 
@@ -172,9 +174,9 @@ function run_complex_nr_rectangular(Ybus, V0, S; slack_idx::Int = 1, maxiter::In
     end
 
     if use_fd
-      V = complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx = slack_idx, damp = damp, h = 1e-6, bus_types = bus_types, Vset = Vset)
+      V = complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx = slack_idx, damp = damp, h = 1e-6, bus_types = bus_types, Vset = Vset, dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
     else
-      V = complex_newton_step_rectangular(Ybus, V, S; slack_idx = slack_idx, damp = damp, bus_types = bus_types, Vset = Vset, use_sparse = use_sparse)
+      V = complex_newton_step_rectangular(Ybus, V, S; slack_idx = slack_idx, damp = damp, bus_types = bus_types, Vset = Vset, use_sparse = use_sparse, dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
     end
   end
 
@@ -277,10 +279,12 @@ With ΔP_i = Re(ΔS_i), ΔQ_i = Im(ΔS_i), ΔV_i = |V_i| - Vset[i].
 Returns:
     J :: SparseMatrixCSC{Float64} with size (2(n-1)) × (2(n-1)).
 """
-function build_rectangular_jacobian_pq_pv_sparse(Ybus::SparseMatrixCSC{ComplexF64}, V::Vector{ComplexF64}, bus_types::Vector{Symbol}, Vset::Vector{Float64}, slack_idx::Int)
+function build_rectangular_jacobian_pq_pv_sparse(Ybus::SparseMatrixCSC{ComplexF64}, V::Vector{ComplexF64}, bus_types::Vector{Symbol}, Vset::Vector{Float64}, slack_idx::Int; dPinj_dVm::Vector{Float64} = zeros(Float64, length(V)), dQinj_dVm::Vector{Float64} = zeros(Float64, length(V)), vm_eps::Float64 = 1e-9)
   n = length(V)
   @assert length(bus_types) == n
   @assert length(Vset) == n
+  @assert length(dPinj_dVm) == n
+  @assert length(dQinj_dVm) == n
 
   I = Ybus * V
 
@@ -452,6 +456,45 @@ function build_rectangular_jacobian_pq_pv_sparse(Ybus::SparseMatrixCSC{ComplexF6
     end
   end
 
+  # Local chain-rule terms for voltage-dependent specified injections.
+  # For ΔP = Pcalc - Pspec(|V|): subtract dPspec/d|V| * d|V|/dVr and d|V|/dVi.
+  # For PQ second row ΔQ = Qcalc - Qspec(|V|): analogous subtraction.
+  for i in non_slack
+    pos = pos_non_slack[i]
+    rb = row_block[i]
+    pos == 0 && continue
+    rb == 0 && continue
+
+    vm = abs(V[i])
+    vm_safe = vm > vm_eps ? vm : vm_eps
+    dvm_dvr = real(V[i]) / vm_safe
+    dvm_dvi = imag(V[i]) / vm_safe
+    colVr = pos
+    colVi = (n - 1) + pos
+
+    dP = dPinj_dVm[i]
+    if dP != 0.0
+      push!(Iidx, rb)
+      push!(Jidx, colVr)
+      push!(Vals, -dP * dvm_dvr)
+      push!(Iidx, rb)
+      push!(Jidx, colVi)
+      push!(Vals, -dP * dvm_dvi)
+    end
+
+    if bus_types[i] == :PQ
+      dQ = dQinj_dVm[i]
+      if dQ != 0.0
+        push!(Iidx, rb + 1)
+        push!(Jidx, colVr)
+        push!(Vals, -dQ * dvm_dvr)
+        push!(Iidx, rb + 1)
+        push!(Jidx, colVi)
+        push!(Vals, -dQ * dvm_dvi)
+      end
+    end
+  end
+
   return sparse(Iidx, Jidx, Vals, m, nvar)
 end
 
@@ -470,10 +513,12 @@ defined in `mismatch_rectangular`.
 
 `bus_types` and `Vset` must be consistent with `mismatch_rectangular`.
 """
-function build_rectangular_jacobian_pq_pv_dense(Ybus, V::Vector{ComplexF64}, bus_types::Vector{Symbol}, Vset::Vector{Float64}, slack_idx::Int)
+function build_rectangular_jacobian_pq_pv_dense(Ybus, V::Vector{ComplexF64}, bus_types::Vector{Symbol}, Vset::Vector{Float64}, slack_idx::Int; dPinj_dVm::Vector{Float64} = zeros(Float64, length(V)), dQinj_dVm::Vector{Float64} = zeros(Float64, length(V)), vm_eps::Float64 = 1e-9)
   n = length(V)
   @assert length(bus_types) == n
   @assert length(Vset) == n
+  @assert length(dPinj_dVm) == n
+  @assert length(dQinj_dVm) == n
 
   # --- 1) Wirtinger blocks for S(V) = V .* conj(Ybus * V)
   J11, J12, J21, J22 = build_complex_jacobian(Ybus, V)
@@ -553,6 +598,24 @@ function build_rectangular_jacobian_pq_pv_dense(Ybus, V::Vector{ComplexF64}, bus
     row += 2
   end
 
+  for i in non_slack
+    rowP = 2 * pos_map[i] - 1
+    pos = pos_map[i]
+    vm = abs(V[i])
+    vm_safe = vm > vm_eps ? vm : vm_eps
+    dvm_dvr = real(V[i]) / vm_safe
+    dvm_dvi = imag(V[i]) / vm_safe
+
+    J[rowP, pos] -= dPinj_dVm[i] * dvm_dvr
+    J[rowP, (n-1)+pos] -= dPinj_dVm[i] * dvm_dvi
+
+    if bus_types[i] == :PQ
+      rowQ = rowP + 1
+      J[rowQ, pos] -= dQinj_dVm[i] * dvm_dvr
+      J[rowQ, (n-1)+pos] -= dQinj_dVm[i] * dvm_dvi
+    end
+  end
+
   return J
 end
 
@@ -573,11 +636,11 @@ Dispatches to either the dense or sparse rectangular Jacobian builder matching
   sparse builder is used.
 - Otherwise, the dense builder is used.
 """
-function build_rectangular_jacobian_pq_pv(Ybus, V::Vector{ComplexF64}, bus_types::Vector{Symbol}, Vset::Vector{Float64}, slack_idx::Int; use_sparse::Bool = false)
+function build_rectangular_jacobian_pq_pv(Ybus, V::Vector{ComplexF64}, bus_types::Vector{Symbol}, Vset::Vector{Float64}, slack_idx::Int; use_sparse::Bool = false, dPinj_dVm::Vector{Float64} = zeros(Float64, length(V)), dQinj_dVm::Vector{Float64} = zeros(Float64, length(V)), vm_eps::Float64 = 1e-9)
   if use_sparse && Ybus isa SparseMatrixCSC{ComplexF64}
-    return build_rectangular_jacobian_pq_pv_sparse(Ybus, V, bus_types, Vset, slack_idx)
+    return build_rectangular_jacobian_pq_pv_sparse(Ybus, V, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm, vm_eps = vm_eps)
   else
-    return build_rectangular_jacobian_pq_pv_dense(Ybus, V, bus_types, Vset, slack_idx)
+    return build_rectangular_jacobian_pq_pv_dense(Ybus, V, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm, vm_eps = vm_eps)
   end
 end
 
@@ -599,22 +662,24 @@ Jacobian that matches `mismatch_rectangular`.
 - State: x = [Vr(non-slack); Vi(non-slack)]
 - Residual: F(x) = mismatch_rectangular(...)
 """
-function complex_newton_step_rectangular(Ybus, V::Vector{ComplexF64}, S::Vector{ComplexF64}; slack_idx::Int, damp::Float64 = 1.0, bus_types::Vector{Symbol}, Vset::Vector{Float64}, use_sparse::Bool = false)
+function complex_newton_step_rectangular(Ybus, V::Vector{ComplexF64}, S::Vector{ComplexF64}; slack_idx::Int, damp::Float64 = 1.0, bus_types::Vector{Symbol}, Vset::Vector{Float64}, use_sparse::Bool = false, dPinj_dVm::Vector{Float64} = zeros(Float64, length(V)), dQinj_dVm::Vector{Float64} = zeros(Float64, length(V)))
   n = length(V)
   @assert length(S) == n
   @assert length(bus_types) == n
   @assert length(Vset) == n
+  @assert length(dPinj_dVm) == n
+  @assert length(dQinj_dVm) == n
 
   # Non-slack indices
   non_slack = non_slack_indices(n, slack_idx)
   # Residual matching the FD variant
-  F0 = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx)
+  F0 = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
   m = length(F0)
   nvar = 2 * (n - 1)
   @assert m == nvar "complex_newton_step_rectangular: mismatch and state dimension differ"
 
   # Analytic Jacobian (dense or sparse)
-  J = build_rectangular_jacobian_pq_pv(Ybus, V, bus_types, Vset, slack_idx; use_sparse = use_sparse)
+  J = build_rectangular_jacobian_pq_pv(Ybus, V, bus_types, Vset, slack_idx; use_sparse = use_sparse, dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
 
   # Solve J * δx = -F
   δx = solve_linear(J, -F0; allow_pinv = true)
@@ -711,8 +776,12 @@ function run_complex_nr_rectangular_for_net!(net::Net; maxiter::Int = 20, tol::F
   # 1) Initial complex voltages V0 and slack index
   V0, slack_idx = initialVrect(net; flatstart = opt_flatstart)
 
-  # 2) Specified complex power injections S (p.u.), sign convention wie im Polar-NR
+  # 2) Specified complex power injections S (p.u.). For Q(U)/P(U) controllers
+  # this vector becomes state-dependent and is re-evaluated per Newton iteration.
   S = buildComplexSVec(net)
+  dPinj_dVm = zeros(Float64, n)
+  dQinj_dVm = zeros(Float64, n)
+  has_vdep_control = has_voltage_dependent_control(net)
 
   # 3) Bus types and PV setpoints from Node data
   bus_types = Vector{Symbol}(undef, n)
@@ -779,8 +848,12 @@ function run_complex_nr_rectangular_for_net!(net::Net; maxiter::Int = 20, tol::F
   for it = 1:maxiter
     iters = it
 
-    # Mismatch with current bus_types & S
-    F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx)
+    if has_vdep_control
+      S, dPinj_dVm, dQinj_dVm = buildControlledSVec(net, V)
+    end
+
+    # Mismatch with current bus_types and (possibly) voltage-dependent S.
+    F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
     max_mis = maximum(abs.(F))
     push!(history, max_mis)
 
@@ -901,16 +974,16 @@ function run_complex_nr_rectangular_for_net!(net::Net; maxiter::Int = 20, tol::F
 
       # If bus_types/spec changed, mismatch definition changed (ΔQ ↔ ΔV) => rebuild F
       if changed || reenabled
-        F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx)
+        F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
         max_mis = maximum(abs.(F))
         history[end] = max_mis  # optional: overwrite last stored value for this iteration
       end
     end
     # --- Newton-Stepp (FD oder analytisch) -----------------------------
     if use_fd
-      V = complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx = slack_idx, damp = damp, h = 1e-6, bus_types = bus_types, Vset = Vset)
+      V = complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx = slack_idx, damp = damp, h = 1e-6, bus_types = bus_types, Vset = Vset, dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
     else
-      V = complex_newton_step_rectangular(Ybus, V, S; slack_idx = slack_idx, damp = damp, bus_types = bus_types, Vset = Vset, use_sparse = sparse)
+      V = complex_newton_step_rectangular(Ybus, V, S; slack_idx = slack_idx, damp = damp, bus_types = bus_types, Vset = Vset, use_sparse = sparse, dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
     end
 
     # Keep slack voltage fixed (safety belt)
@@ -1142,6 +1215,7 @@ where `status == 0` indicates convergence.
 function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; method::Symbol = :rectangular, opt_fd::Bool = false, opt_sparse::Bool = true, opt_flatstart::Bool = net.flatstart, damp = 1.0, pv_table_rows::Int = 30, validate_limits_after_pf::Bool = false, q_limit_violation_headroom::Float64 = 0.0, lock_pv_to_pq_buses::AbstractVector{Int} = Int[], qlimit_mode::Symbol = :switch_to_pq, qlimit_max_outer::Int = 30)
   wnet, reps, has_merges = _merged_pf_net(net)
   refreshBusTypesFromProsumers!(wnet)
+  has_vdep_control = has_voltage_dependent_control(wnet)
 
   function _sync_merged_results_to_original!()
     for i in eachindex(net.nodeVec)
@@ -1154,6 +1228,7 @@ function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int =
 
   #@info "Running AC Power Flow using method: $(method)"
   if method === :polar_full
+    has_vdep_control && error("runpf!: P(U)/Q(U) voltage-dependent controllers are currently supported only for method=:rectangular.")
     if qlimit_mode != :switch_to_pq
       @warn "runpf!: qlimit_mode=$(qlimit_mode) is only supported for method=:rectangular. Falling back to :switch_to_pq behavior."
     end
@@ -1167,6 +1242,7 @@ function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int =
     return iters, erg
   elseif method === :rectangular
     if has_merges
+      has_vdep_control && error("runpf!: P(U)/Q(U) voltage-dependent controllers are not supported with active-link merge fallback to :polar_full. Disable merges or use a topology without internal isolated buses.")
       if verbose > 0
         @warn "runpf!: rectangular solver does not support internal Isolated buses from active-link merges; falling back to :polar_full"
       end
@@ -1182,6 +1258,7 @@ function runpf!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int =
     end
     return iters, erg
   elseif method === :classic
+    has_vdep_control && error("runpf!: P(U)/Q(U) voltage-dependent controllers are currently supported only for method=:rectangular.")
     if qlimit_mode != :switch_to_pq
       @warn "runpf!: qlimit_mode=$(qlimit_mode) is only supported for method=:rectangular. Falling back to :switch_to_pq behavior."
     end

--- a/src/jacobian_fd.jl
+++ b/src/jacobian_fd.jl
@@ -62,11 +62,11 @@ Arguments:
 Returns:
 - Updated complex voltage vector `V_new` (length n)
 """
-function complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx::Int = 1, damp::Float64 = 1.0, h::Float64 = 1e-6, bus_types::Vector{Symbol}, Vset::Vector{Float64})
+function complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx::Int = 1, damp::Float64 = 1.0, h::Float64 = 1e-6, bus_types::Vector{Symbol}, Vset::Vector{Float64}, dPinj_dVm::Vector{Float64} = zeros(Float64, length(V)), dQinj_dVm::Vector{Float64} = zeros(Float64, length(V)))
   n = length(V)
 
   # Base mismatch F(V)
-  F0 = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx)
+  F0 = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
   m  = length(F0)  # expected = 2 * (n-1)
 
   # Non-slack buses
@@ -86,7 +86,7 @@ function complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx::Int = 1, damp
     V_pert = copy(V)
     V_pert[bus] = ComplexF64(Vr[bus] + h, Vi[bus])
 
-    Fp = mismatch_rectangular(Ybus, V_pert, S, bus_types, Vset, slack_idx)
+    Fp = mismatch_rectangular(Ybus, V_pert, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
     J[:, col_idx] .= (Fp .- F0) ./ h
   end
 
@@ -96,7 +96,7 @@ function complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx::Int = 1, damp
     V_pert = copy(V)
     V_pert[bus] = ComplexF64(Vr[bus], Vi[bus] + h)
 
-    Fp = mismatch_rectangular(Ybus, V_pert, S, bus_types, Vset, slack_idx)
+    Fp = mismatch_rectangular(Ybus, V_pert, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
     J[:, col_idx] .= (Fp .- F0) ./ h
   end
 

--- a/src/jacobian_full.jl
+++ b/src/jacobian_full.jl
@@ -414,8 +414,8 @@ end
 # ------------------------------
 const _warned_full_solver_deprecated = Ref(false)
 
-function runpf_full!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; opt_sparse::Bool = false, opt_flatstart::Bool = net.flatstart, pv_table_rows::Int = 30, lock_pv_to_pq_buses::AbstractVector{Int} = Int[])
-  if !_warned_full_solver_deprecated[]
+function runpf_full!(net::Net, maxIte::Int, tolerance::Float64 = 1e-6, verbose::Int = 0; opt_sparse::Bool = false, opt_flatstart::Bool = net.flatstart, pv_table_rows::Int = 30, lock_pv_to_pq_buses::AbstractVector{Int} = Int[], warn_deprecated::Bool = true)
+  if warn_deprecated && !_warned_full_solver_deprecated[]
     @warn "runpf_full! / method=:polar_full is deprecated and will be removed in a future release. Please use method=:rectangular (complex Jacobian)."
     _warned_full_solver_deprecated[] = true
   end

--- a/src/network.jl
+++ b/src/network.jl
@@ -979,6 +979,8 @@ function addProsumer!(;
   vstep_pu::Union{Nothing,Float64} = nothing,
   tap_steps_down::Union{Nothing,Int} = nothing,
   tap_steps_up::Union{Nothing,Int} = nothing,
+  qu_controller::Union{Nothing,QUController} = nothing,
+  pu_controller::Union{Nothing,PUController} = nothing,
   isRegulated::Bool = false,
 )
   busIdx = geNetBusIdx(net = net, busName = busName)
@@ -1000,7 +1002,7 @@ function addProsumer!(;
   has_vm_setpoint = !isnothing(vm_pu)
   has_vstep_with_taps = !isnothing(vstep_pu) && (!isnothing(tap_steps_down) || !isnothing(tap_steps_up))
   auto_regulated = isRegulated || has_vm_setpoint || has_vstep_with_taps
-  ps = ProSumer(vn_kv = vn_kV, busIdx = busIdx, oID = idProsSum, type = proTy, p = p, q = q, minP = pMin, maxP = pMax, minQ = qMin, maxQ = qMax, referencePri = refPriIdx, vm_pu = vm_pu, va_deg = va_deg, vstep_pu = vstep_pu, tap_steps_down = tap_steps_down, tap_steps_up = tap_steps_up, isRegulated = auto_regulated, isAPUNode = isAPUNode)
+  ps = ProSumer(vn_kv = vn_kV, busIdx = busIdx, oID = idProsSum, type = proTy, p = p, q = q, minP = pMin, maxP = pMax, minQ = qMin, maxQ = qMax, referencePri = refPriIdx, vm_pu = vm_pu, va_deg = va_deg, vstep_pu = vstep_pu, tap_steps_down = tap_steps_down, tap_steps_up = tap_steps_up, isRegulated = auto_regulated, isAPUNode = isAPUNode, quController = qu_controller, puController = pu_controller)
   push!(net.prosumpsVec, ps)
   node = net.nodeVec[busIdx]
   if (isGenerator(proTy))
@@ -1810,6 +1812,67 @@ function buildComplexSVec(net::Net)
   end
 
   return S
+end
+
+function has_voltage_dependent_control(net::Net)::Bool
+  for ps in net.prosumpsVec
+    if has_qu_controller(ps) || has_pu_controller(ps)
+      return true
+    end
+  end
+  return false
+end
+
+@inline _safe_vm(vm::Float64; eps::Float64 = 1e-9) = vm > eps ? vm : eps
+
+"""
+    buildControlledSVec(net, V) -> (Sspec, dPinj_dVm, dQinj_dVm)
+
+Evaluate bus injections for the current voltage state. If a prosumer carries a
+`PUController` and/or `QUController`, the corresponding active/reactive setpoint
+is evaluated as a function of local bus voltage magnitude. The derivative
+vectors contain `dP_spec/d|V|` and `dQ_spec/d|V|` (both in p.u. per p.u.).
+"""
+function buildControlledSVec(net::Net, V::Vector{ComplexF64})
+  n = length(net.nodeVec)
+  length(V) == n || error("buildControlledSVec: voltage vector length mismatch.")
+
+  Sspec = zeros(ComplexF64, n)
+  dPinj_dVm = zeros(Float64, n)
+  dQinj_dVm = zeros(Float64, n)
+  base = net.baseMVA
+
+  for ps in net.prosumpsVec
+    bus = getPosumerBusIndex(ps)
+    (1 <= bus <= n) || continue
+
+    vm = abs(V[bus])
+    vm_safe = _safe_vm(vm)
+
+    p_mw = isnothing(ps.pVal) ? 0.0 : ps.pVal
+    q_mvar = isnothing(ps.qVal) ? 0.0 : ps.qVal
+    dp_dvm_mw = 0.0
+    dq_dvm_mvar = 0.0
+
+    if has_pu_controller(ps)
+      p_pu, dp_dvm_pu = evaluate_controller(ps.puController, vm_safe)
+      p_mw = p_pu * base
+      dp_dvm_mw = dp_dvm_pu * base
+    end
+
+    if has_qu_controller(ps)
+      q_pu, dq_dvm_pu = evaluate_controller(ps.quController, vm_safe)
+      q_mvar = q_pu * base
+      dq_dvm_mvar = dq_dvm_pu * base
+    end
+
+    sign = isGenerator(ps) ? 1.0 : -1.0
+    Sspec[bus] += ComplexF64(sign * p_mw / base, sign * q_mvar / base)
+    dPinj_dVm[bus] += sign * dp_dvm_mw / base
+    dQinj_dVm[bus] += sign * dq_dvm_mvar / base
+  end
+
+  return Sspec, dPinj_dVm, dQinj_dVm
 end
 
 """

--- a/src/prosumer.jl
+++ b/src/prosumer.jl
@@ -51,6 +51,49 @@ struct PUController <: AbstractVoltageDependentController
   pmax_pu::Union{Nothing,Float64}
 end
 
+@inline _to_pu_power(value::Float64, sbase_MVA::Float64) = value / sbase_MVA
+@inline _to_pu_voltage(value::Float64, vn_kV::Float64) = value / vn_kV
+
+function _convert_power_limit_to_pu(name::String, value::Union{Nothing,Float64}, unit::Symbol, sbase_MVA::Union{Nothing,Float64})
+  isnothing(value) && return nothing
+  if unit === :pu
+    return value
+  elseif (unit === :MW) || (unit === :MVAr)
+    isnothing(sbase_MVA) && error("$(name): sbase_MVA is required when using $(unit) limits.")
+    return _to_pu_power(value, sbase_MVA)
+  else
+    error("$(name): unsupported unit $(unit). Use :pu, :MW, or :MVAr.")
+  end
+end
+
+"""
+    QUController(characteristic; qmin_pu=nothing, qmax_pu=nothing,
+                 qmin_MVAr=nothing, qmax_MVAr=nothing, sbase_MVA=nothing)
+
+Convenience constructor for `QUController` that accepts limits either in p.u. or in MVAr.
+"""
+function QUController(characteristic::PiecewiseLinearCharacteristic; qmin_pu::Union{Nothing,Float64} = nothing, qmax_pu::Union{Nothing,Float64} = nothing, qmin_MVAr::Union{Nothing,Float64} = nothing, qmax_MVAr::Union{Nothing,Float64} = nothing, sbase_MVA::Union{Nothing,Float64} = nothing)
+  (!isnothing(qmin_pu) && !isnothing(qmin_MVAr)) && error("QUController: specify either qmin_pu or qmin_MVAr, not both.")
+  (!isnothing(qmax_pu) && !isnothing(qmax_MVAr)) && error("QUController: specify either qmax_pu or qmax_MVAr, not both.")
+  qmin = isnothing(qmin_MVAr) ? qmin_pu : _convert_power_limit_to_pu("QUController", qmin_MVAr, :MVAr, sbase_MVA)
+  qmax = isnothing(qmax_MVAr) ? qmax_pu : _convert_power_limit_to_pu("QUController", qmax_MVAr, :MVAr, sbase_MVA)
+  return QUController(characteristic, qmin, qmax)
+end
+
+"""
+    PUController(characteristic; pmin_pu=nothing, pmax_pu=nothing,
+                 pmin_MW=nothing, pmax_MW=nothing, sbase_MVA=nothing)
+
+Convenience constructor for `PUController` that accepts limits either in p.u. or in MW.
+"""
+function PUController(characteristic::PiecewiseLinearCharacteristic; pmin_pu::Union{Nothing,Float64} = nothing, pmax_pu::Union{Nothing,Float64} = nothing, pmin_MW::Union{Nothing,Float64} = nothing, pmax_MW::Union{Nothing,Float64} = nothing, sbase_MVA::Union{Nothing,Float64} = nothing)
+  (!isnothing(pmin_pu) && !isnothing(pmin_MW)) && error("PUController: specify either pmin_pu or pmin_MW, not both.")
+  (!isnothing(pmax_pu) && !isnothing(pmax_MW)) && error("PUController: specify either pmax_pu or pmax_MW, not both.")
+  pmin = isnothing(pmin_MW) ? pmin_pu : _convert_power_limit_to_pu("PUController", pmin_MW, :MW, sbase_MVA)
+  pmax = isnothing(pmax_MW) ? pmax_pu : _convert_power_limit_to_pu("PUController", pmax_MW, :MW, sbase_MVA)
+  return PUController(characteristic, pmin, pmax)
+end
+
 @inline function _apply_limits(value_pu::Float64, slope_pu::Float64, min_pu::Union{Nothing,Float64}, max_pu::Union{Nothing,Float64})
   if !isnothing(min_pu) && value_pu < min_pu
     return min_pu, 0.0
@@ -101,11 +144,39 @@ function evaluate_controller(ctrl::PUController, u_pu::Float64)
 end
 
 """
-    make_characteristic(points)
+    make_characteristic(points; voltage_unit=:pu, value_unit=:pu, vn_kV=nothing, sbase_MVA=nothing)
 
-Convenience constructor for `PiecewiseLinearCharacteristic`.
+Create a piecewise linear characteristic from points in p.u. or physical units.
+
+- `voltage_unit = :pu` expects voltage in per-unit.
+- `voltage_unit = :kV` expects voltage in kV and requires `vn_kV`.
+- `value_unit = :pu` expects power output in per-unit.
+- `value_unit = :MW` or `:MVAr` expects physical power values and requires `sbase_MVA`.
 """
-make_characteristic(points::Vector{Tuple{Float64,Float64}}) = PiecewiseLinearCharacteristic(points)
+function make_characteristic(points::Vector{Tuple{Float64,Float64}}; voltage_unit::Symbol = :pu, value_unit::Symbol = :pu, vn_kV::Union{Nothing,Float64} = nothing, sbase_MVA::Union{Nothing,Float64} = nothing)
+  converted = Tuple{Float64,Float64}[]
+  for (u, y) in points
+    u_pu = if voltage_unit === :pu
+      u
+    elseif voltage_unit === :kV
+      isnothing(vn_kV) && error("make_characteristic: vn_kV is required when voltage_unit=:kV.")
+      _to_pu_voltage(u, vn_kV)
+    else
+      error("make_characteristic: unsupported voltage_unit $(voltage_unit). Use :pu or :kV.")
+    end
+
+    y_pu = if value_unit === :pu
+      y
+    elseif (value_unit === :MW) || (value_unit === :MVAr)
+      isnothing(sbase_MVA) && error("make_characteristic: sbase_MVA is required when value_unit=$(value_unit).")
+      _to_pu_power(y, sbase_MVA)
+    else
+      error("make_characteristic: unsupported value_unit $(value_unit). Use :pu, :MW, or :MVAr.")
+    end
+    push!(converted, (u_pu, y_pu))
+  end
+  return PiecewiseLinearCharacteristic(converted)
+end
 
 # Data type to describe producers and consumers
 """

--- a/src/prosumer.jl
+++ b/src/prosumer.jl
@@ -16,6 +16,97 @@
 # Date: 10.05.2023
 # file: src/prosumer.jl
 
+abstract type AbstractVoltageDependentController end
+
+"""
+    PiecewiseLinearCharacteristic(points)
+
+Piecewise linear characteristic `y = f(u)` represented by ordered `(u, y)` points.
+Outside the point range, values are clamped to the edge points and the derivative is `0.0`.
+"""
+struct PiecewiseLinearCharacteristic
+  points::Vector{Tuple{Float64,Float64}}
+
+  function PiecewiseLinearCharacteristic(points::Vector{Tuple{Float64,Float64}})
+    length(points) >= 2 || error("PiecewiseLinearCharacteristic requires at least 2 points.")
+    u_prev = points[1][1]
+    for i in 2:length(points)
+      u = points[i][1]
+      u > u_prev || error("PiecewiseLinearCharacteristic points must have strictly increasing voltage values.")
+      u_prev = u
+    end
+    new(points)
+  end
+end
+
+struct QUController <: AbstractVoltageDependentController
+  characteristic::PiecewiseLinearCharacteristic
+  qmin_pu::Union{Nothing,Float64}
+  qmax_pu::Union{Nothing,Float64}
+end
+
+struct PUController <: AbstractVoltageDependentController
+  characteristic::PiecewiseLinearCharacteristic
+  pmin_pu::Union{Nothing,Float64}
+  pmax_pu::Union{Nothing,Float64}
+end
+
+@inline function _apply_limits(value_pu::Float64, slope_pu::Float64, min_pu::Union{Nothing,Float64}, max_pu::Union{Nothing,Float64})
+  if !isnothing(min_pu) && value_pu < min_pu
+    return min_pu, 0.0
+  end
+  if !isnothing(max_pu) && value_pu > max_pu
+    return max_pu, 0.0
+  end
+  return value_pu, slope_pu
+end
+
+"""
+    evaluate_characteristic(ch, u_pu) -> (value, slope)
+
+Evaluate piecewise linear characteristic at `u_pu`.
+"""
+function evaluate_characteristic(ch::PiecewiseLinearCharacteristic, u_pu::Float64)
+  pts = ch.points
+  u1 = pts[1][1]
+  uN = pts[end][1]
+
+  if u_pu <= u1
+    return pts[1][2], 0.0
+  elseif u_pu >= uN
+    return pts[end][2], 0.0
+  end
+
+  for i in 1:(length(pts)-1)
+    uk, yk = pts[i]
+    uk1, yk1 = pts[i+1]
+    if uk <= u_pu <= uk1
+      slope = (yk1 - yk) / (uk1 - uk)
+      value = yk + slope * (u_pu - uk)
+      return value, slope
+    end
+  end
+
+  return pts[end][2], 0.0
+end
+
+function evaluate_controller(ctrl::QUController, u_pu::Float64)
+  value, slope = evaluate_characteristic(ctrl.characteristic, u_pu)
+  return _apply_limits(value, slope, ctrl.qmin_pu, ctrl.qmax_pu)
+end
+
+function evaluate_controller(ctrl::PUController, u_pu::Float64)
+  value, slope = evaluate_characteristic(ctrl.characteristic, u_pu)
+  return _apply_limits(value, slope, ctrl.pmin_pu, ctrl.pmax_pu)
+end
+
+"""
+    make_characteristic(points)
+
+Convenience constructor for `PiecewiseLinearCharacteristic`.
+"""
+make_characteristic(points::Vector{Tuple{Float64,Float64}}) = PiecewiseLinearCharacteristic(points)
+
 # Data type to describe producers and consumers
 """
     ProSumer
@@ -63,6 +154,8 @@ mutable struct ProSumer
   isRegulated::Bool
   proSumptionType::ProSumptionType
   isAPUNode::Bool
+  quController::Union{Nothing,QUController}
+  puController::Union{Nothing,PUController}
   qGenRepl::Union{Nothing,Float64}
   pRes::Union{Nothing,Float64}
   qRes::Union{Nothing,Float64}
@@ -90,6 +183,8 @@ mutable struct ProSumer
     tap_steps_up::Union{Nothing,Int} = nothing,
     isRegulated::Bool = false,
     isAPUNode::Bool = false,
+    quController::Union{Nothing,QUController} = nothing,
+    puController::Union{Nothing,PUController} = nothing,
   )
     comp = getProSumPGMComp(vn_kv, busIdx, isGenerator(type), oID)
 
@@ -101,7 +196,7 @@ mutable struct ProSumer
       va_deg = 0.0
     end
 
-    new(comp, ratedS, ratedU, qPercent, p, q, maxP, minP, maxQ, minQ, ratedPowerFactor, referencePri, vm_pu, va_deg, vstep_pu, tap_steps_down, tap_steps_up, isRegulated, type, isAPUNode, nothing, nothing, nothing)
+    new(comp, ratedS, ratedU, qPercent, p, q, maxP, minP, maxQ, minQ, ratedPowerFactor, referencePri, vm_pu, va_deg, vstep_pu, tap_steps_down, tap_steps_up, isRegulated, type, isAPUNode, quController, puController, nothing, nothing, nothing)
   end
 
   function Base.show(io::IO, prosumption::ProSumer)
@@ -171,6 +266,12 @@ mutable struct ProSumer
     if prosumption.isRegulated
       print(io, "isRegulated: true, ")
     end
+    if !isnothing(prosumption.quController)
+      print(io, "quController: yes, ")
+    end
+    if !isnothing(prosumption.puController)
+      print(io, "puController: yes, ")
+    end
 
     if (!isnothing(prosumption.qGenRepl))
       print(io, "qGenRepl: ", prosumption.qGenRepl, ", ")
@@ -217,6 +318,9 @@ end # isGenerator
 function isGenerator(o::ProSumer)::Bool
   return isGenerator(o.proSumptionType)
 end # isGenerator
+
+@inline has_qu_controller(ps::ProSumer)::Bool = !isnothing(ps.quController)
+@inline has_pu_controller(ps::ProSumer)::Bool = !isnothing(ps.puController)
 
 function getProSumPGMComp(Vn::Float64, from::Int, isGen::Bool, id::Int)
   cTyp = isGen ? toComponentTyp("GENERATOR") : toComponentTyp("LOAD")

--- a/src/results.jl
+++ b/src/results.jl
@@ -67,6 +67,30 @@ function _effective_pf_node_count(net::Net)::Int
   return length(unique(reps))
 end
 
+function _bus_control_flags(net::Net, bus_idx::Int)
+  has_qu = false
+  has_pu = false
+  for ps in net.prosumpsVec
+    getPosumerBusIndex(ps) == bus_idx || continue
+    has_qu |= has_qu_controller(ps)
+    has_pu |= has_pu_controller(ps)
+  end
+  return has_qu, has_pu
+end
+
+function _control_label(net::Net, bus_idx::Int)::String
+  has_qu, has_pu = _bus_control_flags(net, bus_idx)
+  if has_qu && has_pu
+    return "Q(U), P(U)"
+  elseif has_qu
+    return "Q(U)"
+  elseif has_pu
+    return "P(U)"
+  else
+    return "-"
+  end
+end
+
 function _branch_kind_label(br::Branch)::String
   name = br.comp.cName
   if occursin("_ACL_", name)
@@ -114,6 +138,7 @@ function buildACPFlowReport(net::Net;
       q_shunt_MVar = _default0(n._qShunt),
       is_isolated = isIsolated(n),
       q_limit_hit = haskey(net.qLimitEvents, n.busIdx),
+      control = _control_label(net, n.busIdx),
     ))
   end
 
@@ -322,9 +347,9 @@ function printACPFlowResults(net::Net, ct::Float64, ite::Int, tol::Float64, toFi
 
   println(io, "\n", totalLosses)
 
-  @printf(io, "===============================================================================================================================================================================\n")
-  @printf(io, "| %-5s | %-20s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s |\n", "Nr", "Bus", "Vn [kV]", "V [kV]", "V [pu]", "phi [deg]", "Pg [MW]", "Qg [MVar]", "Pl [MW]", "Ql [MVar]", "Ps [MW]", "Qs [MVar]", "Type")
-  @printf(io, "===============================================================================================================================================================================\n")
+  @printf(io, "====================================================================================================================================================================================================\n")
+  @printf(io, "| %-5s | %-20s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-12s |\n", "Nr", "Bus", "Vn [kV]", "V [kV]", "V [pu]", "phi [deg]", "Pg [MW]", "Qg [MVar]", "Pl [MW]", "Ql [MVar]", "Ps [MW]", "Qs [MVar]", "Type", "Control")
+  @printf(io, "====================================================================================================================================================================================================\n")
 
   pGS = qGS = pLS = qLS = ""
   tpGS = tqGS = tpLS = tqLS = 0.0
@@ -370,6 +395,7 @@ function printACPFlowResults(net::Net, ct::Float64, ite::Int, tol::Float64, toFi
       qShunt_str = ""
     end
     typeStr = toString(n._nodeType)
+    controlStr = _control_label(net, n.busIdx)
 
     # Mark PV→PQ buses (hit Q-limit) with a star in the Type column
     if haskey(net.qLimitEvents, n.busIdx)
@@ -384,10 +410,10 @@ function printACPFlowResults(net::Net, ct::Float64, ite::Int, tol::Float64, toFi
       end
     end
 
-    @printf(io, "| %-5d | %-20s | %-10.1f | %-10.3f | %-10.3f | %-10.3f | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s |\n", n.busIdx, nodeName, n.comp.cVN, v, n._vm_pu, n._va_deg, pGS, qGS, pLS, qLS, pShunt_str, qShunt_str, typeStr)
+    @printf(io, "| %-5d | %-20s | %-10.1f | %-10.3f | %-10.3f | %-10.3f | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-10s | %-12s |\n", n.busIdx, nodeName, n.comp.cVN, v, n._vm_pu, n._va_deg, pGS, qGS, pLS, qLS, pShunt_str, qShunt_str, typeStr, controlStr)
   end
 
-  @printf(io, "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n")
+  @printf(io, "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n")
   println(io, flowResults)
 
 

--- a/src/results.jl
+++ b/src/results.jl
@@ -85,8 +85,9 @@ end
 
 function _effective_bus_power_components(net::Net, bus_idx::Int)
   base = net.baseMVA
+  node = net.nodeVec[bus_idx]
 
-  vm = net.nodeVec[bus_idx]._vm_pu
+  vm = node._vm_pu
   vm_safe = vm > 1e-9 ? vm : 1e-9
 
   p_gen = 0.0

--- a/src/results.jl
+++ b/src/results.jl
@@ -91,6 +91,43 @@ function _control_label(net::Net, bus_idx::Int)::String
   end
 end
 
+function _effective_bus_power_components(net::Net, bus_idx::Int)
+  base = net.baseMVA
+  vm = net.nodeVec[bus_idx]._vm_pu
+  vm_safe = vm > 1e-9 ? vm : 1e-9
+
+  p_gen = 0.0
+  q_gen = 0.0
+  p_load = 0.0
+  q_load = 0.0
+
+  for ps in net.prosumpsVec
+    getPosumerBusIndex(ps) == bus_idx || continue
+
+    p_mw = isnothing(ps.pVal) ? 0.0 : ps.pVal
+    q_mvar = isnothing(ps.qVal) ? 0.0 : ps.qVal
+
+    if has_pu_controller(ps)
+      p_pu, _ = evaluate_controller(ps.puController, vm_safe)
+      p_mw = p_pu * base
+    end
+    if has_qu_controller(ps)
+      q_pu, _ = evaluate_controller(ps.quController, vm_safe)
+      q_mvar = q_pu * base
+    end
+
+    if isGenerator(ps)
+      p_gen += p_mw
+      q_gen += q_mvar
+    else
+      p_load += p_mw
+      q_load += q_mvar
+    end
+  end
+
+  return p_gen, q_gen, p_load, q_load
+end
+
 function _branch_kind_label(br::Branch)::String
   name = br.comp.cName
   if occursin("_ACL_", name)
@@ -122,6 +159,7 @@ function buildACPFlowReport(net::Net;
 
   node_rows = NamedTuple[]
   for n in nodes_sorted
+    p_gen, q_gen, p_load, q_load = _effective_bus_power_components(net, n.busIdx)
     push!(node_rows, (
       bus = n.busIdx,
       bus_name = get(busNameByIdx, n.busIdx, n.comp.cName),
@@ -130,10 +168,10 @@ function buildACPFlowReport(net::Net;
       va_deg = n._va_deg,
       vn_kV = n.comp.cVN,
       v_kV = n.comp.cVN * n._vm_pu,
-      p_gen_MW = _default0(n._pƩGen),
-      q_gen_MVar = _default0(n._qƩGen),
-      p_load_MW = _default0(n._pƩLoad),
-      q_load_MVar = _default0(n._qƩLoad),
+      p_gen_MW = p_gen,
+      q_gen_MVar = q_gen,
+      p_load_MW = p_load,
+      q_load_MVar = q_load,
       p_shunt_MW = _default0(n._pShunt),
       q_shunt_MVar = _default0(n._qShunt),
       is_isolated = isIsolated(n),
@@ -356,29 +394,29 @@ function printACPFlowResults(net::Net, ct::Float64, ite::Int, tol::Float64, toFi
   pShunt_str = qShunt_str = ""
   tpShunt = tqShunt = 0.0
   for n in nodes
-    if !isnothing(n._pƩGen)
-      abs(n._pƩGen) > 1e-6
-      pGS = @sprintf("%10.3f", n._pƩGen)
-      tpGS += n._pƩGen
+    p_gen, q_gen, p_load, q_load = _effective_bus_power_components(net, n.busIdx)
+    if abs(p_gen) > 1e-6
+      pGS = @sprintf("%10.3f", p_gen)
+      tpGS += p_gen
     else
       pGS = ""
     end
-    if !isnothing(n._qƩGen) && abs(n._qƩGen) > 1e-6
-      qGS = @sprintf("%10.3f", n._qƩGen)
-      tqGS += n._qƩGen
+    if abs(q_gen) > 1e-6
+      qGS = @sprintf("%10.3f", q_gen)
+      tqGS += q_gen
     else
       qGS = ""
     end
 
-    if !isnothing(n._pƩLoad) && abs(n._pƩLoad) > 1e-6
-      pLS = @sprintf("%10.3f", n._pƩLoad)
-      tpLS += n._pƩLoad
+    if abs(p_load) > 1e-6
+      pLS = @sprintf("%10.3f", p_load)
+      tpLS += p_load
     else
       pLS = ""
     end
-    if !isnothing(n._qƩLoad) && abs(n._qƩLoad) > 1e-6
-      qLS = @sprintf("%10.3f", n._qƩLoad)
-      tqLS += n._qƩLoad
+    if abs(q_load) > 1e-6
+      qLS = @sprintf("%10.3f", q_load)
+      tqLS += q_load
     else
       qLS = ""
     end

--- a/src/results.jl
+++ b/src/results.jl
@@ -41,15 +41,7 @@ struct ACPFlowReport
 end
 
 function Base.show(io::IO, report::ACPFlowReport)
-  print(io,
-    "ACPFlowReport(",
-    "case=", report.metadata.case,
-    ", converged=", report.metadata.converged,
-    ", nodes=", length(report.nodes),
-    ", branches=", length(report.branches),
-    ", links=", length(report.links),
-    ", q_limit_events=", length(report.q_limit_events),
-    ")")
+  print(io, "ACPFlowReport(", "case=", report.metadata.case, ", converged=", report.metadata.converged, ", nodes=", length(report.nodes), ", branches=", length(report.branches), ", links=", length(report.links), ", q_limit_events=", length(report.q_limit_events), ")")
 end
 
 _default0(x) = isnothing(x) ? 0.0 : x
@@ -93,6 +85,7 @@ end
 
 function _effective_bus_power_components(net::Net, bus_idx::Int)
   base = net.baseMVA
+
   vm = net.nodeVec[bus_idx]._vm_pu
   vm_safe = vm > 1e-9 ? vm : 1e-9
 
@@ -125,6 +118,22 @@ function _effective_bus_power_components(net::Net, bus_idx::Int)
     end
   end
 
+  if node._nodeType == Sparlectra.Slack
+    if !isnothing(node._pƩGen)
+      p_gen = node._pƩGen
+    end
+    if !isnothing(node._qƩGen)
+      q_gen = node._qƩGen
+    end
+  elseif node._nodeType == Sparlectra.PV
+    if abs(q_gen) <= 1e-9 && !isnothing(node._qƩGen)
+      q_gen = node._qƩGen
+    end
+    if abs(p_gen) <= 1e-9 && !isnothing(node._pƩGen)
+      p_gen = node._pƩGen
+    end
+  end
+
   return p_gen, q_gen, p_load, q_load
 end
 
@@ -147,37 +156,34 @@ end
 Builds a structured report object from solved network data.
 This provides a machine-readable alternative to `printACPFlowResults`.
 """
-function buildACPFlowReport(net::Net;
-  ct::Float64 = 0.0,
-  ite::Int = 0,
-  tol::Float64 = 1e-6,
-  converged::Bool = true,
-  solver::Symbol = :NR,
-)::ACPFlowReport
+function buildACPFlowReport(net::Net; ct::Float64 = 0.0, ite::Int = 0, tol::Float64 = 1e-6, converged::Bool = true, solver::Symbol = :NR)::ACPFlowReport
   busNameByIdx = _bus_name_by_idx(net)
   nodes_sorted = sort(net.nodeVec, by = x -> x.busIdx)
 
   node_rows = NamedTuple[]
   for n in nodes_sorted
     p_gen, q_gen, p_load, q_load = _effective_bus_power_components(net, n.busIdx)
-    push!(node_rows, (
-      bus = n.busIdx,
-      bus_name = get(busNameByIdx, n.busIdx, n.comp.cName),
-      type = toString(n._nodeType),
-      vm_pu = n._vm_pu,
-      va_deg = n._va_deg,
-      vn_kV = n.comp.cVN,
-      v_kV = n.comp.cVN * n._vm_pu,
-      p_gen_MW = p_gen,
-      q_gen_MVar = q_gen,
-      p_load_MW = p_load,
-      q_load_MVar = q_load,
-      p_shunt_MW = _default0(n._pShunt),
-      q_shunt_MVar = _default0(n._qShunt),
-      is_isolated = isIsolated(n),
-      q_limit_hit = haskey(net.qLimitEvents, n.busIdx),
-      control = _control_label(net, n.busIdx),
-    ))
+    push!(
+      node_rows,
+      (
+        bus = n.busIdx,
+        bus_name = get(busNameByIdx, n.busIdx, n.comp.cName),
+        type = toString(n._nodeType),
+        vm_pu = n._vm_pu,
+        va_deg = n._va_deg,
+        vn_kV = n.comp.cVN,
+        v_kV = n.comp.cVN * n._vm_pu,
+        p_gen_MW = p_gen,
+        q_gen_MVar = q_gen,
+        p_load_MW = p_load,
+        q_load_MVar = q_load,
+        p_shunt_MW = _default0(n._pShunt),
+        q_shunt_MVar = _default0(n._qShunt),
+        is_isolated = isIsolated(n),
+        q_limit_hit = haskey(net.qLimitEvents, n.busIdx),
+        control = _control_label(net, n.busIdx),
+      ),
+    )
   end
 
   branch_rows = NamedTuple[]
@@ -193,36 +199,12 @@ function buildACPFlowReport(net::Net;
     rated = isnothing(br.sn_MVA) ? 0.0 : br.sn_MVA
     overload = rated > 0.0 && max(abs(p_from), abs(p_to)) > rated
 
-    push!(branch_rows, (
-      branch = br.comp.cName,
-      branch_index = br.branchIdx,
-      from_bus = br.fromBus,
-      to_bus = br.toBus,
-      status = br.status,
-      p_from_MW = p_from,
-      q_from_MVar = q_from,
-      p_to_MW = p_to,
-      q_to_MVar = q_to,
-      p_loss_MW = p_loss,
-      q_loss_MVar = q_loss,
-      rated_MVA = rated,
-      overloaded = overload,
-    ))
+    push!(branch_rows, (branch = br.comp.cName, branch_index = br.branchIdx, from_bus = br.fromBus, to_bus = br.toBus, status = br.status, p_from_MW = p_from, q_from_MVar = q_from, p_to_MW = p_to, q_to_MVar = q_to, p_loss_MW = p_loss, q_loss_MVar = q_loss, rated_MVA = rated, overloaded = overload))
   end
 
   link_rows = NamedTuple[]
   for l in net.linkVec
-    push!(link_rows, (
-      link = l.cName,
-      link_index = l.linkIdx,
-      from_bus = l.fromBus,
-      to_bus = l.toBus,
-      status = l.status,
-      p_MW = _default0(l.pFlow_MW),
-      q_MVar = _default0(l.qFlow_MVar),
-      ifrom_kA = _default0(l.iFrom_kA),
-      ito_kA = _default0(l.iTo_kA),
-    ))
+    push!(link_rows, (link = l.cName, link_index = l.linkIdx, from_bus = l.fromBus, to_bus = l.toBus, status = l.status, p_MW = _default0(l.pFlow_MW), q_MVar = _default0(l.qFlow_MVar), ifrom_kA = _default0(l.iFrom_kA), ito_kA = _default0(l.iTo_kA)))
   end
 
   q_events = NamedTuple[]
@@ -231,18 +213,7 @@ function buildACPFlowReport(net::Net;
   end
 
   p_loss_total, q_loss_total = getTotalLosses(net = net)
-  metadata = (
-    case = net.name,
-    baseMVA = net.baseMVA,
-    converged = converged,
-    elapsed_s = ct,
-    iterations = ite,
-    tolerance = tol,
-    solver = solver,
-    timestamp = Dates.now(),
-    total_p_loss_MW = p_loss_total,
-    total_q_loss_MVar = q_loss_total,
-  )
+  metadata = (case = net.name, baseMVA = net.baseMVA, converged = converged, elapsed_s = ct, iterations = ite, tolerance = tol, solver = solver, timestamp = Dates.now(), total_p_loss_MW = p_loss_total, total_q_loss_MVar = q_loss_total)
 
   return ACPFlowReport(metadata, node_rows, branch_rows, link_rows, q_events)
 end
@@ -357,10 +328,10 @@ function printACPFlowResults(net::Net, ct::Float64, ite::Int, tol::Float64, toFi
   else
     @printf(io, "Status         :%10s\n", "Not Converged")
   end
-  @printf(io, "Case           :%15s\n", net.name)  
+  @printf(io, "Case           :%15s\n", net.name)
   @printf(io, "Cooldown iters :%10d\n", net.cooldown_iters)
   @printf(io, "Q-hysteresis   :%10.4f pu\n", net.q_hyst_pu)
-  
+
   @printf(io, "BaseMVA        :%10d\n", net.baseMVA)
   if auxb > 0 && niso > 0
     @printf(io, "Nodes          :%10d (PV: %d PQ: %d (Aux: %d) Iso: %d Slack: %d\n", busses, npv, npq, auxb, niso, 1)
@@ -453,7 +424,6 @@ function printACPFlowResults(net::Net, ct::Float64, ite::Int, tol::Float64, toFi
 
   @printf(io, "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\n")
   println(io, flowResults)
-
 
   if !isempty(net.linkVec)
     @printf(io, "\n----------------------------------- Link Flows (KCL) -----------------------------------\n")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ using Printf
 using LinearAlgebra
 
 # keep logs quiet unless there's a warning or error
-global_logger(ConsoleLogger(stderr, Logging.Info))
+global_logger(ConsoleLogger(stderr, Logging.Warn))
 
 # Suppress one-time deprecation warnings in test output. Deprecated solver
 # behavior is covered by dedicated tests and does not need to spam full-suite logs.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,10 +27,12 @@ include("testgrid.jl")
 include("testremove.jl")
 include("test_solver_interface.jl")
 include("test_state_estimation.jl")
+include("test_voltage_dependent_control.jl")
 
 @testset "Sparlectra.jl" begin
   run_grid_tests()
   run_remove_tests()
   run_solver_interface_tests()
   run_state_estimation_tests()
+  run_voltage_dependent_control_tests()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,11 @@ using LinearAlgebra
 # keep logs quiet unless there's a warning or error
 global_logger(ConsoleLogger(stderr, Logging.Info))
 
+# Suppress one-time deprecation warnings in test output. Deprecated solver
+# behavior is covered by dedicated tests and does not need to spam full-suite logs.
+Sparlectra._warned_full_solver_deprecated[] = true
+Sparlectra._warned_classic_solver_deprecated[] = true
+
 include("testgrid.jl")
 include("testremove.jl")
 include("test_solver_interface.jl")

--- a/test/test_voltage_dependent_control.jl
+++ b/test/test_voltage_dependent_control.jl
@@ -118,8 +118,11 @@ function run_voltage_dependent_control_tests()
 
       report = buildACPFlowReport(net; ct = 0.0, ite = 1, tol = 1e-8, converged = true, solver = :rectangular)
       row_ctrl = only(filter(r -> r.bus_name == "B4", report.nodes))
+      row_slack = only(filter(r -> r.bus_name == "B1", report.nodes))
       @test isapprox(row_ctrl.p_gen_MW, p_ctrl_mw; atol = 1e-8)
       @test isapprox(row_ctrl.q_gen_MVar, q_ctrl_mvar; atol = 1e-8)
+      @test abs(row_slack.p_gen_MW) > 1e-6
+      @test abs(row_slack.q_gen_MVar) > 1e-6
     end
   end
 

--- a/test/test_voltage_dependent_control.jl
+++ b/test/test_voltage_dependent_control.jl
@@ -26,6 +26,22 @@ function run_voltage_dependent_control_tests()
       @test q_slope == 0.0
     end
 
+    @testset "Physical-unit controller inputs (kV, MW, MVAr)" begin
+      ch_qu = make_characteristic([(104.5, 30.0), (110.0, 0.0), (115.5, -20.0)]; voltage_unit = :kV, value_unit = :MVAr, vn_kV = 110.0, sbase_MVA = 100.0)
+      ch_pu = make_characteristic([(104.5, 20.0), (110.0, 10.0), (115.5, 0.0)]; voltage_unit = :kV, value_unit = :MW, vn_kV = 110.0, sbase_MVA = 100.0)
+
+      @test ch_qu.points == [(0.95, 0.3), (1.0, 0.0), (1.05, -0.2)]
+      @test ch_pu.points == [(0.95, 0.2), (1.0, 0.1), (1.05, 0.0)]
+
+      qu = QUController(ch_qu; qmin_MVAr = -50.0, qmax_MVAr = 50.0, sbase_MVA = 100.0)
+      pu = PUController(ch_pu; pmin_MW = 0.0, pmax_MW = 50.0, sbase_MVA = 100.0)
+
+      @test isapprox(qu.qmin_pu, -0.5; atol = 1e-12)
+      @test isapprox(qu.qmax_pu, 0.5; atol = 1e-12)
+      @test isapprox(pu.pmin_pu, 0.0; atol = 1e-12)
+      @test isapprox(pu.pmax_pu, 0.5; atol = 1e-12)
+    end
+
     @testset "No-control compatibility and solver integration" begin
       net_plain = createTest3BusNet()
       V_plain = buildVoltageVector(net_plain)

--- a/test/test_voltage_dependent_control.jl
+++ b/test/test_voltage_dependent_control.jl
@@ -2,6 +2,7 @@
 
 using Test
 using Sparlectra
+using Printf
 
 function run_voltage_dependent_control_tests()
   @testset "Voltage dependent P(U)/Q(U) control" begin
@@ -97,12 +98,23 @@ function run_voltage_dependent_control_tests()
       tmp = mktempdir()
       printACPFlowResults(net, 0.0, 1, 1e-8, true, tmp; converged = true, solver = :rectangular)
       out = read(joinpath(tmp, "result_$(net.name).txt"), String)
+      V = buildVoltageVector(net)
+      controlled_idx = findfirst(ps -> !isnothing(ps.puController) && !isnothing(ps.quController), net.prosumpsVec)
+      @test !isnothing(controlled_idx)
+      ps_ctrl = net.prosumpsVec[controlled_idx]
+      vm_ctrl = abs(V[getPosumerBusIndex(ps_ctrl)])
+      p_ctrl_pu, _ = evaluate_controller(ps_ctrl.puController, vm_ctrl)
+      q_ctrl_pu, _ = evaluate_controller(ps_ctrl.quController, vm_ctrl)
+      p_ctrl_mw = p_ctrl_pu * net.baseMVA
+      q_ctrl_mvar = q_ctrl_pu * net.baseMVA
 
       @test occursin("Control", out)
       @test occursin("Q(U)", out)
       @test occursin("P(U)", out)
       @test occursin("Q(U), P(U)", out)
       @test occursin(" - ", out)
+      @test occursin(@sprintf("%10.3f", p_ctrl_mw), out)
+      @test occursin(@sprintf("%10.3f", q_ctrl_mvar), out)
     end
   end
 

--- a/test/test_voltage_dependent_control.jl
+++ b/test/test_voltage_dependent_control.jl
@@ -115,6 +115,11 @@ function run_voltage_dependent_control_tests()
       @test occursin(" - ", out)
       @test occursin(@sprintf("%10.3f", p_ctrl_mw), out)
       @test occursin(@sprintf("%10.3f", q_ctrl_mvar), out)
+
+      report = buildACPFlowReport(net; ct = 0.0, ite = 1, tol = 1e-8, converged = true, solver = :rectangular)
+      row_ctrl = only(filter(r -> r.bus_name == "B4", report.nodes))
+      @test isapprox(row_ctrl.p_gen_MW, p_ctrl_mw; atol = 1e-8)
+      @test isapprox(row_ctrl.q_gen_MVar, q_ctrl_mvar; atol = 1e-8)
     end
   end
 

--- a/test/test_voltage_dependent_control.jl
+++ b/test/test_voltage_dependent_control.jl
@@ -1,0 +1,94 @@
+# Copyright 2023–2026 Udo Schmitz
+
+using Test
+using Sparlectra
+
+function run_voltage_dependent_control_tests()
+  @testset "Voltage dependent P(U)/Q(U) control" begin
+    @testset "Characteristic evaluation" begin
+      ch = PiecewiseLinearCharacteristic([(0.95, -0.2), (1.0, 0.0), (1.05, 0.2)])
+
+      v_mid, dv_mid = evaluate_characteristic(ch, 0.975)
+      @test isapprox(v_mid, -0.1; atol = 1e-12)
+      @test isapprox(dv_mid, 4.0; atol = 1e-12)
+
+      v_lo, dv_lo = evaluate_characteristic(ch, 0.90)
+      @test isapprox(v_lo, -0.2; atol = 1e-12)
+      @test dv_lo == 0.0
+
+      v_hi, dv_hi = evaluate_characteristic(ch, 1.10)
+      @test isapprox(v_hi, 0.2; atol = 1e-12)
+      @test dv_hi == 0.0
+
+      qu = QUController(ch, -0.05, 0.05)
+      q_val, q_slope = evaluate_controller(qu, 1.05)
+      @test isapprox(q_val, 0.05; atol = 1e-12)
+      @test q_slope == 0.0
+    end
+
+    @testset "No-control compatibility and solver integration" begin
+      net_plain = createTest3BusNet()
+      V_plain = buildVoltageVector(net_plain)
+      S_plain = buildComplexSVec(net_plain)
+      S_eval_plain, dP_plain, dQ_plain = buildControlledSVec(net_plain, V_plain)
+      @test S_plain ≈ S_eval_plain
+      @test all(iszero, dP_plain)
+      @test all(iszero, dQ_plain)
+
+      net = Net(name = "qu_control_case", baseMVA = 100.0)
+      addBus!(net = net, busName = "B1", vn_kV = 110.0)
+      addBus!(net = net, busName = "B2", vn_kV = 110.0)
+      addACLine!(net = net, fromBus = "B1", toBus = "B2", length = 20.0, r = 0.05, x = 0.4)
+
+      addProsumer!(net = net, busName = "B1", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "B1")
+      qu_curve = PiecewiseLinearCharacteristic([(0.95, 0.4), (1.0, 0.0), (1.05, -0.2)])
+      addProsumer!(net = net, busName = "B2", type = "SYNCHRONOUSMACHINE", p = 20.0, q = 0.0, qu_controller = QUController(qu_curve, -0.5, 0.5))
+      addProsumer!(net = net, busName = "B2", type = "ENERGYCONSUMER", p = 60.0, q = 20.0)
+
+      ite, erg = runpf!(net, 30, 1e-9, 0; method = :rectangular, opt_sparse = true)
+      @test erg == 0
+      @test ite <= 30
+
+      V = buildVoltageVector(net)
+      vm = abs(V[2])
+      q_ctrl_pu, _ = evaluate_controller(net.prosumpsVec[2].quController, vm)
+      S_eval, _, _ = buildControlledSVec(net, V)
+      qnet_expected = q_ctrl_pu * net.baseMVA - 20.0
+      @test isapprox(imag(S_eval[2]) * net.baseMVA, qnet_expected; atol = 1e-8)
+    end
+
+    @testset "Result printout shows Control column" begin
+      net = Net(name = "control_print_case", baseMVA = 100.0)
+      for b in ("B1", "B2", "B3", "B4")
+        addBus!(net = net, busName = b, vn_kV = 110.0)
+      end
+
+      addACLine!(net = net, fromBus = "B1", toBus = "B2", length = 20.0, r = 0.02, x = 0.2)
+      addACLine!(net = net, fromBus = "B1", toBus = "B3", length = 20.0, r = 0.02, x = 0.2)
+      addACLine!(net = net, fromBus = "B1", toBus = "B4", length = 20.0, r = 0.02, x = 0.2)
+
+      addProsumer!(net = net, busName = "B1", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "B1")
+      addProsumer!(net = net, busName = "B2", type = "SYNCHRONOUSMACHINE", p = 15.0, q = 0.0, qu_controller = QUController(make_characteristic([(0.95, 0.2), (1.05, -0.2)]), -0.5, 0.5))
+      addProsumer!(net = net, busName = "B3", type = "SYNCHRONOUSMACHINE", p = 0.0, q = 5.0, pu_controller = PUController(make_characteristic([(0.95, 0.2), (1.05, 0.0)]), -0.5, 0.5))
+      addProsumer!(net = net, busName = "B4", type = "SYNCHRONOUSMACHINE", p = 0.0, q = 0.0, qu_controller = QUController(make_characteristic([(0.95, 0.1), (1.05, -0.1)]), -0.5, 0.5), pu_controller = PUController(make_characteristic([(0.95, 0.1), (1.05, 0.0)]), -0.5, 0.5))
+      addProsumer!(net = net, busName = "B2", type = "ENERGYCONSUMER", p = 30.0, q = 12.0)
+      addProsumer!(net = net, busName = "B3", type = "ENERGYCONSUMER", p = 20.0, q = 8.0)
+      addProsumer!(net = net, busName = "B4", type = "ENERGYCONSUMER", p = 10.0, q = 4.0)
+
+      _, erg = runpf!(net, 30, 1e-8, 0; method = :rectangular)
+      @test erg == 0
+
+      tmp = mktempdir()
+      printACPFlowResults(net, 0.0, 1, 1e-8, true, tmp; converged = true, solver = :rectangular)
+      out = read(joinpath(tmp, "result_$(net.name).txt"), String)
+
+      @test occursin("Control", out)
+      @test occursin("Q(U)", out)
+      @test occursin("P(U)", out)
+      @test occursin("Q(U), P(U)", out)
+      @test occursin(" - ", out)
+    end
+  end
+
+  return true
+end

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -1032,6 +1032,37 @@ function test_link_bus_merge_pf_default_method()
   return test_link_bus_merge_pf()
 end
 
+function test_rectangular_merge_fallback_suppresses_polar_deprecation_warning()::Bool
+  net = Net(name = "link_merge_warning_gate", baseMVA = 100.0)
+  addBus!(net = net, busName = "B0", vn_kV = 110.0)
+  addBus!(net = net, busName = "B1", vn_kV = 110.0)
+  addBus!(net = net, busName = "B2", vn_kV = 110.0)
+  addBus!(net = net, busName = "B3", vn_kV = 110.0)
+
+  addACLine!(net = net, fromBus = "B0", toBus = "B1", length = 5.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)
+  addACLine!(net = net, fromBus = "B2", toBus = "B3", length = 20.0, r = 0.05, x = 0.5, c_nf_per_km = 10.0, tanδ = 0.0)
+  addLink!(net = net, fromBus = "B1", toBus = "B2", status = 1)
+  addProsumer!(net = net, busName = "B0", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "B0")
+  addProsumer!(net = net, busName = "B1", type = "GENERATOR", p = 10.0, q = 1.0)
+  addProsumer!(net = net, busName = "B2", type = "ENERGYCONSUMER", p = 15.0, q = 5.0)
+  addProsumer!(net = net, busName = "B3", type = "ENERGYCONSUMER", p = 25.0, q = 10.0)
+
+  old_warned = Sparlectra._warned_full_solver_deprecated[]
+  Sparlectra._warned_full_solver_deprecated[] = false
+  try
+    @test_logs min_level = Logging.Warn (:warn, r"runpf!: rectangular solver does not support internal Isolated buses from active-link merges; falling back to :polar_full") match_mode = :all begin
+      _, erg = runpf!(net, 30, 1e-8, 1; method = :rectangular, opt_sparse = true)
+      if erg != 0
+        return false
+      end
+    end
+  finally
+    Sparlectra._warned_full_solver_deprecated[] = old_warned
+  end
+
+  return true
+end
+
 function test_link_closed_keeps_shunt_reporting_on_original_bus()
   net = Net(name = "link_shunt_reporting", baseMVA = 100.0)
   addBus!(net = net, busName = "B0", vn_kV = 110.0)
@@ -1574,6 +1605,7 @@ function run_grid_tests()
       @test test_link_rejects_mixed_bus_types() == true
       @test test_link_bus_merge_pf() == true
       @test test_link_bus_merge_pf_default_method() == true
+      @test test_rectangular_merge_fallback_suppresses_polar_deprecation_warning() == true
       @test test_link_closed_keeps_shunt_reporting_on_original_bus() == true
       @test test_link_kcl_ring_allocation() == true
       @test test_link_kcl_ring_allocation_with_shunt() == true

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -317,13 +317,24 @@ function test_matpower_import_uses_bus_type_for_regulation()::Bool
     bus_name = nothing,
   )
 
-  net = Sparlectra.createNetFromMatPowerCase(mpc = mpc, log = false, flatstart = false)
+  net = nothing
+  @test_logs (:info, r"MATPOWER import: PQ generator limits mapped to constant P\(U\)/Q\(U\) controllers") match_mode = :any begin
+    net = Sparlectra.createNetFromMatPowerCase(mpc = mpc, log = false, flatstart = false)
+  end
 
   b2 = geNetBusIdx(net = net, busName = "2")
   b3 = geNetBusIdx(net = net, busName = "3")
+  b2_prosumers = getBusProsumers(net, b2)
+  b3_prosumers = getBusProsumers(net, b3)
+  b2_gen = only(filter(isGenerator, b2_prosumers))
+  b3_gen = only(filter(isGenerator, b3_prosumers))
 
   return getNodeType(net.nodeVec[b2]) == Sparlectra.PQ &&
-         getNodeType(net.nodeVec[b3]) == Sparlectra.PV
+         getNodeType(net.nodeVec[b3]) == Sparlectra.PV &&
+         !isnothing(b2_gen.puController) &&
+         !isnothing(b2_gen.quController) &&
+         isnothing(b3_gen.puController) &&
+         isnothing(b3_gen.quController)
 end
 
 function test_matpower_vmva_selfcheck_noncontiguous_bus_numbers()::Bool

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -1062,7 +1062,9 @@ function test_rectangular_merge_fallback_suppresses_polar_deprecation_warning():
   Sparlectra._warned_full_solver_deprecated[] = false
   try
     @test_logs min_level = Logging.Warn (:warn, r"runpf!: rectangular solver does not support internal Isolated buses from active-link merges; falling back to :polar_full") match_mode = :all begin
-      _, erg = runpf!(net, 30, 1e-8, 1; method = :rectangular, opt_sparse = true)
+      _, erg = redirect_stdout(devnull) do
+        runpf!(net, 30, 1e-8, 1; method = :rectangular, opt_sparse = true)
+      end
       if erg != 0
         return false
       end

--- a/test/testremove.jl
+++ b/test/testremove.jl
@@ -66,8 +66,7 @@ function createTestNetwork()::Net
 end
 
 function testRemoveBranch()
-  # Use a minimal logger to suppress expected error messages
-  with_logger(SimpleLogger(stderr, Logging.Warn)) do
+  with_logger(NullLogger()) do
     net = createTestNetwork()
 
     # Get initial counts
@@ -117,8 +116,7 @@ function testRemoveBranch()
 end
 
 function testRemoveShunt()
-  # Use a minimal logger to suppress expected error messages
-  with_logger(SimpleLogger(stderr, Logging.Warn)) do
+  with_logger(NullLogger()) do
     net = createTestNetwork()
 
     # Verify shunts exist where we expect
@@ -146,8 +144,7 @@ function testRemoveShunt()
 end
 
 function testRemoveProsumer()
-  # Use a minimal logger to suppress expected error messages
-  with_logger(SimpleLogger(stderr, Logging.Warn)) do
+  with_logger(NullLogger()) do
     net = createTestNetwork()
 
     # Get initial prosumer count
@@ -197,8 +194,7 @@ function testRemoveProsumer()
 end
 
 function testIsolatedBuses()
-  # Use a minimal logger to suppress expected error messages
-  with_logger(SimpleLogger(stderr, Logging.Warn)) do
+  with_logger(NullLogger()) do
     net = createTestNetwork()
 
     # Initially no isolated buses
@@ -242,13 +238,11 @@ end
 function testRemoveBus()
   # Skip actual tests since Net is immutable and can't be modified
   # Return true for compatibility with other tests
-  println("  Note: Bus removal tests skipped - Net struct is immutable")
   return true
 end
 
 function testRemoveSpecialCases()
-  # Use a minimal logger to suppress expected error messages
-  with_logger(SimpleLogger(stderr, Logging.Warn)) do
+  with_logger(NullLogger()) do
     net = createTestNetwork()
 
     # Test cannot remove slack bus
@@ -272,37 +266,30 @@ function testRemoveSpecialCases()
 end
 
 function testRemoveFunctions()
-  println("Testing branch removal...")
   if !testRemoveBranch()
     return false
   end
 
-  println("Testing shunt removal...")
   if !testRemoveShunt()
     return false
   end
 
-  println("Testing prosumer removal...")
   if !testRemoveProsumer()
     return false
   end
 
-  println("Testing bus removal...")
   if !testRemoveBus()
     return false
   end
 
-  println("Testing isolated buses...")
   if !testIsolatedBuses()
     return false
   end
 
-  println("Testing special cases...")
   if !testRemoveSpecialCases()
     return false
   end
 
-  println("All removal tests passed!")
   return true
 end
 


### PR DESCRIPTION
## Merge Request: `dev/r07.0`

### Motivation
This branch consolidates the AC power-flow, controller behavior, and reporting updates targeted for release 0.7.0.


### What’s included

#### 1) Functional updates (0.7.0)
- Added support for voltage-dependent **P(U)** and **Q(U)** controller models in the power-flow workflow with matpower support
- Improved result reporting behavior around AC power-flow outputs.

#### 2) Bug fix: ACPFlow reporting regression
- Fixed a regression that could raise `UndefVarError: node not defined` during effective bus power component computation.
- The fix restores stable Slack/PV fallback handling in report generation.

#### 3) Test/logging quality improvements
- Reduced noisy test output:

