### PR TITLE
Add GitHub Actions clean-up workflow (manual + weekly)

### DIFF
--- a/.github/workflows/actions-cleanup.yml
+++ b/.github/workflows/actions-cleanup.yml
@@ -1,0 +1,17 @@
+name: Actions Clean-Up
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * 0' # weekly
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: Mattraks/delete-workflow-runs@v2
+        with:
+          retain_days: 30
+          keep_minimum_runs: 10


### PR DESCRIPTION
### Motivation
- Automatisch und manuell alte GitHub Actions-Runs bereinigen, um die Run-Historie überschaubar zu halten und gleichzeitig die letzten 30 Tage sowie mindestens 10 Runs zu behalten.

### Description
- Fügt ` .github/workflows/actions-cleanup.yml` hinzu, das per `workflow_dispatch` manuell gestartet werden kann und zusätzlich wöchentlich per Cron (`0 2 * * 0`) läuft, und verwendet `Mattraks/delete-workflow-runs@v2` mit `retain_days: 30` und `keep_minimum_runs: 10` sowie der benötigten Berechtigung `actions: write`.

### Testing
- Validiert mit `nl -ba .github/workflows/actions-cleanup.yml`, `git rev-parse --short HEAD` und `git status --short`, alle Befehle lieferten erwartete Ausgaben; es wurden keine Julia-Quellcodeänderungen vorgenommen, daher wurden keine `julia --project=. test/runtests.jl`-Tests ausgeführt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0bf254b08330a0704cd09785f9ba)