### PR TITLE
Handle piecewise-linear kink slopes, add plotting & tests, prefer run_net_acpflow, and docs/workflow updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,9 @@ This keeps the code compatible with non-standard array indices and avoids Static
 - If no narrower test is obvious, run:
   `julia --project=. test/runtests.jl`
 - Report the exact command and the relevant failure output if tests fail.
+
+## Power-flow execution preference
+- Prefer `run_net_acpflow(...)` over calling `runpf!(...)` directly when practical.
+- Reason: `run_net_acpflow(...)` also executes post-processing (e.g. `calcNetLosses!`,
+  branch-flow calculation, and link-flow calculation) so reported network losses
+  and branch/link flows are populated consistently.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,26 @@ Sparlectra prioritizes:
 3. Implement agreed changes  
 4. Open a Pull Request  
 
+### Optional local hot-reload workflow (Revise.jl, not a project dependency)
+
+For interactive development (especially in VS Code), you can use `Revise.jl`
+from your global Julia environment so you do **not** need to restart Julia
+after every edit.
+
+Important:
+- Do **not** add `Revise` to Sparlectra's project dependencies.
+- Keep `Revise` only in your personal/global environment.
+
+Typical REPL flow:
+
+```julia
+using Revise
+using Sparlectra
+```
+
+Then run example entry points via `Base.invokelatest(...)` where available to
+avoid world-age issues during interactive sessions.
+
 ---
 
 ## Coding Guidelines

--- a/src/examples/example_voltage_dependent_control_rectangular.jl
+++ b/src/examples/example_voltage_dependent_control_rectangular.jl
@@ -3,7 +3,46 @@
 using Sparlectra
 using Printf
 
-function run_example_voltage_dependent_control_rectangular(; verbose::Int = 1)
+function _maybe_plot_characteristic(ch::PiecewiseLinearCharacteristic; enable_plot::Bool = false, out_file::String = "kink_characteristic.png")
+  enable_plot || return
+
+  if isnothing(Base.find_package("Plots"))
+    @info "Skipping curve plot: package Plots.jl is not available in the current/global Julia environment."
+    @info "Install globally if desired: julia -e 'using Pkg; Pkg.add(\"Plots\")'"
+    return
+  end
+
+  @eval using Plots
+  xs = range(ch.points[1][1], ch.points[end][1]; length = 200)
+  ys = [first(evaluate_characteristic(ch, x)) for x in xs]
+  xk = [p[1] for p in ch.points]
+  yk = [p[2] for p in ch.points]
+
+  plt = plot(xs, ys; lw = 2, xlabel = "Voltage [pu]", ylabel = "P [pu]", label = "Characteristic", title = "Piecewise-linear kink characteristic")
+  scatter!(plt, xk, yk; ms = 4, label = "Kink points")
+  savefig(plt, out_file)
+  @info "Characteristic curve plot written to $(abspath(out_file))"
+end
+
+function _run_kink_check()
+  kink_curve = make_characteristic([(104.5, 20.0), (110.0, 10.0), (115.5, 20.0)]; voltage_unit = :kV, value_unit = :MW, vn_kV = 110.0, sbase_MVA = 100.0)
+
+  _, slope_left = evaluate_characteristic(kink_curve, 1.0 - 1e-8)
+  value_kink, slope_kink = evaluate_characteristic(kink_curve, 1.0)
+  _, slope_right = evaluate_characteristic(kink_curve, 1.0 + 1e-8)
+
+  @assert isapprox(value_kink, 0.1; atol = 1e-12)
+  @assert slope_left < 0.0
+  @assert slope_right > 0.0
+  @assert isapprox(slope_kink, slope_left; atol = 1e-12)
+
+  return (curve = kink_curve, slope_left = slope_left, slope_kink = slope_kink, slope_right = slope_right)
+end
+
+function run_example_voltage_dependent_control_rectangular(; verbose::Int = 1, plot_curve::Bool = false)
+  kink_check = _run_kink_check()
+  _maybe_plot_characteristic(kink_check.curve; enable_plot = plot_curve)
+
   net = Net(name = "voltage_dependent_control", baseMVA = 100.0)
 
   addBus!(net = net, busName = "Slack", vn_kV = 110.0)
@@ -28,7 +67,15 @@ function run_example_voltage_dependent_control_rectangular(; verbose::Int = 1)
 
   addProsumer!(net = net, busName = "Prosumer", type = "ENERGYCONSUMER", p = 45.0, q = 18.0)
 
-  ite, erg = runpf!(net, 40, 1e-9, verbose; method = :rectangular, opt_sparse = true)
+  ite, erg, etime = run_net_acpflow(
+    net = net,
+    max_ite = 40,
+    tol = 1e-9,
+    verbose = verbose,
+    opt_sparse = true,
+    method = :rectangular,
+    show_results = false,
+  )
   converged = (erg == 0)
 
   if converged
@@ -44,8 +91,9 @@ function run_example_voltage_dependent_control_rectangular(; verbose::Int = 1)
     @printf("Bus %-10s |V| = %.5f pu, angle = %.3f deg\n", "Prosumer", abs(V[2]), rad2deg(angle(V[2])))
     @printf("Controlled prosumer setpoints at Vm=%.5f pu: P=%.3f MW, Q=%.3f MVar\n", vm, p_ctrl_pu * net.baseMVA, q_ctrl_pu * net.baseMVA)
     @printf("Net specified injection at Prosumer bus: P=%.3f MW, Q=%.3f MVar\n", real(Sspec[2]) * net.baseMVA, imag(Sspec[2]) * net.baseMVA)
+    @printf("Kink check (dP/dU): left=%.6f, at kink=%.6f, right=%.6f\n", kink_check.slope_left, kink_check.slope_kink, kink_check.slope_right)
     println("\nDetailed results:")
-    printACPFlowResults(net, 0.0, ite, 1e-9; converged = true, solver = :rectangular)
+    printACPFlowResults(net, etime, ite, 1e-9; converged = true, solver = :rectangular)
   else
     println("Power flow did not converge.")
   end

--- a/src/prosumer.jl
+++ b/src/prosumer.jl
@@ -108,6 +108,11 @@ end
     evaluate_characteristic(ch, u_pu) -> (value, slope)
 
 Evaluate piecewise linear characteristic at `u_pu`.
+
+For interior breakpoints (turning points), the implementation uses the segment
+found first during the left-to-right scan, i.e. the slope of the segment on
+the left side of the breakpoint. Outside the point range, the value is clamped
+and the returned slope is `0.0`.
 """
 function evaluate_characteristic(ch::PiecewiseLinearCharacteristic, u_pu::Float64)
   pts = ch.points

--- a/test/test_voltage_dependent_control.jl
+++ b/test/test_voltage_dependent_control.jl
@@ -25,6 +25,15 @@ function run_voltage_dependent_control_tests()
       q_val, q_slope = evaluate_controller(qu, 1.05)
       @test isapprox(q_val, 0.05; atol = 1e-12)
       @test q_slope == 0.0
+
+      ch_kink = PiecewiseLinearCharacteristic([(0.95, 0.2), (1.0, 0.0), (1.05, 0.2)])
+      v_kink, dv_kink = evaluate_characteristic(ch_kink, 1.0)
+      _, dv_left = evaluate_characteristic(ch_kink, 1.0 - 1e-8)
+      _, dv_right = evaluate_characteristic(ch_kink, 1.0 + 1e-8)
+      @test isapprox(v_kink, 0.0; atol = 1e-12)
+      @test isapprox(dv_left, -4.0; atol = 1e-6)
+      @test isapprox(dv_right, 4.0; atol = 1e-6)
+      @test isapprox(dv_kink, dv_left; atol = 1e-12)
     end
 
     @testset "Physical-unit controller inputs (kV, MW, MVAr)" begin
@@ -72,6 +81,35 @@ function run_voltage_dependent_control_tests()
       S_eval, _, _ = buildControlledSVec(net, V)
       qnet_expected = q_ctrl_pu * net.baseMVA - 20.0
       @test isapprox(imag(S_eval[2]) * net.baseMVA, qnet_expected; atol = 1e-8)
+    end
+
+    @testset "Solver operating point at characteristic kink" begin
+      net = Net(name = "kink_operating_point", baseMVA = 100.0)
+      addBus!(net = net, busName = "B1", vn_kV = 110.0)
+      addBus!(net = net, busName = "B2", vn_kV = 110.0)
+      addACLine!(net = net, fromBus = "B1", toBus = "B2", length = 1.0, r = 0.01, x = 0.1)
+
+      addProsumer!(net = net, busName = "B1", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.0, va_deg = 0.0, referencePri = "B1")
+
+      kink_curve = PiecewiseLinearCharacteristic([(0.95, 0.2), (1.0, 0.0), (1.05, 0.2)])
+      addProsumer!(
+        net = net,
+        busName = "B2",
+        type = "SYNCHRONOUSMACHINE",
+        p = 0.0,
+        q = 0.0,
+        pu_controller = PUController(kink_curve; pmin_pu = -0.5, pmax_pu = 0.5),
+      )
+
+      ite, erg = runpf!(net, 30, 1e-10, 0; method = :rectangular, opt_sparse = true)
+      @test erg == 0
+      @test ite <= 30
+
+      vm = abs(buildVoltageVector(net)[2])
+      _, slope_at = evaluate_characteristic(kink_curve, vm)
+      _, slope_left = evaluate_characteristic(kink_curve, 1.0 - 1e-8)
+      @test isapprox(vm, 1.0; atol = 1e-8)
+      @test isapprox(slope_at, slope_left; atol = 1e-8)
     end
 
     @testset "Result printout shows Control column" begin


### PR DESCRIPTION
### Motivation
- Ensure piecewise-linear controller characteristics behave predictably at interior breakpoints (kinks) and make that behavior explicit in docs and tests. 
- Provide a small example plotting helper and runtime checks to make kink behavior easier to inspect during development. 
- Prefer the higher-level power-flow entrypoint that runs post-processing so losses and branch/link flows are populated consistently. 
- Document an optional local hot-reload workflow for developer convenience without adding extra project dependencies.

### Description
- Update `prosumer.jl` to document the evaluation policy for interior breakpoints in `evaluate_characteristic`, clarifying that the left segment slope is returned at a kink and clamped slopes outside the domain. 
- Extend `src/examples/example_voltage_dependent_control_rectangular.jl` with `_run_kink_check` and `_maybe_plot_characteristic` helpers, switch the example to `run_net_acpflow(...)` (so post-processing and execution time are returned), and print kink slope diagnostics. 
- Add unit tests in `test/test_voltage_dependent_control.jl` covering kink evaluation behavior and a solver operating point located exactly at a characteristic kink. 
- Update `AGENTS.md` to prefer `run_net_acpflow(...)` over directly calling `runpf!(...)` when practical. 
- Update `CONTRIBUTING.md` with an optional local hot-reload workflow using `Revise.jl`, with guidance to keep `Revise` out of project dependencies.

### Testing
- Ran the updated controller tests with `julia --project=. test/test_voltage_dependent_control.jl`, which exercises characteristic evaluation and the new kink/operating-point tests, and they completed successfully. 
- Recommend CI run the full test suite with `julia --project=. test/runtests.jl` to validate integration across the project.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde9e040888330a76e568502d5b71e)