### PR TITLE
Support prosumer voltage-adjust configs and integrate adjustable Q-limit handling

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,4 +1,16 @@
 # Change Log
+## Version 0.7.1 – 2026-04-XX
+### Improvements
+* Refactored decision logic for `qlimit_mode = :adjust_vset`:
+  * consolidated Q-limit event handling via shared active-set flow
+  * extracted voltage-step handling into dedicated helper logic
+* Added typed `VoltageAdjustConfig` support for prosumers and integrated it into voltage-regulation detection.
+* Simplified rectangular mismatch API by removing unused derivative keyword arguments from `mismatch_rectangular(...)`.
+
+### Solver Robustness
+* Rectangular solver now handles reduced Ybus matrices (caused by internal isolated buses) by expanding them back to full network dimension for mismatch/Jacobian processing.
+* For rectangular runs with active-link merges and internal isolated buses, solver now uses a rectangular FD fallback path instead of switching to `:polar_full`.
+
 ## Version 0.7.0 – 2026-04-15
 ### New Features
 * Added support for **P(U)** and **Q(U)** controller models in power flow calculations

--- a/src/Sparlectra.jl
+++ b/src/Sparlectra.jl
@@ -64,7 +64,7 @@ export
   # Trafo
   TrafoTyp, PowerTransformerTaps,  PowerTransformerWinding,  PowerTransformer, TransformerModelParameters,
   # ProSumer
-  ProSumer, AbstractVoltageDependentController, PiecewiseLinearCharacteristic, QUController, PUController,
+  ProSumer, AbstractVoltageDependentController, PiecewiseLinearCharacteristic, QUController, PUController, VoltageAdjustConfig,
   # Branch
   AbstractBranch, Branch, BranchModel, BranchFlow, getBranchFlow, setBranchFlow!, getBranchNumber, getBranchLosses, setBranchLosses!, setBranchStatus!,
   # Link

--- a/src/jacobian_complex.jl
+++ b/src/jacobian_complex.jl
@@ -216,6 +216,29 @@ function update_net_voltages_from_complex!(net::Net, V::Vector{ComplexF64})
   end
 end
 
+function _expand_ybus_for_isolated_nodes(Yred, n::Int, iso_nodes::Vector{Int})
+  isempty(iso_nodes) && return Yred
+
+  iso_mask = falses(n)
+  for bus in iso_nodes
+    if 1 <= bus <= n
+      iso_mask[bus] = true
+    end
+  end
+
+  active = Int[]
+  for bus in eachindex(iso_mask)
+    iso_mask[bus] || push!(active, bus)
+  end
+
+  size(Yred, 1) == length(active) || error("_expand_ybus_for_isolated_nodes: size mismatch between reduced Ybus and active buses.")
+  size(Yred, 2) == length(active) || error("_expand_ybus_for_isolated_nodes: Ybus is not square in active-bus space.")
+
+  Yfull = issparse(Yred) ? spzeros(ComplexF64, n, n) : zeros(ComplexF64, n, n)
+  Yfull[active, active] = Yred
+  return Yfull
+end
+
 @inline function _has_vset_adjust_config(ps::ProSumer)::Bool
   return !isnothing(ps.vset_adjust) || !(isnothing(ps.vstep_pu) && isnothing(ps.tap_steps_down) && isnothing(ps.tap_steps_up))
 end
@@ -869,7 +892,8 @@ function run_complex_nr_rectangular_for_net!(
   else
     sparse = opt_sparse
   end
-  Ybus = createYBUS(net = net, sparse = sparse, printYBUS = (verbose > 1))
+  Yred = createYBUS(net = net, sparse = sparse, printYBUS = (verbose > 1))
+  Ybus = (size(Yred, 1) == n) ? Yred : _expand_ybus_for_isolated_nodes(Yred, n, net.isoNodes)
 
   # 1) Initial complex voltages V0 and slack index
   V0, slack_idx = initialVrect(net; flatstart = opt_flatstart)
@@ -893,6 +917,11 @@ function run_complex_nr_rectangular_for_net!(
       bus_types[k] = :PV
     elseif BusType == PQ
       bus_types[k] = :PQ
+    elseif BusType == Isolated
+      # Keep isolated buses in the rectangular state vector as neutral PQ rows.
+      # Their injections are forced to zero so they do not affect the solved grid.
+      bus_types[k] = :PQ
+      S[k] = 0.0 + 0.0im
     else
       error("run_complex_nr_rectangular_for_net!: unsupported bus type at bus $k, given: $(BusType)")
     end
@@ -1312,11 +1341,11 @@ function runpf!(
     return iters, erg
   elseif method === :rectangular
     if has_merges
-      has_vdep_control && error("runpf!: P(U)/Q(U) voltage-dependent controllers are not supported with active-link merge fallback to :polar_full. Disable merges or use a topology without internal isolated buses.")
+      has_vdep_control && error("runpf!: P(U)/Q(U) voltage-dependent controllers are not supported with active-link merge handling in rectangular mode. Disable merges or use a topology without internal isolated buses.")
       if verbose > 0
-        @warn "runpf!: rectangular solver does not support internal Isolated buses from active-link merges; falling back to :polar_full"
+        @warn "runpf!: rectangular solver detected internal Isolated buses from active-link merges; using rectangular FD fallback instead of :polar_full"
       end
-      iters, erg = runpf_full!(wnet, maxIte, tolerance, verbose; opt_sparse = opt_sparse, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, lock_pv_to_pq_buses = lock_pv_to_pq_buses, warn_deprecated = false)
+      iters, erg = runpf_rectangular!(wnet, maxIte, tolerance, verbose; opt_fd = true, opt_sparse = opt_sparse, damp = damp, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, lock_pv_to_pq_buses = lock_pv_to_pq_buses, qlimit_mode = qlimit_mode, qlimit_max_outer = qlimit_max_outer)
     else
       iters, erg = runpf_rectangular!(wnet, maxIte, tolerance, verbose; opt_fd = opt_fd, opt_sparse = opt_sparse, damp = damp, opt_flatstart = opt_flatstart, pv_table_rows = pv_table_rows, lock_pv_to_pq_buses = lock_pv_to_pq_buses, qlimit_mode = qlimit_mode, qlimit_max_outer = qlimit_max_outer)
     end

--- a/src/jacobian_complex.jl
+++ b/src/jacobian_complex.jl
@@ -111,14 +111,11 @@ For each non-slack bus i:
 
 F is stacked as [ΔP_2, ΔQ/ΔV_2, ..., ΔP_n, ΔQ/ΔV_n] over all non-slack buses.
 """
-function mismatch_rectangular(Ybus, V::Vector{ComplexF64}, S::Vector{ComplexF64}, bus_types::Vector{Symbol}, Vset::Vector{Float64}, slack_idx::Int; dPinj_dVm::Vector{Float64} = zeros(Float64, length(V)), dQinj_dVm::Vector{Float64} = zeros(Float64, length(V)))
+function mismatch_rectangular(Ybus, V::Vector{ComplexF64}, S::Vector{ComplexF64}, bus_types::Vector{Symbol}, Vset::Vector{Float64}, slack_idx::Int)
   n = length(V)
   @assert length(S) == n
   @assert length(bus_types) == n
   @assert length(Vset) == n
-  @assert length(dPinj_dVm) == n
-  @assert length(dQinj_dVm) == n
-
   # Network-based injections for the current state
   S_calc = calc_injections(Ybus, V)
 
@@ -180,7 +177,7 @@ function run_complex_nr_rectangular(
   history = Float64[]
 
   for iter = 1:maxiter
-    F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
+    F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx)
     max_mis = maximum(abs.(F))
     push!(history, max_mis)
 
@@ -220,15 +217,26 @@ function update_net_voltages_from_complex!(net::Net, V::Vector{ComplexF64})
 end
 
 @inline function _has_vset_adjust_config(ps::ProSumer)::Bool
-  return !(isnothing(ps.vstep_pu) && isnothing(ps.tap_steps_down) && isnothing(ps.tap_steps_up))
+  return !isnothing(ps.vset_adjust) || !(isnothing(ps.vstep_pu) && isnothing(ps.tap_steps_down) && isnothing(ps.tap_steps_up))
 end
 
 @inline function _bus_label(net::Net, bus::Int)::String
   return getCompName(net.nodeVec[bus].comp)
 end
 
+@inline function _resolve_vset_adjust_config(ps::ProSumer)::Union{Nothing,VoltageAdjustConfig}
+  if !isnothing(ps.vset_adjust)
+    return ps.vset_adjust
+  end
+  has_any = _has_vset_adjust_config(ps)
+  has_any || return nothing
+  all_defined = !isnothing(ps.vstep_pu) && !isnothing(ps.tap_steps_down) && !isnothing(ps.tap_steps_up)
+  all_defined || return nothing
+  return VoltageAdjustConfig(Float64(ps.vstep_pu), Int(ps.tap_steps_down), Int(ps.tap_steps_up))
+end
+
 function _build_vset_adjust_controllers(net::Net)
-  controllers = Dict{Int,NamedTuple{(:prosumer_idx, :vstep_pu, :tap_steps_down, :tap_steps_up),Tuple{Int,Float64,Int,Int}}}()
+  controllers = Dict{Int,NamedTuple{(:prosumer_idx, :config),Tuple{Int,VoltageAdjustConfig}}}()
 
   for (ps_idx, ps) in enumerate(net.prosumpsVec)
     isGenerator(ps) || continue
@@ -236,14 +244,15 @@ function _build_vset_adjust_controllers(net::Net)
 
     has_any = _has_vset_adjust_config(ps)
     if has_any
-      all_defined = !isnothing(ps.vstep_pu) && !isnothing(ps.tap_steps_down) && !isnothing(ps.tap_steps_up)
+      cfg = _resolve_vset_adjust_config(ps)
+      all_defined = !isnothing(cfg)
       all_defined || error("Bus $(_bus_label(net, bus)): invalid voltage adjustment config at prosumer $ps_idx. vstep_pu, tap_steps_down and tap_steps_up must be provided together.")
-      ps.vstep_pu > 0.0 || error("Bus $(_bus_label(net, bus)): invalid vstep_pu=$(ps.vstep_pu). Must be > 0.")
-      ps.tap_steps_down >= 0 || error("Bus $(_bus_label(net, bus)): invalid tap_steps_down=$(ps.tap_steps_down). Must be ≥ 0.")
-      ps.tap_steps_up >= 0 || error("Bus $(_bus_label(net, bus)): invalid tap_steps_up=$(ps.tap_steps_up). Must be ≥ 0.")
+      cfg.vstep_pu > 0.0 || error("Bus $(_bus_label(net, bus)): invalid vstep_pu=$(cfg.vstep_pu). Must be > 0.")
+      cfg.tap_steps_down >= 0 || error("Bus $(_bus_label(net, bus)): invalid tap_steps_down=$(cfg.tap_steps_down). Must be ≥ 0.")
+      cfg.tap_steps_up >= 0 || error("Bus $(_bus_label(net, bus)): invalid tap_steps_up=$(cfg.tap_steps_up). Must be ≥ 0.")
       haskey(controllers, bus) && error("Bus $(_bus_label(net, bus)): multiple prosumers define voltage adjustment data. Only one controller per bus is allowed.")
 
-      controllers[bus] = (prosumer_idx = ps_idx, vstep_pu = Float64(ps.vstep_pu), tap_steps_down = Int(ps.tap_steps_down), tap_steps_up = Int(ps.tap_steps_up))
+      controllers[bus] = (prosumer_idx = ps_idx, config = cfg)
     else
       partially_set = !isnothing(ps.vstep_pu) || !isnothing(ps.tap_steps_down) || !isnothing(ps.tap_steps_up)
       partially_set && error("Bus $(_bus_label(net, bus)): incomplete voltage adjustment config at prosumer $ps_idx. vstep_pu, tap_steps_down and tap_steps_up must be provided together.")
@@ -251,6 +260,52 @@ function _build_vset_adjust_controllers(net::Net)
   end
 
   return controllers
+end
+
+function _try_adjust_vset_on_q_limit!(
+  net::Net,
+  bus::Int,
+  side::Symbol,
+  it::Int,
+  controllers::Dict{Int,NamedTuple{(:prosumer_idx, :config),Tuple{Int,VoltageAdjustConfig}}},
+  base_vset::Vector{Float64},
+  Vset::Vector{Float64},
+  adjust_counter::Vector{Int},
+  qlimit_max_outer::Int,
+  verbose::Int,
+)::Bool
+  cname = _bus_label(net, bus)
+  if !haskey(controllers, bus)
+    if verbose > 0
+      @info "Bus $cname: no voltage adjustment controller -> fallback PV→PQ (it=$it)"
+    end
+    return false
+  end
+
+  ctrl = controllers[bus].config
+  vm_base = base_vset[bus]
+  vm_min = vm_base - ctrl.tap_steps_down * ctrl.vstep_pu
+  vm_max = vm_base + ctrl.tap_steps_up * ctrl.vstep_pu
+  vm_old = Vset[bus]
+  vm_new = side == :max ? vm_old - ctrl.vstep_pu : vm_old + ctrl.vstep_pu
+  can_step = (vm_new >= vm_min - 1e-12) && (vm_new <= vm_max + 1e-12)
+
+  if can_step && adjust_counter[bus] < qlimit_max_outer
+    vm_new = clamp(vm_new, vm_min, vm_max)
+    Vset[bus] = vm_new
+    net.nodeVec[bus]._vm_pu = vm_new
+    adjust_counter[bus] += 1
+    if verbose > 0
+      event = side == :max ? "Qmax violated" : "Qmin violated"
+      @info "Bus $cname: $event -> voltage adjusted from $vm_old to $vm_new (it=$it, step=$(adjust_counter[bus]))"
+    end
+    return true
+  end
+
+  if verbose > 0
+    @info "Bus $cname: no further voltage steps (vm_min=$vm_min, vm_max=$vm_max, vm=$vm_old) -> fallback PV→PQ (it=$it)"
+  end
+  return false
 end
 
 """
@@ -703,7 +758,7 @@ function complex_newton_step_rectangular(
   # Non-slack indices
   non_slack = non_slack_indices(n, slack_idx)
   # Residual matching the FD variant
-  F0 = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
+  F0 = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx)
   m = length(F0)
   nvar = 2 * (n - 1)
   @assert m == nvar "complex_newton_step_rectangular: mismatch and state dimension differ"
@@ -868,7 +923,7 @@ function run_complex_nr_rectangular_for_net!(
   qlimit_mode in (:switch_to_pq, :adjust_vset) || error("Unsupported qlimit_mode=$(qlimit_mode). Supported: :switch_to_pq, :adjust_vset.")
   qlimit_max_outer > 0 || error("qlimit_max_outer must be > 0 (got $(qlimit_max_outer)).")
 
-  controllers = qlimit_mode == :adjust_vset ? _build_vset_adjust_controllers(net) : Dict{Int,NamedTuple{(:prosumer_idx, :vstep_pu, :tap_steps_down, :tap_steps_up),Tuple{Int,Float64,Int,Int}}}()
+  controllers = qlimit_mode == :adjust_vset ? _build_vset_adjust_controllers(net) : Dict{Int,NamedTuple{(:prosumer_idx, :config),Tuple{Int,VoltageAdjustConfig}}}()
   base_vset = copy(Vset)
   adjust_counter = zeros(Int, nb)
 
@@ -896,7 +951,7 @@ function run_complex_nr_rectangular_for_net!(
     end
 
     # Mismatch with current bus_types and (possibly) voltage-dependent S.
-    F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
+    F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx)
     max_mis = maximum(abs.(F))
     push!(history, max_mis)
 
@@ -916,108 +971,38 @@ function run_complex_nr_rectangular_for_net!(
     if it > 1
       Scalc_pu = calc_injections(Ybus, V)
 
-      if qlimit_mode == :switch_to_pq
-        changed, reenabled = active_set_q_limits!(
-          net,
-          it,
-          nb;
-          qmin_pu = qmin_pu,
-          qmax_pu = qmax_pu,
-          pv_orig_mask = pv_orig_mask,
-          allow_reenable = allow_reenable,
-          q_hyst_pu = q_hyst_pu,
-          cooldown_iters = cooldown_iters,
-          lock_pv_to_pq_buses = lock_pv_to_pq_buses,
-          verbose = verbose,
-          get_qreq_pu = bus -> begin
-            (bus_types[bus] == :Slack) && return 0.0
-            return imag(Scalc_pu[bus]) + Qload_pu[bus]
-          end,
-          is_pv = bus -> (bus_types[bus] == :PV),
-          make_pq! = (bus, qclamp_gen_pu, side) -> begin
-            bus_types[bus] = :PQ
-            qinj_pu = qclamp_gen_pu - Qload_pu[bus]
-            S[bus] = ComplexF64(real(S[bus]), qinj_pu)
-            net.nodeVec[bus]._qƩGen = qclamp_gen_pu * net.baseMVA
-          end,
-          make_pv! = (bus) -> begin
-            bus_types[bus] = :PV
-          end,
-        )
-      else
-        lock_mask = falses(nb)
-        for bus in lock_pv_to_pq_buses
-          if 1 <= bus <= nb
-            lock_mask[bus] = true
-          end
-        end
-
-        for bus in eachindex(bus_types)
-          bus_types[bus] == :PV || continue
-          lock_mask[bus] && continue
-
-          qreq = imag(Scalc_pu[bus]) + Qload_pu[bus]
-          has_hi = (bus <= length(qmax_pu)) && isfinite(qmax_pu[bus])
-          has_lo = (bus <= length(qmin_pu)) && isfinite(qmin_pu[bus])
-
-          side = :none
-          qclamp = 0.0
-          if has_hi && (qreq > qmax_pu[bus])
-            side = :max
-            qclamp = qmax_pu[bus]
-          elseif has_lo && (qreq < qmin_pu[bus])
-            side = :min
-            qclamp = qmin_pu[bus]
-          end
-          side == :none && continue
-
-          cname = _bus_label(net, bus)
-          if !haskey(controllers, bus)
-            if verbose > 0
-              @info "Bus $cname: no voltage adjustment controller -> fallback PV→PQ (it=$it)"
-            end
-            bus_types[bus] = :PQ
-            S[bus] = ComplexF64(real(S[bus]), qclamp - Qload_pu[bus])
-            net.nodeVec[bus]._qƩGen = qclamp * net.baseMVA
-            logQLimitHit!(net, it, bus, side)
-            changed = true
-            continue
-          end
-
-          ctrl = controllers[bus]
-          vm_base = base_vset[bus]
-          vm_min = vm_base - ctrl.tap_steps_down * ctrl.vstep_pu
-          vm_max = vm_base + ctrl.tap_steps_up * ctrl.vstep_pu
-          vm_old = Vset[bus]
-          vm_new = side == :max ? vm_old - ctrl.vstep_pu : vm_old + ctrl.vstep_pu
-          can_step = (vm_new >= vm_min - 1e-12) && (vm_new <= vm_max + 1e-12)
-
-          if can_step && adjust_counter[bus] < qlimit_max_outer
-            vm_new = clamp(vm_new, vm_min, vm_max)
-            Vset[bus] = vm_new
-            net.nodeVec[bus]._vm_pu = vm_new
-            adjust_counter[bus] += 1
-            changed = true
-            if verbose > 0
-              event = side == :max ? "Qmax violated" : "Qmin violated"
-              @info "Bus $cname: $event -> voltage adjusted from $vm_old to $vm_new (it=$it, step=$(adjust_counter[bus]))"
-            end
-          else
-            if verbose > 0
-              @info "Bus $cname: no further voltage steps (vm_min=$vm_min, vm_max=$vm_max, vm=$vm_old) -> fallback PV→PQ (it=$it)"
-            end
-            bus_types[bus] = :PQ
-            S[bus] = ComplexF64(real(S[bus]), qclamp - Qload_pu[bus])
-            net.nodeVec[bus]._qƩGen = qclamp * net.baseMVA
-            logQLimitHit!(net, it, bus, side)
-            changed = true
-          end
-        end
-      end
+      changed, reenabled = active_set_q_limits!(
+        net,
+        it,
+        nb;
+        qmin_pu = qmin_pu,
+        qmax_pu = qmax_pu,
+        pv_orig_mask = pv_orig_mask,
+        allow_reenable = qlimit_mode == :switch_to_pq ? allow_reenable : false,
+        q_hyst_pu = q_hyst_pu,
+        cooldown_iters = cooldown_iters,
+        lock_pv_to_pq_buses = lock_pv_to_pq_buses,
+        on_violation! = qlimit_mode == :adjust_vset ? ((bus, qreq, side, qclamp) -> _try_adjust_vset_on_q_limit!(net, bus, side, it, controllers, base_vset, Vset, adjust_counter, qlimit_max_outer, verbose)) : nothing,
+        verbose = verbose,
+        get_qreq_pu = bus -> begin
+          (bus_types[bus] == :Slack) && return 0.0
+          return imag(Scalc_pu[bus]) + Qload_pu[bus]
+        end,
+        is_pv = bus -> (bus_types[bus] == :PV),
+        make_pq! = (bus, qclamp_gen_pu, side) -> begin
+          bus_types[bus] = :PQ
+          qinj_pu = qclamp_gen_pu - Qload_pu[bus]
+          S[bus] = ComplexF64(real(S[bus]), qinj_pu)
+          net.nodeVec[bus]._qƩGen = qclamp_gen_pu * net.baseMVA
+        end,
+        make_pv! = (bus) -> begin
+          bus_types[bus] = :PV
+        end,
+      )
 
       # If bus_types/spec changed, mismatch definition changed (ΔQ ↔ ΔV) => rebuild F
       if changed || reenabled
-        F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
+        F = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx)
         max_mis = maximum(abs.(F))
         history[end] = max_mis  # optional: overwrite last stored value for this iteration
       end

--- a/src/jacobian_fd.jl
+++ b/src/jacobian_fd.jl
@@ -66,7 +66,7 @@ function complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx::Int = 1, damp
   n = length(V)
 
   # Base mismatch F(V)
-  F0 = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
+  F0 = mismatch_rectangular(Ybus, V, S, bus_types, Vset, slack_idx)
   m  = length(F0)  # expected = 2 * (n-1)
 
   # Non-slack buses
@@ -86,7 +86,7 @@ function complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx::Int = 1, damp
     V_pert = copy(V)
     V_pert[bus] = ComplexF64(Vr[bus] + h, Vi[bus])
 
-    Fp = mismatch_rectangular(Ybus, V_pert, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
+    Fp = mismatch_rectangular(Ybus, V_pert, S, bus_types, Vset, slack_idx)
     J[:, col_idx] .= (Fp .- F0) ./ h
   end
 
@@ -96,7 +96,7 @@ function complex_newton_step_rectangular_fd(Ybus, V, S; slack_idx::Int = 1, damp
     V_pert = copy(V)
     V_pert[bus] = ComplexF64(Vr[bus], Vi[bus] + h)
 
-    Fp = mismatch_rectangular(Ybus, V_pert, S, bus_types, Vset, slack_idx; dPinj_dVm = dPinj_dVm, dQinj_dVm = dQinj_dVm)
+    Fp = mismatch_rectangular(Ybus, V_pert, S, bus_types, Vset, slack_idx)
     J[:, col_idx] .= (Fp .- F0) ./ h
   end
 

--- a/src/limits.jl
+++ b/src/limits.jl
@@ -346,6 +346,8 @@ Callbacks:
 - is_pv(bus) -> Bool
 - make_pq!(bus, q_clamp_pu::Float64, side::Symbol)  # side = :min/:max
 - make_pv!(bus)
+- on_violation!(bus, qreq_pu::Float64, side::Symbol, q_clamp_pu::Float64) -> Bool
+  (optional; return true if violation was handled without PV->PQ fallback)
 """
 function active_set_q_limits!(
   net::Net,
@@ -362,6 +364,7 @@ function active_set_q_limits!(
   q_hyst_pu::Float64,
   cooldown_iters::Int,
   lock_pv_to_pq_buses::AbstractVector{Int} = Int[],
+  on_violation! = nothing,
   verbose::Int = 0,
 )
   changed   = false
@@ -384,15 +387,32 @@ function active_set_q_limits!(
     has_hi = (bus <= length(qmax_pu)) && isfinite(qmax_pu[bus])
     has_lo = (bus <= length(qmin_pu)) && isfinite(qmin_pu[bus])
 
+    side = :none
+    qclamp = 0.0
     if has_hi && (qreq > qmax_pu[bus])
-      make_pq!(bus, qmax_pu[bus], :max)
-      logQLimitHit!(net, it, bus, :max)
+      side = :max
+      qclamp = qmax_pu[bus]
+    elseif has_lo && (qreq < qmin_pu[bus])
+      side = :min
+      qclamp = qmin_pu[bus]
+    end
+    side == :none && continue
+
+    handled = false
+    if !isnothing(on_violation!)
+      handled = on_violation!(bus, qreq, side, qclamp)
+    end
+
+    if handled
+      changed = true
+    elseif side == :max
+      make_pq!(bus, qclamp, side)
+      logQLimitHit!(net, it, bus, side)
       changed = true
       (verbose > 0) && @printf "PV->PQ Bus %d: Q=%.6f > Qmax=%.6f (it=%d)\n" bus qreq qmax_pu[bus] it
-
-    elseif has_lo && (qreq < qmin_pu[bus])
-      make_pq!(bus, qmin_pu[bus], :min)
-      logQLimitHit!(net, it, bus, :min)
+    else
+      make_pq!(bus, qclamp, side)
+      logQLimitHit!(net, it, bus, side)
       changed = true
       (verbose > 0) && @printf "PV->PQ Bus %d: Q=%.6f < Qmin=%.6f (it=%d)\n" bus qreq qmin_pu[bus] it
     end

--- a/src/network.jl
+++ b/src/network.jl
@@ -1002,7 +1002,12 @@ function addProsumer!(;
   has_vm_setpoint = !isnothing(vm_pu)
   has_vstep_with_taps = !isnothing(vstep_pu) && (!isnothing(tap_steps_down) || !isnothing(tap_steps_up))
   auto_regulated = isRegulated || has_vm_setpoint || has_vstep_with_taps
-  ps = ProSumer(vn_kv = vn_kV, busIdx = busIdx, oID = idProsSum, type = proTy, p = p, q = q, minP = pMin, maxP = pMax, minQ = qMin, maxQ = qMax, referencePri = refPriIdx, vm_pu = vm_pu, va_deg = va_deg, vstep_pu = vstep_pu, tap_steps_down = tap_steps_down, tap_steps_up = tap_steps_up, isRegulated = auto_regulated, isAPUNode = isAPUNode, quController = qu_controller, puController = pu_controller)
+  vset_adjust_cfg = if !isnothing(vstep_pu) && !isnothing(tap_steps_down) && !isnothing(tap_steps_up)
+    VoltageAdjustConfig(vstep_pu, tap_steps_down, tap_steps_up)
+  else
+    nothing
+  end
+  ps = ProSumer(vn_kv = vn_kV, busIdx = busIdx, oID = idProsSum, type = proTy, p = p, q = q, minP = pMin, maxP = pMax, minQ = qMin, maxQ = qMax, referencePri = refPriIdx, vm_pu = vm_pu, va_deg = va_deg, vstep_pu = vstep_pu, tap_steps_down = tap_steps_down, tap_steps_up = tap_steps_up, vset_adjust = vset_adjust_cfg, isRegulated = auto_regulated, isAPUNode = isAPUNode, quController = qu_controller, puController = pu_controller)
   push!(net.prosumpsVec, ps)
   node = net.nodeVec[busIdx]
   if (isGenerator(proTy))

--- a/src/prosumer.jl
+++ b/src/prosumer.jl
@@ -126,6 +126,12 @@ struct PUController <: AbstractVoltageDependentController
   pmax_pu::Union{Nothing,Float64}
 end
 
+struct VoltageAdjustConfig
+  vstep_pu::Float64
+  tap_steps_down::Int
+  tap_steps_up::Int
+end
+
 @inline _to_pu_power(value::Float64, sbase_MVA::Float64) = value / sbase_MVA
 @inline _to_pu_voltage(value::Float64, vn_kV::Float64) = value / vn_kV
 
@@ -321,6 +327,7 @@ mutable struct ProSumer
   vstep_pu::Union{Nothing,Float64}
   tap_steps_down::Union{Nothing,Int}
   tap_steps_up::Union{Nothing,Int}
+  vset_adjust::Union{Nothing,VoltageAdjustConfig}
   isRegulated::Bool
   proSumptionType::ProSumptionType
   isAPUNode::Bool
@@ -351,6 +358,7 @@ mutable struct ProSumer
     vstep_pu::Union{Nothing,Float64} = nothing,
     tap_steps_down::Union{Nothing,Int} = nothing,
     tap_steps_up::Union{Nothing,Int} = nothing,
+    vset_adjust::Union{Nothing,VoltageAdjustConfig} = nothing,
     isRegulated::Bool = false,
     isAPUNode::Bool = false,
     quController::Union{Nothing,QUController} = nothing,
@@ -366,7 +374,7 @@ mutable struct ProSumer
       va_deg = 0.0
     end
 
-    new(comp, ratedS, ratedU, qPercent, p, q, maxP, minP, maxQ, minQ, ratedPowerFactor, referencePri, vm_pu, va_deg, vstep_pu, tap_steps_down, tap_steps_up, isRegulated, type, isAPUNode, quController, puController, nothing, nothing, nothing)
+    new(comp, ratedS, ratedU, qPercent, p, q, maxP, minP, maxQ, minQ, ratedPowerFactor, referencePri, vm_pu, va_deg, vstep_pu, tap_steps_down, tap_steps_up, vset_adjust, isRegulated, type, isAPUNode, quController, puController, nothing, nothing, nothing)
   end
 
   function Base.show(io::IO, prosumption::ProSumer)
@@ -432,6 +440,9 @@ mutable struct ProSumer
     end
     if (!isnothing(prosumption.tap_steps_up))
       print(io, "tap_steps_up: ", prosumption.tap_steps_up, ", ")
+    end
+    if !isnothing(prosumption.vset_adjust)
+      print(io, "vset_adjust: ", prosumption.vset_adjust, ", ")
     end
     if prosumption.isRegulated
       print(io, "isRegulated: true, ")
@@ -525,7 +536,7 @@ function isSlack(o::ProSumer)
 end
 
 function isRegulating(o::ProSumer)::Bool
-  has_controller = !isnothing(o.vstep_pu) || !isnothing(o.tap_steps_down) || !isnothing(o.tap_steps_up)
+  has_controller = !isnothing(o.vset_adjust) || !isnothing(o.vstep_pu) || !isnothing(o.tap_steps_down) || !isnothing(o.tap_steps_up)
   return o.isRegulated || has_controller
 end
 

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -1061,7 +1061,7 @@ function test_rectangular_merge_fallback_suppresses_polar_deprecation_warning():
   old_warned = Sparlectra._warned_full_solver_deprecated[]
   Sparlectra._warned_full_solver_deprecated[] = false
   try
-    @test_logs min_level = Logging.Warn (:warn, r"runpf!: rectangular solver does not support internal Isolated buses from active-link merges; falling back to :polar_full") match_mode = :all begin
+    @test_logs min_level = Logging.Warn (:warn, r"runpf!: rectangular solver detected internal Isolated buses from active-link merges; using rectangular FD fallback instead of :polar_full") match_mode = :all begin
       _, erg = redirect_stdout(devnull) do
         runpf!(net, 30, 1e-8, 1; method = :rectangular, opt_sparse = true)
       end


### PR DESCRIPTION
### Motivation
- Introduce a first-class representation for prosumer voltage-adjustment parameters so voltage-step + tap-range data can be passed and handled as a single config object.
- Allow the PV Q-limit active-set to optionally try adjusting voltage setpoints instead of immediately switching PV→PQ, enabling the `:adjust_vset` `qlimit_mode` behavior.
- Simplify the rectangular mismatch API by removing unused injection-derivative keyword arguments from the public mismatch call sites.

### Description
- Add a new `VoltageAdjustConfig` struct and attach it to `ProSumer` via a new `vset_adjust` field, and include it in `Base.show` output and `isRegulating` detection.
- Populate `vset_adjust` in `addProsumer!` when `vstep_pu` and both tap step counts are provided, and keep backward-compatible fields for `vstep_pu` / taps.
- Implement `_resolve_vset_adjust_config` and `_try_adjust_vset_on_q_limit!` helpers and change `_has_vset_adjust_config` and `_build_vset_adjust_controllers` to work with the new config object.
- Extend `active_set_q_limits!` with an optional `on_violation!` callback that can handle Q-limit violations (returning true to avoid PV→PQ fallback), and wire that callback from the rectangular NR loop when `qlimit_mode == :adjust_vset`.
- Replace direct PV→PQ voltage-step logic in the rectangular NR loop with a call to the unified `active_set_q_limits!` API and use the new callback for voltage adjustments; adjust controller dictionary types accordingly.
- Simplify `mismatch_rectangular` signature by removing the `dPinj_dVm`/`dQinj_dVm` keyword arguments and update all finite-difference and Newton-step callers to the simplified call pattern.

### Testing
- Ran the package test suite with `] test Sparlectra` including core power-flow scenarios and the PV Q-limit active-set tests, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df44bcbc3883308783651f9eeefa4b)