### PR TITLE
Defer bus-type refresh during MATPOWER import and add load-flow examples

### DIFF
--- a/src/createnet_powermat.jl
+++ b/src/createnet_powermat.jl
@@ -161,6 +161,7 @@ function createNetFromMatPowerCase(; mpc, log::Bool=false, flatstart::Bool=false
         pMax = pMax,
         qMin = qMin,
         qMax = qMax,
+        defer_bus_type_refresh = true,
       )
     end
   end
@@ -265,8 +266,12 @@ function createNetFromMatPowerCase(; mpc, log::Bool=false, flatstart::Bool=false
       qu_controller = qu_controller,
       pu_controller = pu_controller,
       isRegulated = (btype == 2),
+      defer_bus_type_refresh = true,
     )
   end
+
+  refreshBusTypesFromProsumers!(myNet)
+  _buildQLimits!(myNet)
 
   if enable_pq_gen_controllers && pq_gen_controller_count > 0
     @info "MATPOWER import: PQ generator limits mapped to constant P(U)/Q(U) controllers" count = pq_gen_controller_count

--- a/src/examples/compare_stands_loadflow.jl
+++ b/src/examples/compare_stands_loadflow.jl
@@ -1,0 +1,132 @@
+# Copyright 2023–2026 Udo Schmitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""
+Compare load-flow behavior (convergence + runtime) for one or multiple MATPOWER cases.
+
+Intended workflow to compare versions/states (e.g. r0.7.1 vs current):
+1) Run this script in checkout A.
+2) Run the same command in checkout B.
+3) Compare the printed table.
+
+Usage:
+  julia --project=. src/examples/compare_stands_loadflow.jl
+  julia --project=. src/examples/compare_stands_loadflow.jl case14.m case118.m
+
+Env overrides:
+  SPARLECTRA_COMPARE_REPEATS     (default: 3)
+  SPARLECTRA_COMPARE_MAX_ITE     (default: 40)
+  SPARLECTRA_COMPARE_TOL         (default: 1e-8)
+  SPARLECTRA_COMPARE_METHOD      (default: rectangular)
+  SPARLECTRA_COMPARE_OPT_SPARSE  (default: true)
+  SPARLECTRA_COMPARE_OPT_FD      (default: false)
+  SPARLECTRA_COMPARE_ENABLE_PQ_CONTROLLERS (default: true)
+"""
+
+using Sparlectra
+using Statistics
+using Printf
+
+const DEFAULT_CASES = ["case14.m"]
+
+_bool_env(name::String, default::Bool) = lowercase(get(ENV, name, string(default))) in ("1", "true", "yes", "on")
+
+function run_case_benchmark(casefile::String;
+                            repeats::Int,
+                            max_ite::Int,
+                            tol::Float64,
+                            method::Symbol,
+                            opt_sparse::Bool,
+                            opt_fd::Bool,
+                            enable_pq_gen_controllers::Bool)
+  local_case = Sparlectra.FetchMatpowerCase.ensure_casefile(casefile; outdir = Sparlectra.MPOWER_DIR, to_jl = false, overwrite = false)
+
+  elapsed_s = Float64[]
+  iterations = Int[]
+  converged = Bool[]
+
+  for _ in 1:repeats
+    status_ref = Ref{Any}(nothing)
+    run_acpflow(
+      casefile = basename(local_case),
+      path = dirname(local_case),
+      max_ite = max_ite,
+      tol = tol,
+      method = method,
+      opt_sparse = opt_sparse,
+      opt_fd = opt_fd,
+      verbose = 0,
+      show_results = false,
+      show_compact_result = false,
+      status_ref = status_ref,
+      enable_pq_gen_controllers = enable_pq_gen_controllers,
+    )
+
+    st = status_ref[]
+    push!(elapsed_s, st.elapsed_s)
+    push!(iterations, st.iterations)
+    push!(converged, st.converged)
+  end
+
+  return (
+    casefile = casefile,
+    runs = repeats,
+    converged_runs = count(identity, converged),
+    median_elapsed_s = median(elapsed_s),
+    min_elapsed_s = minimum(elapsed_s),
+    max_elapsed_s = maximum(elapsed_s),
+    median_iterations = Int(round(median(iterations))),
+    max_iterations = maximum(iterations),
+  )
+end
+
+function main()
+  cases = isempty(ARGS) ? DEFAULT_CASES : collect(ARGS)
+
+  repeats = parse(Int, get(ENV, "SPARLECTRA_COMPARE_REPEATS", "3"))
+  max_ite = parse(Int, get(ENV, "SPARLECTRA_COMPARE_MAX_ITE", "40"))
+  tol = parse(Float64, get(ENV, "SPARLECTRA_COMPARE_TOL", "1e-8"))
+  method = Symbol(get(ENV, "SPARLECTRA_COMPARE_METHOD", "rectangular"))
+  opt_sparse = _bool_env("SPARLECTRA_COMPARE_OPT_SPARSE", true)
+  opt_fd = _bool_env("SPARLECTRA_COMPARE_OPT_FD", false)
+  enable_pq_gen_controllers = _bool_env("SPARLECTRA_COMPARE_ENABLE_PQ_CONTROLLERS", true)
+
+  println("=== Sparlectra load-flow comparison run ===")
+  println("Version: ", Sparlectra.version())
+  println("Settings: repeats=", repeats,
+          ", method=", method,
+          ", max_ite=", max_ite,
+          ", tol=", tol,
+          ", opt_sparse=", opt_sparse,
+          ", opt_fd=", opt_fd,
+          ", enable_pq_gen_controllers=", enable_pq_gen_controllers)
+  println("")
+
+  results = NamedTuple[]
+  for casefile in cases
+    try
+      push!(results, run_case_benchmark(casefile;
+                                        repeats = repeats,
+                                        max_ite = max_ite,
+                                        tol = tol,
+                                        method = method,
+                                        opt_sparse = opt_sparse,
+                                        opt_fd = opt_fd,
+                                        enable_pq_gen_controllers = enable_pq_gen_controllers))
+    catch err
+      @warn "Case benchmark failed" casefile exception = (err, catch_backtrace())
+    end
+  end
+
+  println("casefile | converged/runs | median_iter | max_iter | median_s | min_s | max_s")
+  println("---------|----------------|-------------|----------|----------|-------|------")
+  for r in results
+    @printf("%s | %d/%d | %d | %d | %.4f | %.4f | %.4f\n",
+            r.casefile, r.converged_runs, r.runs, r.median_iterations, r.max_iterations,
+            r.median_elapsed_s, r.min_elapsed_s, r.max_elapsed_s)
+  end
+end
+
+Base.invokelatest(main)

--- a/src/examples/import_case_xxxyyyy_loadflow.jl
+++ b/src/examples/import_case_xxxyyyy_loadflow.jl
@@ -1,0 +1,66 @@
+# Copyright 2023–2026 Udo Schmitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example: import a (parameterizable) MATPOWER case and run AC load flow.
+
+Usage examples:
+- julia --project=. src/examples/import_case_xxxyyyy_loadflow.jl
+- julia --project=. src/examples/import_case_xxxyyyy_loadflow.jl case14.m
+- julia --project=. src/examples/import_case_xxxyyyy_loadflow.jl xxxyyyy.m
+"""
+
+using Sparlectra
+
+const DEFAULT_CASEFILE = "case14.m"
+
+function run_import_case_xxxyyyy_loadflow_example(; casefile::AbstractString = DEFAULT_CASEFILE,
+                                                  method::Symbol = :rectangular,
+                                                  max_ite::Int = 30,
+                                                  tol::Float64 = 1e-6,
+                                                  verbose::Int = 1)
+  local_case = Sparlectra.FetchMatpowerCase.ensure_casefile(
+    String(casefile);
+    outdir = Sparlectra.MPOWER_DIR,
+    to_jl = false,
+    overwrite = false,
+  )
+
+  println("Loaded case file: ", local_case)
+  println("Running AC power flow with method=", method, ", max_ite=", max_ite, ", tol=", tol)
+
+  net = createNetFromMatPowerFile(filename = local_case, log = (verbose > 0), flatstart = false)
+  ite, erg, etime = run_net_acpflow(
+    net = net,
+    max_ite = max_ite,
+    tol = tol,
+    verbose = verbose,
+    opt_sparse = true,
+    opt_fd = false,
+    method = method,
+    show_results = true,
+  )
+
+  converged = (erg == 0)
+  println("Summary: converged=", converged, ", iterations=", ite, ", elapsed_s=", round(etime; digits = 6))
+
+  return (net = net, converged = converged, iterations = ite, elapsed_s = etime)
+end
+
+function main()
+  casefile = isempty(ARGS) ? DEFAULT_CASEFILE : ARGS[1]
+  Base.invokelatest(() -> run_import_case_xxxyyyy_loadflow_example(casefile = casefile))
+end
+
+main()

--- a/src/network.jl
+++ b/src/network.jl
@@ -982,6 +982,7 @@ function addProsumer!(;
   qu_controller::Union{Nothing,QUController} = nothing,
   pu_controller::Union{Nothing,PUController} = nothing,
   isRegulated::Bool = false,
+  defer_bus_type_refresh::Bool = false,
 )
   busIdx = geNetBusIdx(net = net, busName = busName)
   idProsSum = length(net.prosumpsVec) + 1
@@ -1016,8 +1017,10 @@ function addProsumer!(;
     addLoadPower!(node = node, p = p, q = q)
   end
 
-  refreshBusTypesFromProsumers!(net)
-  _buildQLimits!(net)
+  if !defer_bus_type_refresh
+    refreshBusTypesFromProsumers!(net)
+    _buildQLimits!(net)
+  end
 end
 
 """


### PR DESCRIPTION
### Motivation
- Reduce redundant work when importing MATPOWER cases by avoiding repeated bus-type refreshes and Q-limit rebuilds for every prosumer added. 
- Provide example scripts to benchmark and demonstrate importing MATPOWER cases and running AC load flow.

### Description
- Added a `defer_bus_type_refresh::Bool=false` argument to `addProsumer!` and guard the internal calls to `refreshBusTypesFromProsumers!` and `_buildQLimits!` so refresh can be skipped during bulk imports. 
- Updated MATPOWER importer `createNetFromMatPowerCase` to call `addProsumer!` with `defer_bus_type_refresh = true` and then invoke `refreshBusTypesFromProsumers!(myNet)` and `_buildQLimits!(myNet)` once after all prosumers are added. 
- Kept existing behavior when `defer_bus_type_refresh` is not provided by defaulting it to `false`, preserving backwards compatibility. 
- Added two example scripts: `src/examples/compare_stands_loadflow.jl` for benchmarking convergence and runtime across MATPOWER cases and `src/examples/import_case_xxxyyyy_loadflow.jl` demonstrating case import and AC load-flow execution.

### Testing
- No automated test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8d058f0c8330a062de6b2ba241d3)