### PR TITLE
Add PV->PQ event counts to compact power-flow output

### DIFF
--- a/src/run_acpflow.jl
+++ b/src/run_acpflow.jl
@@ -125,12 +125,14 @@ function run_acpflow(;
   end
 
   if show_compact_result
+    pv_to_pq_events = length(myNet.qLimitLog)
+    pv_to_pq_buses = length(myNet.qLimitEvents)
     if erg == 0
-      @printf("method=%-12s  converged=%s  iterations=%d  time=%8.6f s\n", String(method), "yes", ite, etime)
+      @printf("method=%-12s  converged=%s  iterations=%d  pv2pq_events=%d  pv2pq_buses=%d  time=%8.6f s\n", String(method), "yes", ite, pv_to_pq_events, pv_to_pq_buses, etime)
     elseif erg == 1
-      @printf("method=%-12s  converged=%s  iterations=%d  time=%8.6f s\n", String(method), "no", ite, etime)
+      @printf("method=%-12s  converged=%s  iterations=%d  pv2pq_events=%d  pv2pq_buses=%d  time=%8.6f s\n", String(method), "no", ite, pv_to_pq_events, pv_to_pq_buses, etime)
     else
-      @printf("method=%-12s  converged=%s  iterations=%d  time=%8.6f s\n", String(method), "error", ite, etime)
+      @printf("method=%-12s  converged=%s  iterations=%d  pv2pq_events=%d  pv2pq_buses=%d  time=%8.6f s\n", String(method), "error", ite, pv_to_pq_events, pv_to_pq_buses, etime)
     end
   end
 


### PR DESCRIPTION
### Motivation
- Provide immediate visibility of PV-to-PQ limit events in the compact output when `show_compact_result` is enabled.  

### Description
- Compute `pv_to_pq_events = length(myNet.qLimitLog)` and `pv_to_pq_buses = length(myNet.qLimitEvents)` and include `pv2pq_events` and `pv2pq_buses` fields in the `@printf` lines for the compact result output.  

### Testing
- Ran the package test suite with `] test` and the automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa63f16c0833084acb07faf76880f)