### PR TITLE
Introduce PowerTransformerControl and wire controller attachment into transformer creation

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,7 +14,7 @@
   * phase-shift transformer active-power control
 
 ### Improvements
-* Refactored transformer controller model to `PowerTransformerControl` in `transformer.jl`; controller capacity is now derived from transformer type (`OLTC=1`, `PST=1`, `STE=2`) and network transformer creation APIs accept `controls = [...]`.
+* Refactored transformer controller model to `PowerTransformerControl` in `transformer.jl`; controller capacity is now derived from transformer type (`OLTC=1`, `PST=1`, `STE=2`), `PowerTransformerWinding` now carries `controls`, and network transformer creation APIs accept `controls = [...]`.
 * Updated branch-model documentation with practical controller-direction probing guidance for phase-shift control.
 * Improved tap-control reporting in classic and structured ACP flow outputs, including typed transformer-controller rows with tap position/stage and consistent branch power direction reporting.
 * Updated `tap_control_demo_grid.jl` logging to create versioned run logs in `src/examples/_out/` and refined OLTC demo step resolution to `tap_step = 0.00625` for the unchanged `0.90 .. 1.10` ratio range.

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,7 @@
   * phase-shift transformer active-power control
 
 ### Improvements
+* Refactored transformer controller model to `PowerTransformerControl` in `transformer.jl`; controller capacity is now derived from transformer type (`OLTC=1`, `PST=1`, `STE=2`) and network transformer creation APIs accept `controls = [...]`.
 * Updated branch-model documentation with practical controller-direction probing guidance for phase-shift control.
 * Improved tap-control reporting in classic and structured ACP flow outputs, including typed transformer-controller rows with tap position/stage and consistent branch power direction reporting.
 * Updated `tap_control_demo_grid.jl` logging to create versioned run logs in `src/examples/_out/` and refined OLTC demo step resolution to `tap_step = 0.00625` for the unchanged `0.90 .. 1.10` ratio range.

--- a/docs/src/transformer_control.md
+++ b/docs/src/transformer_control.md
@@ -106,3 +106,7 @@ addPIModelTrafo!(
 ```
 
 See `src/examples/example_transformer_tap.jl` for a runnable example.
+
+Internally, passed controller channels are also attached to the selected transformer winding
+(`PowerTransformerWinding.controls`), so controller-side assignment is explicitly represented
+on the transformer model itself.

--- a/docs/src/transformer_control.md
+++ b/docs/src/transformer_control.md
@@ -34,7 +34,7 @@ The augmented Newton formulation with tap variables is intentionally deferred.
 ## API
 
 ```julia
-addTapController!(net;
+addPowerTransformerControl!(net;
   trafo = "1",
   mode = :voltage,
   target_bus = "B5",
@@ -45,7 +45,7 @@ addTapController!(net;
 ```
 
 ```julia
-addTapController!(net;
+addPowerTransformerControl!(net;
   trafo = "1",
   mode = :branch_active_power,
   target_branch = ("B1", "B2"),
@@ -56,7 +56,7 @@ addTapController!(net;
 ```
 
 ```julia
-addTapController!(net;
+addPowerTransformerControl!(net;
   trafo = "1",
   mode = :voltage_and_branch_active_power,
   target_bus = "B5",
@@ -79,4 +79,30 @@ addTapController!(net;
 - No coupled Jacobian with tap states yet.
 - No multi-transformer coordinated remote control yet.
 
-See `src/examples/transformer_complex_tap_control.jl` for a runnable example.
+You can also pass controller definitions directly while creating a transformer:
+
+```julia
+ctrl = PowerTransformerControl(
+  trafo = "",
+  mode = :voltage,
+  target_bus = "B5",
+  target_vm_pu = 1.01,
+  control_ratio = true,
+  control_phase = false,
+)
+
+addPIModelTrafo!(
+  net = net,
+  fromBus = "B1",
+  toBus = "B2",
+  r_pu = 0.01,
+  x_pu = 0.08,
+  b_pu = 0.0,
+  ratio = 1.0,
+  shift_deg = 0.0,
+  status = 1,
+  controls = [ctrl],
+)
+```
+
+See `src/examples/example_transformer_tap.jl` for a runnable example.

--- a/src/Sparlectra.jl
+++ b/src/Sparlectra.jl
@@ -62,7 +62,7 @@ export
   # ProSumer
   ProSumer, AbstractVoltageDependentController, PiecewiseLinearCharacteristic, QUController, PUController, VoltageAdjustConfig,
   # Tap controller
-  TapController,
+  PowerTransformerControl,
   # Branch
   AbstractBranch, Branch, BranchModel, BranchFlow, getBranchFlow, setBranchFlow!, getBranchNumber, getBranchLosses, setBranchLosses!, setBranchStatus!,
   # Link
@@ -100,7 +100,7 @@ export
   getNetOrigBusIdx, geNetBusIdx, setNetBranchStatus!, getNetBranch, getNetBranchNumberVec, setTotalLosses!, getTotalLosses, getBusType, getEffectiveBusType, getBusProsumers, refreshBusTypesFromProsumers!, get_bus_vn_kV, get_vn_kV, updateBranchParameters!, hasShunt!, 
   getShunt!, markIsolatedBuses!,setTotalBusPower!, setPVBusVset!, setQLimits!, getNodeVm,distributeBusResults!, getTotalBusPower, getTotalLosses, buildVoltageVector,initialVrect, buildComplexSVec, buildControlledSVec, has_voltage_dependent_control, addShuntMatpower!,
   add2WTPIModelTrafo!, add3WTPiModelTrafo!,showNet, buildQLimits!,updateShuntPowers!, addLink!, setNetLinkStatus!, getNetLinks, calcLinkFlowsKCL!,
-  addTapController!, get_bus_vm_pu, get_branch_p_from_to_mw, get_branch_q_from_to_mvar, run_tap_controllers_outer!, buildTapControllerReportRows, printTapControllerSummary,
+  addPowerTransformerControl!, addTapController!, get_bus_vm_pu, get_branch_p_from_to_mw, get_branch_q_from_to_mvar, run_tap_controllers_outer!, buildTapControllerReportRows, printTapControllerSummary,
   # remove_functions.jl
   removeBus!, removeBranch!, removeACLine!, removeTrafo!, removeShunt!, removeProsumer!, clearIsolatedBuses!,apply_mp_isolated_buses!,
   # import.jl

--- a/src/examples/example_transformer_tap.jl
+++ b/src/examples/example_transformer_tap.jl
@@ -62,21 +62,21 @@ function run_example_transformer_complex_tap_control(; verbose::Int = 0)
   _print_snapshot(net_ctrl, "Base point before control")
 
   println("\n--- Voltage regulator (ratio tap) ---")
-  addTapController!(net_ctrl; trafo = string(tbr.branchIdx), mode = :voltage, target_bus = "Load", target_vm_pu = 0.985, control_ratio = true, control_phase = false, is_discrete = true, deadband_vm_pu = 2e-3, max_outer_iters = 12)
+  addPowerTransformerControl!(net_ctrl; trafo = string(tbr.branchIdx), mode = :voltage, target_bus = "Load", target_vm_pu = 0.985, control_ratio = true, control_phase = false, is_discrete = true, deadband_vm_pu = 2e-3, max_outer_iters = 12)
   run_net_acpflow(net = net_ctrl, max_ite = 30, tol = 1e-9, verbose = verbose, method = :rectangular, show_results = false)
   _print_snapshot(net_ctrl, "After voltage control")
 
   println("\n--- Querregler / phase shifter (branch active power) ---")
   empty!(net_ctrl.tapControllers)
   p_ref = get_branch_p_from_to_mw(net_ctrl, "Slack", "Mid")
-  addTapController!(net_ctrl; trafo = string(tbr.branchIdx), mode = :branch_active_power, target_branch = ("Slack", "Mid"), p_target_mw = p_ref - 3.0, control_ratio = false, control_phase = true, is_discrete = true, deadband_p_mw = 0.5, max_outer_iters = 12)
+  addPowerTransformerControl!(net_ctrl; trafo = string(tbr.branchIdx), mode = :branch_active_power, target_branch = ("Slack", "Mid"), p_target_mw = p_ref - 3.0, control_ratio = false, control_phase = true, is_discrete = true, deadband_p_mw = 0.5, max_outer_iters = 12)
   run_net_acpflow(net = net_ctrl, max_ite = 30, tol = 1e-9, verbose = verbose, method = :rectangular, show_results = false)
   _print_snapshot(net_ctrl, "After branch active-power control")
 
   println("\n--- Schrägregler (coupled voltage + branch active power) ---")
   empty!(net_ctrl.tapControllers)
   p_ref2 = get_branch_p_from_to_mw(net_ctrl, "Slack", "Mid")
-  addTapController!(
+  addPowerTransformerControl!(
     net_ctrl;
     trafo = string(tbr.branchIdx),
     mode = :voltage_and_branch_active_power,

--- a/src/network.jl
+++ b/src/network.jl
@@ -777,6 +777,13 @@ function addPIModelTrafo!(;
   vn_lv_kV = getNodeVn(net.nodeVec[to])
   w1 = PowerTransformerWinding(vn_hv_kV, r_pu, x_pu, b_pu, 0.0, ratio, shift_deg, ratedU, ratedS, nothing, true)
   w2 = PowerTransformerWinding(vn_lv_kV, 0.0, 0.0)
+  if !isnothing(controls)
+    if side == 1
+      w1.controls = copy(controls)
+    elseif side == 2
+      w2.controls = copy(controls)
+    end
+  end
   comp = getTrafoImpPGMComp(isAux, vn_hv_kV, from, to)
   trafo = PowerTransformer(comp, false, w1, w2, nothing, Sparlectra.PIModel)
   push!(net.trafos, trafo)
@@ -955,6 +962,13 @@ function add2WTrafo!(; net::Net, fromBus::String, toBus::String, sn_mva::Float64
 
   trafo = create2WTRatioTransformerNoTaps(from = from, to = to, vn_hv_kV = vn_hv_kV, vn_lv_kV = vn_lv_kV, sn_mva = sn_mva, vk_percent = vk_percent, vkr_percent = vkr_percent, pfe_kw = pfe_kw, i0_percent = i0_percent)
   side = getSideNumber2WT(trafo)
+  if !isnothing(controls)
+    if side == 1
+      trafo.side1.controls = copy(controls)
+    elseif side == 2
+      trafo.side2.controls = copy(controls)
+    end
+  end
   ratio = calcTransformerRatio(trafo)
   push!(net.trafos, trafo)
 

--- a/src/network.jl
+++ b/src/network.jl
@@ -97,7 +97,7 @@ struct Net
   qmax_pu::Vector{Float64}            # pro Bus Qmax (p.u.)
   qLimitEvents::Dict{Int,Symbol}      # BusIdx -> :min | :max (PV→PQ Change)  
   measurements::Vector
-  tapControllers::Vector{Any}
+  tapControllers::Vector{PowerTransformerControl}
 
   #! format: off
   function Net(; name::String, baseMVA::Float64, vmin_pu::Float64 = 0.9, vmax_pu::Float64 = 1.1, cooldown_iters::Int = 0, q_hyst_pu::Float64 = 0.0, flatstart::Bool = false)    
@@ -129,7 +129,7 @@ struct Net
         [],                                    # qmax_pu
         Dict{Int,Symbol}(),
         [],
-        Any[])                                          
+        PowerTransformerControl[])                                          
   end
   #! format: on
   function Base.show(io::IO, net::Net)
@@ -768,6 +768,7 @@ function addPIModelTrafo!(;
   shift_deg::Union{Nothing,Float64} = nothing,
   isAux::Bool = false,
   side::Int = 1,
+  controls::Union{Nothing,Vector{PowerTransformerControl}} = nothing,
 )
   @assert fromBus != toBus "From and to bus must be different"
   from = geNetBusIdx(net = net, busName = fromBus)
@@ -781,6 +782,16 @@ function addPIModelTrafo!(;
   push!(net.trafos, trafo)
 
   addBranch!(net = net, from = from, to = to, branch = trafo, status = status, ratio = ratio, side = side, vn_kV = vn_hv_kV, values_are_pu = true)
+  if !isnothing(controls)
+    br = net.branchVec[end]
+    for ctrl in controls
+      addPowerTransformerControl!(net; trafo = string(br.branchIdx), mode = ctrl.mode, target_bus = ctrl.target_bus, target_branch = ctrl.target_branch,
+        target_vm_pu = ctrl.target_vm_pu, p_target_mw = ctrl.p_target_mw, q_target_mvar = ctrl.q_target_mvar,
+        control_ratio = ctrl.control_ratio, control_phase = ctrl.control_phase, is_discrete = ctrl.is_discrete,
+        deadband_vm_pu = ctrl.deadband_vm_pu, deadband_p_mw = ctrl.deadband_p_mw, voltage_error_metric = ctrl.voltage_error_metric,
+        max_outer_iters = ctrl.max_outer_iters, enabled = ctrl.enabled)
+    end
+  end
 end
 
 """
@@ -935,7 +946,7 @@ Add a two-winding transformer to the network.
 - `i0_percent::Float64`: No-load current percent of the transformer.
 - `status::Int`: The status of the transformer. Default is 1.
 """
-function add2WTrafo!(; net::Net, fromBus::String, toBus::String, sn_mva::Float64, vk_percent::Float64, vkr_percent::Float64, pfe_kw::Float64, i0_percent::Float64, status::Int = 1)
+function add2WTrafo!(; net::Net, fromBus::String, toBus::String, sn_mva::Float64, vk_percent::Float64, vkr_percent::Float64, pfe_kw::Float64, i0_percent::Float64, status::Int = 1, controls::Union{Nothing,Vector{PowerTransformerControl}} = nothing)
   @assert fromBus != toBus "From and to bus must be different"
   from = geNetBusIdx(net = net, busName = fromBus)
   to = geNetBusIdx(net = net, busName = toBus)
@@ -948,6 +959,16 @@ function add2WTrafo!(; net::Net, fromBus::String, toBus::String, sn_mva::Float64
   push!(net.trafos, trafo)
 
   addBranch!(net = net, from = from, to = to, branch = trafo, status = status, ratio = ratio, side = side, vn_kV = vn_hv_kV)
+  if !isnothing(controls)
+    br = net.branchVec[end]
+    for ctrl in controls
+      addPowerTransformerControl!(net; trafo = string(br.branchIdx), mode = ctrl.mode, target_bus = ctrl.target_bus, target_branch = ctrl.target_branch,
+        target_vm_pu = ctrl.target_vm_pu, p_target_mw = ctrl.p_target_mw, q_target_mvar = ctrl.q_target_mvar,
+        control_ratio = ctrl.control_ratio, control_phase = ctrl.control_phase, is_discrete = ctrl.is_discrete,
+        deadband_vm_pu = ctrl.deadband_vm_pu, deadband_p_mw = ctrl.deadband_p_mw, voltage_error_metric = ctrl.voltage_error_metric,
+        max_outer_iters = ctrl.max_outer_iters, enabled = ctrl.enabled)
+    end
+  end
 end
 
 """

--- a/src/tap_control.jl
+++ b/src/tap_control.jl
@@ -1,68 +1,5 @@
 # Copyright 2023–2026 Udo Schmitz
 
-"""
-    TapController
-
-Outer-loop transformer controller definition.
-
-# Fields
-- `trafo`: Transformer identifier (branch component name/id or branch index as `String`).
-- `mode`: `:voltage`, `:branch_active_power`, or `:voltage_and_branch_active_power`.
-- `target_bus`: Controlled bus name for voltage mode.
-- `target_branch`: Controlled branch tuple `(fromBus, toBus)` for active-power mode.
-- `target_vm_pu`: Voltage target in p.u.
-- `p_target_mw`: Active-power target in MW.
-- `q_target_mvar`: Optional reactive-power target (reserved for future use).
-- `control_ratio`: Enable ratio (`τ`) updates.
-- `control_phase`: Enable phase (`φ`) updates.
-- `is_discrete`: Use discrete tap-step updates.
-- `deadband_vm_pu`: Voltage deadband.
-- `voltage_error_metric`: Error metric for voltage step direction (`:vm` or `:vm2`).
-- `deadband_p_mw`: Active-power deadband.
-- `max_outer_iters`: Maximum outer-loop iterations.
-- `enabled`: Enable/disable controller.
-- Runtime fields (`converged`, `at_limit`, `status`, `achieved_*`, `outer_iters`) are
-  updated by `run_tap_controllers_outer!`.
-"""
-mutable struct TapController
-  trafo::String
-  mode::Symbol
-  target_bus::Union{Nothing,String}
-  target_branch::Union{Nothing,Tuple{String,String}}
-  target_vm_pu::Union{Nothing,Float64}
-  p_target_mw::Union{Nothing,Float64}
-  q_target_mvar::Union{Nothing,Float64}
-  control_ratio::Bool
-  control_phase::Bool
-  is_discrete::Bool
-  deadband_vm_pu::Float64
-  deadband_p_mw::Float64
-  voltage_error_metric::Symbol
-  max_outer_iters::Int
-  enabled::Bool
-  converged::Bool
-  at_limit::Bool
-  status::Symbol
-  achieved_vm_pu::Union{Nothing,Float64}
-  achieved_p_mw::Union{Nothing,Float64}
-  outer_iters::Int
-end
-
-"""
-    TapController(; ...)
-
-Convenience constructor for `TapController` with sane defaults for outer-loop
-execution and status initialization.
-"""
-function TapController(; trafo::String, mode::Symbol, target_bus::Union{Nothing,String}=nothing, target_branch::Union{Nothing,Tuple{String,String}}=nothing,
-  target_vm_pu::Union{Nothing,Float64}=nothing, p_target_mw::Union{Nothing,Float64}=nothing, q_target_mvar::Union{Nothing,Float64}=nothing,
-  control_ratio::Bool=true, control_phase::Bool=false, is_discrete::Bool=true, deadband_vm_pu::Float64=1e-3, deadband_p_mw::Float64=0.5,
-  voltage_error_metric::Symbol=:vm, max_outer_iters::Int=20, enabled::Bool=true)
-  voltage_error_metric in (:vm, :vm2) || error("TapController: unsupported voltage_error_metric=$(voltage_error_metric). Use :vm or :vm2.")
-  return TapController(trafo, mode, target_bus, target_branch, target_vm_pu, p_target_mw, q_target_mvar, control_ratio, control_phase, is_discrete,
-    deadband_vm_pu, deadband_p_mw, voltage_error_metric, max_outer_iters, enabled, false, false, :idle, nothing, nothing, 0)
-end
-
 @inline _voltage_within_deadband(vm::Float64, target_vm_pu::Float64, deadband_vm_pu::Float64)::Bool = abs(vm - target_vm_pu) <= deadband_vm_pu
 @inline _voltage_control_error(vm::Float64, target_vm_pu::Float64, metric::Symbol)::Float64 = metric == :vm2 ? vm^2 - target_vm_pu^2 : vm - target_vm_pu
 
@@ -78,7 +15,7 @@ function _find_trafo_branch(net::Net, name::String)::Branch
       return br
     end
   end
-  error("TapController: transformer $(name) not found. Use branch component name/id or branch index as String.")
+  error("PowerTransformerControl: transformer $(name) not found. Use branch component name/id or branch index as String.")
 end
 
 """
@@ -117,7 +54,7 @@ end
 
 @inline _controller_mode_label(mode::Symbol) = String(mode)
 
-function _controller_type_label(ctrl::TapController, br::Branch)::String
+function _controller_type_label(ctrl::PowerTransformerControl, br::Branch)::String
   ratio = ctrl.control_ratio && br.has_ratio_tap
   phase = ctrl.control_phase && br.has_phase_tap
   if ratio && phase
@@ -130,7 +67,7 @@ function _controller_type_label(ctrl::TapController, br::Branch)::String
   return "fixed transformer"
 end
 
-function _controller_status_label(ctrl::TapController)::String
+function _controller_status_label(ctrl::PowerTransformerControl)::String
   !ctrl.enabled && return "inactive"
   ctrl.converged && return "converged"
   ctrl.at_limit && return "at_limit"
@@ -193,7 +130,7 @@ function buildTapControllerReportRows(net::Net)::Vector{NamedTuple}
 end
 
 """
-    addTapController!(net; ...)
+    addPowerTransformerControl!(net; ...)
 
 Add and validate a transformer tap controller.
 
@@ -202,27 +139,30 @@ Validation rules:
 - Required target fields must be set according to `mode`.
 - `control_ratio` / `control_phase` must match the chosen mode.
 """
-function addTapController!(net::Net; trafo::String, mode::Symbol, target_bus::Union{Nothing,String}=nothing, target_branch::Union{Nothing,Tuple{String,String}}=nothing,
+function addPowerTransformerControl!(net::Net; trafo::String, mode::Symbol, target_bus::Union{Nothing,String}=nothing, target_branch::Union{Nothing,Tuple{String,String}}=nothing,
   target_vm_pu::Union{Nothing,Float64}=nothing, p_target_mw::Union{Nothing,Float64}=nothing, q_target_mvar::Union{Nothing,Float64}=nothing,
   control_ratio::Bool=true, control_phase::Bool=false, is_discrete::Bool=true, deadband_vm_pu::Float64=1e-3, deadband_p_mw::Float64=0.5,
   voltage_error_metric::Symbol=:vm, max_outer_iters::Int=20, enabled::Bool=true)
 
-  _ = _find_trafo_branch(net, trafo)
-  any(c -> c.trafo == trafo && c.enabled, net.tapControllers) && error("TapController: only one active controller per transformer is allowed.")
-  mode in (:voltage, :branch_active_power, :voltage_and_branch_active_power) || error("TapController: unsupported mode=$(mode)")
+  br = _find_trafo_branch(net, trafo)
+  trafo_obj = findfirst(t -> t.comp.cName == br.comp.cName || t.comp.cID == br.comp.cID, net.trafos)
+  max_controls = isnothing(trafo_obj) ? 1 : max(1, net.trafos[trafo_obj].nController)
+  n_active = count(c -> c.trafo == trafo && c.enabled, net.tapControllers)
+  n_active >= max_controls && error("PowerTransformerControl: transformer $(trafo) allows at most $(max_controls) active controller(s).")
+  mode in (:voltage, :branch_active_power, :voltage_and_branch_active_power) || error("PowerTransformerControl: unsupported mode=$(mode)")
 
   if mode in (:voltage, :voltage_and_branch_active_power)
-    isnothing(target_bus) && error("TapController: target_bus is required for mode=$(mode)")
-    isnothing(target_vm_pu) && error("TapController: target_vm_pu is required for mode=$(mode)")
-    !control_ratio && error("TapController: control_ratio must be true for voltage control")
+    isnothing(target_bus) && error("PowerTransformerControl: target_bus is required for mode=$(mode)")
+    isnothing(target_vm_pu) && error("PowerTransformerControl: target_vm_pu is required for mode=$(mode)")
+    !control_ratio && error("PowerTransformerControl: control_ratio must be true for voltage control")
   end
   if mode in (:branch_active_power, :voltage_and_branch_active_power)
-    isnothing(target_branch) && error("TapController: target_branch is required for mode=$(mode)")
-    isnothing(p_target_mw) && error("TapController: p_target_mw is required for mode=$(mode)")
-    !control_phase && error("TapController: control_phase must be true for branch active power control")
+    isnothing(target_branch) && error("PowerTransformerControl: target_branch is required for mode=$(mode)")
+    isnothing(p_target_mw) && error("PowerTransformerControl: p_target_mw is required for mode=$(mode)")
+    !control_phase && error("PowerTransformerControl: control_phase must be true for branch active power control")
   end
 
-  push!(net.tapControllers, TapController(;
+  push!(net.tapControllers, PowerTransformerControl(;
     trafo = trafo,
     mode = mode,
     target_bus = target_bus,
@@ -242,6 +182,8 @@ function addTapController!(net::Net; trafo::String, mode::Symbol, target_bus::Un
   return net
 end
 
+addTapController!(net::Net; kwargs...) = addPowerTransformerControl!(net; kwargs...)
+
 """
     _phase_probe_direction(...)
 
@@ -249,7 +191,7 @@ Internal helper: determines the empirical sign of `ΔP_from_to` for a positive
 phase increment (`+phase_step_deg`) on the controlled transformer and branch.
 Returns `-1`, `0`, or `+1`.
 """
-function _phase_probe_direction(net::Net, br::Branch, ctrl::TapController, max_ite::Int, tol::Float64, verbose::Int, opt_fd::Bool, opt_sparse::Bool, method::Symbol)
+function _phase_probe_direction(net::Net, br::Branch, ctrl::PowerTransformerControl, max_ite::Int, tol::Float64, verbose::Int, opt_fd::Bool, opt_sparse::Bool, method::Symbol)
   oldphi = br.phase_shift_deg
   step = br.phase_step_deg
   _, erg = runpf!(net, max_ite, tol, verbose; opt_fd = opt_fd, opt_sparse = opt_sparse, method = method)
@@ -271,7 +213,7 @@ Internal helper: determines the empirical sign of `ΔVm_target` for a positive
 ratio increment (`+tap_step`) on the controlled transformer and target bus.
 Returns `-1`, `0`, or `+1`.
 """
-function _ratio_probe_direction(net::Net, br::Branch, ctrl::TapController, max_ite::Int, tol::Float64, verbose::Int, opt_fd::Bool, opt_sparse::Bool, method::Symbol)
+function _ratio_probe_direction(net::Net, br::Branch, ctrl::PowerTransformerControl, max_ite::Int, tol::Float64, verbose::Int, opt_fd::Bool, opt_sparse::Bool, method::Symbol)
   oldratio = br.tap_ratio
   step = br.tap_step
   _, erg = runpf!(net, max_ite, tol, verbose; opt_fd = opt_fd, opt_sparse = opt_sparse, method = method)

--- a/src/transformer.jl
+++ b/src/transformer.jl
@@ -178,6 +178,53 @@ mutable struct PowerTransformerTaps
   end
 end
 
+"""
+    PowerTransformerControl
+
+Transformer outer-loop transformer controller channel.
+"""
+mutable struct PowerTransformerControl
+  trafo::String
+  mode::Symbol
+  target_bus::Union{Nothing,String}
+  target_branch::Union{Nothing,Tuple{String,String}}
+  target_vm_pu::Union{Nothing,Float64}
+  p_target_mw::Union{Nothing,Float64}
+  q_target_mvar::Union{Nothing,Float64}
+  control_ratio::Bool
+  control_phase::Bool
+  is_discrete::Bool
+  deadband_vm_pu::Float64
+  deadband_p_mw::Float64
+  voltage_error_metric::Symbol
+  max_outer_iters::Int
+  enabled::Bool
+  converged::Bool
+  at_limit::Bool
+  status::Symbol
+  achieved_vm_pu::Union{Nothing,Float64}
+  achieved_p_mw::Union{Nothing,Float64}
+  outer_iters::Int
+end
+
+function PowerTransformerControl(; trafo::String, mode::Symbol, target_bus::Union{Nothing,String} = nothing, target_branch::Union{Nothing,Tuple{String,String}} = nothing,
+  target_vm_pu::Union{Nothing,Float64} = nothing, p_target_mw::Union{Nothing,Float64} = nothing, q_target_mvar::Union{Nothing,Float64} = nothing,
+  control_ratio::Bool = true, control_phase::Bool = false, is_discrete::Bool = true, deadband_vm_pu::Float64 = 1e-3, deadband_p_mw::Float64 = 0.5,
+  voltage_error_metric::Symbol = :vm, max_outer_iters::Int = 20, enabled::Bool = true)
+  voltage_error_metric in (:vm, :vm2) || error("PowerTransformerControl: unsupported voltage_error_metric=$(voltage_error_metric). Use :vm or :vm2.")
+  return PowerTransformerControl(trafo, mode, target_bus, target_branch, target_vm_pu, p_target_mw, q_target_mvar, control_ratio, control_phase, is_discrete,
+    deadband_vm_pu, deadband_p_mw, voltage_error_metric, max_outer_iters, enabled, false, false, :idle, nothing, nothing, 0)
+end
+
+@inline function expected_controller_count(trafoTyp::TrafoTyp)::Int
+  if trafoTyp == Ratio || trafoTyp == PhaseShifter
+    return 1
+  elseif trafoTyp == PhaseTapChanger
+    return 2
+  end
+  return 0
+end
+
 #= not implemented
 function adjustVkDep(Vk::Float64, Vkmax::Float64, Vkmin::Float64, tap::PowerTransformerTaps)
   if isnothing(tap)
@@ -217,6 +264,7 @@ A mutable structure representing a winding of a power transformer.
 - `ratedU::Union{Nothing,Float64}`: The rated voltage of the winding.
 - `ratedS::Union{Nothing,Float64}`: The rated power of the winding.
 - `taps::Union{Nothing,PowerTransformerTaps}`: The tap settings of the winding.
+- `controls::Vector{PowerTransformerControl}`: Controllers assigned to this winding side.
 - `isPu_RXGB::Union{Nothing,Bool}`: Whether the resistance, reactance, susceptance, and conductance are given in per unit.
 - `modelData::Union{Nothing,TransformerModelParameters}`: The model parameters of the transformer.
 - `_isEmpty::Bool`: Whether the has no model data.
@@ -239,6 +287,7 @@ mutable struct PowerTransformerWinding
   ratedU::Union{Nothing,Float64}             # cim:PowerTransformerEnd.ratedU
   ratedS::Union{Nothing,Float64}             # cim:PowerTransformerEnd.ratedS  
   taps::Union{Nothing,PowerTransformerTaps}
+  controls::Vector{PowerTransformerControl}
   isPu_RXGB::Union{Nothing,Bool}          # r,x,b in p.u. given? nothing = false
   modelData::Union{Nothing,TransformerModelParameters}
   _isEmpty::Bool
@@ -256,8 +305,10 @@ mutable struct PowerTransformerWinding
     taps::Union{Nothing,PowerTransformerTaps} = nothing,
     isPu_RXGB::Union{Nothing,Bool} = nothing,
     modelData::Union{Nothing,TransformerModelParameters} = nothing,
+    controls::Union{Nothing,Vector{PowerTransformerControl}} = nothing,
   )
-    new(Vn, r, x, b, g, ratio, shift_degree, ratedU, ratedS, taps, isPu_RXGB, modelData, isnothing(modelData))
+    ctrls = isnothing(controls) ? PowerTransformerControl[] : controls
+    new(Vn, r, x, b, g, ratio, shift_degree, ratedU, ratedS, taps, ctrls, isPu_RXGB, modelData, isnothing(modelData))
   end
 
   function PowerTransformerWinding(;
@@ -268,6 +319,7 @@ mutable struct PowerTransformerWinding
     ratedU::Union{Nothing,Float64} = nothing,
     ratedS::Union{Nothing,Float64} = nothing,
     taps::Union{Nothing,PowerTransformerTaps} = nothing,
+    controls::Union{Nothing,Vector{PowerTransformerControl}} = nothing,
   )
     @assert Vn_kV > 0.0 "Vn_kv must be > 0.0"
     if isnothing(ratedU)
@@ -275,10 +327,12 @@ mutable struct PowerTransformerWinding
     end
 
     if isnothing(modelData)
-      new(Vn_kV, 0.0, 0.0, 0.0, 0.0, ratio, shift_degree, ratedU, ratedS, taps, false, nothing, true)
+      ctrls = isnothing(controls) ? PowerTransformerControl[] : controls
+      new(Vn_kV, 0.0, 0.0, 0.0, 0.0, ratio, shift_degree, ratedU, ratedS, taps, ctrls, false, nothing, true)
     else
       r, x, b, g = calcTransformerRXGB(ratedU, modelData)
-      new(Vn_kV, r, x, b, g, ratio, shift_degree, ratedU, ratedS, taps, false, modelData, false)
+      ctrls = isnothing(controls) ? PowerTransformerControl[] : controls
+      new(Vn_kV, r, x, b, g, ratio, shift_degree, ratedU, ratedS, taps, ctrls, false, modelData, false)
     end
   end
 
@@ -307,6 +361,9 @@ mutable struct PowerTransformerWinding
     end
     if !isnothing(x.taps)
       print(io, "taps=$(x.taps), ")
+    end
+    if !isempty(x.controls)
+      print(io, "controls=$(length(x.controls)), ")
     end
     if !isnothing(x.isPu_RXGB)
       print(io, "isPu_RXGB=$(x.isPu_RXGB), ")
@@ -387,6 +444,14 @@ function hasTaps(x::Union{Nothing,PowerTransformerWinding})::Bool
   end
 end
 
+@inline function hasControls(x::Union{Nothing,PowerTransformerWinding})::Bool
+  return !(isnothing(x)) && !isempty(x.controls)
+end
+
+@inline function countWindingControls(x::Union{Nothing,PowerTransformerWinding})::Int
+  return isnothing(x) ? 0 : length(x.controls)
+end
+
 function isPerUnit_RXGB(o::PowerTransformerWinding)
   if isnothing(o.isPu_RXGB)
     return false
@@ -405,60 +470,6 @@ function getWindingRatedS(o::PowerTransformerWinding)
   else
     return o.ratedS
   end
-end
-
-"""
-    PowerTransformerControl
-
-Transformer outer-loop controller definition.
-
-# Notes
-- One `PowerTransformerControl` instance represents one controller channel.
-- Typical channel count by transformer type:
-  - `Ratio` (OLTC): 1
-  - `PhaseShifter` (PST): 1
-  - `PhaseTapChanger` (Schrägregler / STE): 2 (ratio + phase)
-"""
-mutable struct PowerTransformerControl
-  trafo::String
-  mode::Symbol
-  target_bus::Union{Nothing,String}
-  target_branch::Union{Nothing,Tuple{String,String}}
-  target_vm_pu::Union{Nothing,Float64}
-  p_target_mw::Union{Nothing,Float64}
-  q_target_mvar::Union{Nothing,Float64}
-  control_ratio::Bool
-  control_phase::Bool
-  is_discrete::Bool
-  deadband_vm_pu::Float64
-  deadband_p_mw::Float64
-  voltage_error_metric::Symbol
-  max_outer_iters::Int
-  enabled::Bool
-  converged::Bool
-  at_limit::Bool
-  status::Symbol
-  achieved_vm_pu::Union{Nothing,Float64}
-  achieved_p_mw::Union{Nothing,Float64}
-  outer_iters::Int
-end
-
-function PowerTransformerControl(; trafo::String, mode::Symbol, target_bus::Union{Nothing,String} = nothing, target_branch::Union{Nothing,Tuple{String,String}} = nothing,
-  target_vm_pu::Union{Nothing,Float64} = nothing, p_target_mw::Union{Nothing,Float64} = nothing, q_target_mvar::Union{Nothing,Float64} = nothing,
-  control_ratio::Bool = true, control_phase::Bool = false, is_discrete::Bool = true, deadband_vm_pu::Float64 = 1e-3, deadband_p_mw::Float64 = 0.5,
-  voltage_error_metric::Symbol = :vm, max_outer_iters::Int = 20, enabled::Bool = true)
-  voltage_error_metric in (:vm, :vm2) || error("PowerTransformerControl: unsupported voltage_error_metric=$(voltage_error_metric). Use :vm or :vm2.")
-  return PowerTransformerControl(trafo, mode, target_bus, target_branch, target_vm_pu, p_target_mw, q_target_mvar, control_ratio, control_phase, is_discrete,
-    deadband_vm_pu, deadband_p_mw, voltage_error_metric, max_outer_iters, enabled, false, false, :idle, nothing, nothing, 0)
-end
-
-@inline function expected_controller_count(trafoTyp::TrafoTyp)::Int
-  if trafoTyp == Ratio || trafoTyp == PhaseShifter
-    return 1
-  elseif trafoTyp == PhaseTapChanger
-    return 2
-  end
-  return 0
 end
 """
     PowerTransformer
@@ -517,16 +528,23 @@ mutable struct PowerTransformer <: AbstractBranch
     end
 
     taps_controller = 0
+    winding_controller = 0
     TapSideNumber = 0
     for x in [s1, s2, s3]
+      has_ctrl = hasControls(x)
       if hasTaps(x)
         taps_controller += 1
-        if taps_controller == 1
+      end
+      if has_ctrl
+        winding_controller += countWindingControls(x)
+      end
+      if hasTaps(x) || has_ctrl
+        if TapSideNumber == 0
           TapSideNumber = x == s1 ? 1 : (x == s2 ? 2 : 3)
         end
       end
     end
-    controller = tapEnable ? max(taps_controller, expected_controller_count(trafoTyp)) : taps_controller
+    controller = tapEnable ? max(taps_controller + winding_controller, expected_controller_count(trafoTyp)) : (taps_controller + winding_controller)
 
     v1 = s1.Vn
     v2 = s2.Vn

--- a/src/transformer.jl
+++ b/src/transformer.jl
@@ -406,6 +406,60 @@ function getWindingRatedS(o::PowerTransformerWinding)
     return o.ratedS
   end
 end
+
+"""
+    PowerTransformerControl
+
+Transformer outer-loop controller definition.
+
+# Notes
+- One `PowerTransformerControl` instance represents one controller channel.
+- Typical channel count by transformer type:
+  - `Ratio` (OLTC): 1
+  - `PhaseShifter` (PST): 1
+  - `PhaseTapChanger` (Schrägregler / STE): 2 (ratio + phase)
+"""
+mutable struct PowerTransformerControl
+  trafo::String
+  mode::Symbol
+  target_bus::Union{Nothing,String}
+  target_branch::Union{Nothing,Tuple{String,String}}
+  target_vm_pu::Union{Nothing,Float64}
+  p_target_mw::Union{Nothing,Float64}
+  q_target_mvar::Union{Nothing,Float64}
+  control_ratio::Bool
+  control_phase::Bool
+  is_discrete::Bool
+  deadband_vm_pu::Float64
+  deadband_p_mw::Float64
+  voltage_error_metric::Symbol
+  max_outer_iters::Int
+  enabled::Bool
+  converged::Bool
+  at_limit::Bool
+  status::Symbol
+  achieved_vm_pu::Union{Nothing,Float64}
+  achieved_p_mw::Union{Nothing,Float64}
+  outer_iters::Int
+end
+
+function PowerTransformerControl(; trafo::String, mode::Symbol, target_bus::Union{Nothing,String} = nothing, target_branch::Union{Nothing,Tuple{String,String}} = nothing,
+  target_vm_pu::Union{Nothing,Float64} = nothing, p_target_mw::Union{Nothing,Float64} = nothing, q_target_mvar::Union{Nothing,Float64} = nothing,
+  control_ratio::Bool = true, control_phase::Bool = false, is_discrete::Bool = true, deadband_vm_pu::Float64 = 1e-3, deadband_p_mw::Float64 = 0.5,
+  voltage_error_metric::Symbol = :vm, max_outer_iters::Int = 20, enabled::Bool = true)
+  voltage_error_metric in (:vm, :vm2) || error("PowerTransformerControl: unsupported voltage_error_metric=$(voltage_error_metric). Use :vm or :vm2.")
+  return PowerTransformerControl(trafo, mode, target_bus, target_branch, target_vm_pu, p_target_mw, q_target_mvar, control_ratio, control_phase, is_discrete,
+    deadband_vm_pu, deadband_p_mw, voltage_error_metric, max_outer_iters, enabled, false, false, :idle, nothing, nothing, 0)
+end
+
+@inline function expected_controller_count(trafoTyp::TrafoTyp)::Int
+  if trafoTyp == Ratio || trafoTyp == PhaseShifter
+    return 1
+  elseif trafoTyp == PhaseTapChanger
+    return 2
+  end
+  return 0
+end
 """
     PowerTransformer
 
@@ -462,16 +516,17 @@ mutable struct PowerTransformer <: AbstractBranch
       equiParms = 3
     end
 
-    controller = 0
+    taps_controller = 0
     TapSideNumber = 0
     for x in [s1, s2, s3]
       if hasTaps(x)
-        controller += 1
-        if controller == 1
+        taps_controller += 1
+        if taps_controller == 1
           TapSideNumber = x == s1 ? 1 : (x == s2 ? 2 : 3)
         end
       end
     end
+    controller = tapEnable ? max(taps_controller, expected_controller_count(trafoTyp)) : taps_controller
 
     v1 = s1.Vn
     v2 = s2.Vn

--- a/test/test_tap_controller.jl
+++ b/test/test_tap_controller.jl
@@ -168,5 +168,7 @@ function run_tap_controller_tests()
     addPIModelTrafo!(net = net, fromBus = "B1", toBus = "B2", r_pu = 0.01, x_pu = 0.08, b_pu = 0.0, ratio = 1.0, shift_deg = 0.0, status = 1, controls = [ctrl])
     @test length(net.tapControllers) == 1
     @test net.tapControllers[1].trafo == string(getNetBranch(net = net, fromBus = "B1", toBus = "B2").branchIdx)
+    @test length(net.trafos[1].side1.controls) == 1
+    @test net.trafos[1].tapSideNumber == 1
   end
 end

--- a/test/test_tap_controller.jl
+++ b/test/test_tap_controller.jl
@@ -28,9 +28,9 @@ function run_tap_controller_tests()
 
   @testset "Tap controller API validation" begin
     net, _ = _build_net()
-    @test_throws ErrorException addTapController!(net; trafo = "does_not_exist", mode = :voltage, target_bus = "Load", target_vm_pu = 1.0)
-    @test_throws ErrorException addTapController!(net; trafo = "1", mode = :voltage)
-    @test_throws ErrorException addTapController!(net; trafo = "1", mode = :voltage, target_bus = "Load", target_vm_pu = 1.0, voltage_error_metric = :invalid)
+    @test_throws ErrorException addPowerTransformerControl!(net; trafo = "does_not_exist", mode = :voltage, target_bus = "Load", target_vm_pu = 1.0)
+    @test_throws ErrorException addPowerTransformerControl!(net; trafo = "1", mode = :voltage)
+    @test_throws ErrorException addPowerTransformerControl!(net; trafo = "1", mode = :voltage, target_bus = "Load", target_vm_pu = 1.0, voltage_error_metric = :invalid)
   end
 
   @testset "Voltage deadband is evaluated in pu Vm space" begin
@@ -47,7 +47,7 @@ function run_tap_controller_tests()
     vm0 = get_bus_vm_pu(net, "Load")
     @test vm0 > 0.98
 
-    addTapController!(net;
+    addPowerTransformerControl!(net;
       trafo = string(tbr.branchIdx),
       mode = :voltage,
       target_bus = "Load",
@@ -77,7 +77,7 @@ function run_tap_controller_tests()
     @test erg0 == 0
     p0 = get_branch_p_from_to_mw(net, "Slack", "Mid")
 
-    addTapController!(net;
+    addPowerTransformerControl!(net;
       trafo = string(tbr.branchIdx),
       mode = :branch_active_power,
       target_branch = ("Slack", "Mid"),
@@ -96,7 +96,7 @@ function run_tap_controller_tests()
 
   @testset "Tap controller reporting rows and classic section" begin
     net, tbr = _build_net()
-    addTapController!(net;
+    addPowerTransformerControl!(net;
       trafo = string(tbr.branchIdx),
       mode = :voltage_and_branch_active_power,
       target_bus = "Load",
@@ -153,5 +153,20 @@ function run_tap_controller_tests()
     @test isapprox(br.tap_min, expected_min; atol = 1e-12)
     @test isapprox(br.tap_max, expected_max; atol = 1e-12)
     @test isapprox(br.tap_step, expected_step; atol = 1e-12)
+  end
+
+  @testset "Controller can be attached during transformer creation" begin
+    net = Net(name = "tap_ctrl_on_create", baseMVA = 100.0)
+    addBus!(net = net, busName = "B1", vn_kV = 110.0)
+    addBus!(net = net, busName = "B2", vn_kV = 110.0)
+    addBus!(net = net, busName = "B3", vn_kV = 110.0)
+    addProsumer!(net = net, busName = "B1", type = "EXTERNALNETWORKINJECTION", vm_pu = 1.01, va_deg = 0.0, referencePri = "B1")
+    addProsumer!(net = net, busName = "B3", type = "ENERGYCONSUMER", p = -20.0, q = -5.0)
+    addPIModelACLine!(net = net, fromBus = "B2", toBus = "B3", r_pu = 0.02, x_pu = 0.12, b_pu = 0.01, status = 1)
+
+    ctrl = PowerTransformerControl(trafo = "", mode = :voltage, target_bus = "B3", target_vm_pu = 0.99, control_ratio = true, control_phase = false)
+    addPIModelTrafo!(net = net, fromBus = "B1", toBus = "B2", r_pu = 0.01, x_pu = 0.08, b_pu = 0.0, ratio = 1.0, shift_deg = 0.0, status = 1, controls = [ctrl])
+    @test length(net.tapControllers) == 1
+    @test net.tapControllers[1].trafo == string(getNetBranch(net = net, fromBus = "B1", toBus = "B2").branchIdx)
   end
 end


### PR DESCRIPTION
### Motivation

- Provide a canonical transformer controller model (`PowerTransformerControl`) and derive the number of controller channels from transformer type (e.g. OLTC=1, PST=1, STE=2).  
- Allow attaching controller definitions at transformer creation so network construction can declare controls up-front.  
- Keep existing tap-controller behavior while making the data model explicit and typed to improve validation and clarity.

### Description

- Added `PowerTransformerControl` (struct + constructor) and `expected_controller_count` in `src/transformer.jl` and use it to set `PowerTransformer.nController` during `PowerTransformer` construction.  
- Refactored tap-controller code in `src/tap_control.jl` to use `PowerTransformerControl`, introduced `addPowerTransformerControl!` as the primary API, and retained `addTapController!` as a thin alias.  
- Typed `Net.tapControllers` as `Vector{PowerTransformerControl}` and extended transformer-creation APIs (`addPIModelTrafo!`, `add2WTrafo!`) with an optional `controls::Union{Nothing,Vector{PowerTransformerControl}}` argument that attaches controllers to the newly created transformer.  
- Updated module exports, documentation (`docs/src/transformer_control.md`, `docs/src/changelog.md`), examples (`src/examples/example_transformer_tap.jl`) and tests (`test/test_tap_controller.jl`) to use the new API and to add a regression test for attaching controls during transformer creation.

### Testing

- Verified toolchain with `which julia && julia --version` (Julia present).  
- Ran the full test suite with `julia --project=. test/runtests.jl` and all tests passed (`Sparlectra.jl | 286 / 286 passed`, suite completed successfully).  
- Ran `julia --project=. test/test_tap_controller.jl` directly which fails when invoked as a standalone script due to missing `@testset` import (error: `UndefVarError: @testset not defined in Main`); this is expected when executing that file outside the package test harness and does not affect the full `test/runtests.jl` run that succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f06a5a205483308df11ae56f4dd558)