### PR TITLE
Add dependency-free YAML parser and synthetic tiled-grid benchmark with docs, example and tests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,6 +23,7 @@ makedocs(
     "Network Reports" => "netreports.md",
     "Power Limits" => "powerlimits.md",
     "Solver" => "solver.md",
+    "Synthetic Tiled Grids" => "synthetic_grids.md",
     "Voltage Dependent Control" => "voltage_dependent_control.md",
     "Transformer Control" => "transformer_control.md",
     "Examples Overview" => "examples_overview.md",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,7 @@
 # Change Log
 ## Version 0.7.4 – 2026-06-02
+- **Feature**: Added a dependency-free YAML subset parser and a synthetic tiled-grid AC network builder, including a YAML-driven benchmark example for scalable power-flow diagnostics.
+- **Bugfix**: Synthetic tiled-grid benchmark example now falls back from `.yaml` to `.yaml.example` and reports when built-in defaults are used.
 ### Improvements
 * Improved large-network MATPOWER and rectangular-solver performance by aggregating prosumer-derived bus types and specified power injections in linear time.
 * 

--- a/docs/src/feature_matrix.md
+++ b/docs/src/feature_matrix.md
@@ -25,6 +25,7 @@ Legend:
 | Shunts / loads / generators in `Net` model | ✅ | ✅ | Shared physical network model and component handling. |
 | Voltage-dependent prosumer control (`Q(U)`, `P(U)`) | ✅ | ❌ | Implemented for PF with controller-aware mismatch/Jacobian terms in rectangular formulation; not part of SE model. |
 | MATPOWER import / cases | ✅ | ✅ | Typical SE studies can start from imported PF-ready networks. |
+| Synthetic tiled-grid generator | ✅ | ⚠️ | `build_synthetic_tiled_grid_net` creates artificial one-voltage-level AC PF benchmark networks; SE can use the resulting `Net` as an artificial study case when measurements are supplied. |
 
 ## Solvers, operations & limits
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,5 +19,6 @@ Markdown.parse(readme_text)
 ## Documentation quick links
 
 * [Feature Matrix](feature_matrix.md)
+* [Synthetic Tiled Grids](synthetic_grids.md)
 * [Transformer Control](transformer_control.md)
 * [Examples Overview](examples_overview.md)

--- a/docs/src/synthetic_grids.md
+++ b/docs/src/synthetic_grids.md
@@ -1,0 +1,117 @@
+# Synthetic Tiled Grids
+
+Sparlectra includes a dependency-free synthetic tiled-grid builder for creating
+simple, reproducible AC power-flow benchmark networks directly from Julia code.
+The builder is useful when you want scalable network sizes without reading a
+MATPOWER, CGMES, or other external case file.
+
+## Builder API
+
+```julia
+using Sparlectra
+
+net, meta = build_synthetic_tiled_grid_net(1000; aspect_ratio = 1.0)
+ite, erg, elapsed_s = run_net_acpflow(net = net, show_results = false)
+```
+
+`build_tiled_grid_net` is an alias for `build_synthetic_tiled_grid_net`.
+The requested bus limit is an upper bound: Sparlectra chooses the largest
+rectangular grid with `rows * cols <= max_buses` while keeping `cols / rows`
+close to `aspect_ratio`.
+
+## Topology
+
+The generated network is a one-voltage-level rectangular grid with deterministic
+row-major bus numbering:
+
+```julia
+synthetic_tiled_grid_bus_index(row, col, cols) = (row - 1) * cols + col
+```
+
+Bus names use the readable form `B_001_001`, `B_001_002`, and so on. The branch
+set contains:
+
+* horizontal PI-model AC lines between neighboring columns,
+* vertical PI-model AC lines between neighboring rows,
+* one diagonal PI-model AC line per rectangular tile from the upper-left bus to
+  the lower-right bus.
+
+The expected branch count is
+
+```math
+N_{branch} = rows(cols - 1) + (rows - 1)cols + (rows - 1)(cols - 1).
+```
+
+All synthetic branches use the Sparlectra AC PI branch convention. The series
+impedance is `r + im*x` in p.u. and the total shunt admittance is `g + im*b` in
+p.u.; Sparlectra splits the branch shunt half/half in Y-bus and branch-flow
+calculations.
+
+## Electrical setup
+
+The default bus role assignment follows the synthetic benchmark convention:
+
+* upper-left bus: slack bus,
+* lower-left bus: scheduled generator bus,
+* upper-right and lower-right buses: scheduled PQ load buses,
+* all non-slack buses start with `vm_flat`, while the slack bus uses `vm_slack`.
+
+Default parameters are intentionally modest:
+
+```julia
+aspect_ratio = 1.0
+base_mva = 100.0
+r = 0.01
+x = 0.05
+g = 0.0
+b = 0.0
+load_mw_per_right_corner = 50.0
+load_mvar_per_right_corner = 15.0
+generation_balance = 0.995
+vm_slack = 1.0
+vm_flat = 1.0
+```
+
+Metadata returned by the builder includes requested and actual bus counts,
+`rows`, `cols`, `branch_count`, bus role lists, and scheduled generation/load
+values. Scheduled power metadata is reported in MW/MVAr. Line parameters and
+voltage magnitudes are reported in p.u.
+
+## YAML configuration utility
+
+The example benchmark uses Sparlectra's small YAML subset parser:
+
+```julia
+cfg = load_yaml_dict("src/examples/exp_synthetic_tiled_grid_pf_perf.yaml.example")
+```
+
+This parser is intentionally not a full YAML implementation. It supports only
+simple example-configuration files: comments beginning with `#`, nested
+2-space-indented dictionaries, scalar key-value pairs, booleans, `null`/`~`,
+integers, floating-point numbers, symbols such as `:rectangular`, strings, and
+one-line scalar lists such as `[100, 300, 500]`.
+
+## Running the example
+
+```bash
+julia --project=. src/examples/exp_synthetic_tiled_grid_pf_perf.jl
+julia --project=. src/examples/exp_synthetic_tiled_grid_pf_perf.jl 100 300 1000
+julia --project=. src/examples/exp_synthetic_tiled_grid_pf_perf.jl src/examples/exp_synthetic_tiled_grid_pf_perf.yaml
+# if the .yaml file is missing, the runner tries .yaml.example automatically
+julia --project=. src/examples/exp_synthetic_tiled_grid_pf_perf.jl src/examples/exp_synthetic_tiled_grid_pf_perf.yaml --max-buses=5000
+```
+
+When no configuration path is supplied, or when neither the requested YAML file nor its `.yaml.example` fallback is available, the example prints a message before using its built-in defaults. The example prints a compact summary with grid size, branch count, convergence,
+iterations, solve time, mismatch diagnostics, system-build timing, allocation
+counts, and total case runtime. It also writes a timestamped log file under
+`src/examples/_out` and prints a small ASCII plot of `nbus` versus solve time.
+
+## Limitations
+
+* The synthetic grid is artificial and intended for solver scaling,
+  diagnostics, and regression checks.
+* It is a one-voltage-level grid.
+* It does not represent realistic protection, voltage-level, transformer, or
+  operational constraints.
+* Large grids are useful for stress testing, but practical convergence behavior
+  may differ from real transmission or distribution cases.

--- a/src/Sparlectra.jl
+++ b/src/Sparlectra.jl
@@ -75,6 +75,10 @@ export
   # functions  
   # utilities.jl
   zero_row!, print_jacobian,
+  # yamlparams.jl
+  parse_yaml_scalar, load_yaml_dict, merge_yaml_dict!, as_bool, as_int_vector,
+  # synthetic_grids.jl
+  synthetic_tiled_grid_bus_index, build_synthetic_tiled_grid_net, build_tiled_grid_net,
   # BusData
   BusData, getBusData, getBusTypeVec, countNodes, map_NR_voltage_to_net!,buildVoltageVector_from_busVec,
   # Compomnent
@@ -144,6 +148,7 @@ export
   ensure_casefile
 
 include("utilities.jl")
+include("yamlparams.jl")
 include("component.jl")
 include("lines.jl")
 include("transformer.jl")
@@ -153,6 +158,7 @@ include("branch.jl")
 include("link.jl")
 include("shunt.jl")
 include("network.jl")
+include("synthetic_grids.jl")
 include("tap_control.jl")
 include("busdata.jl")
 include("MatpowerIO.jl")   

--- a/src/examples/exp_synthetic_tiled_grid_pf_perf.jl
+++ b/src/examples/exp_synthetic_tiled_grid_pf_perf.jl
@@ -1,0 +1,236 @@
+#!/usr/bin/env julia
+# Copyright 2023–2026 Udo Schmitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+using Dates
+using LinearAlgebra
+using Printf
+using Sparlectra
+
+const DEFAULT_CONFIG = Dict{String,Any}(
+  "bus_limits" => [100, 300, 500, 1000],
+  "solver" => Dict{String,Any}(
+    "max_iter" => 25,
+    "tol" => 1e-8,
+    "verbose" => 0,
+    "flatstart" => false,
+    "method" => :rectangular,
+    "opt_sparse" => true,
+  ),
+  "performance" => Dict{String,Any}(
+    "blas_threads" => 0,
+    "show_thread_info" => true,
+  ),
+  "synthetic_network" => Dict{String,Any}(
+    "aspect_ratio" => 1.0,
+    "base_mva" => 100.0,
+    "r" => 0.01,
+    "x" => 0.05,
+    "g" => 0.0,
+    "b" => 0.0,
+    "load_mw_per_right_corner" => 50.0,
+    "load_mvar_per_right_corner" => 15.0,
+    "generation_balance" => 0.995,
+    "vm_slack" => 1.0,
+    "vm_flat" => 1.0,
+  ),
+)
+
+function _copy_config_dict(x::Dict{String,Any})::Dict{String,Any}
+  out = Dict{String,Any}()
+  for (key, value) in x
+    out[key] = value isa Dict{String,Any} ? _copy_config_dict(value) : value
+  end
+  return out
+end
+
+_get(d::Dict{String,Any}, key::String, default) = haskey(d, key) ? d[key] : default
+_as_float(x) = x isa Real ? Float64(x) : parse(Float64, String(x))
+_as_int(x) = x isa Integer ? Int(x) : parse(Int, String(x))
+_as_symbol(x) = x isa Symbol ? x : Symbol(String(x))
+
+function _parse_args(args::Vector{String})
+  config_path = nothing
+  limits = Int[]
+  max_override = nothing
+  for arg in args
+    if startswith(arg, "--max-buses=")
+      max_override = parse(Int, split(arg, "=", limit = 2)[2])
+    elseif _looks_like_yaml_path(arg)
+      config_path = arg
+    else
+      push!(limits, parse(Int, arg))
+    end
+  end
+  return config_path, limits, max_override
+end
+
+function _looks_like_yaml_path(arg::AbstractString)::Bool
+  lower = lowercase(arg)
+  return endswith(lower, ".yaml") || endswith(lower, ".yml") || endswith(lower, ".yaml.example") || endswith(lower, ".yml.example")
+end
+
+function _fallback_example_path(path::AbstractString)::String
+  lower = lowercase(path)
+  if endswith(lower, ".yaml") || endswith(lower, ".yml")
+    return path * ".example"
+  end
+  return path
+end
+
+function _resolve_config_path(config_path)::Union{Nothing,String}
+  if isnothing(config_path)
+    println("No configuration file specified; using built-in defaults.")
+    return nothing
+  end
+
+  if isfile(config_path)
+    return String(config_path)
+  end
+  fallback_path = _fallback_example_path(config_path)
+  if fallback_path != config_path && isfile(fallback_path)
+    println("Configuration file not found: ", config_path)
+    println("Using example configuration fallback: ", fallback_path)
+    return fallback_path
+  end
+
+  println("Configuration file not found: ", config_path)
+  println("No fallback configuration file found; using built-in defaults.")
+  return nothing
+end
+
+function _configure_blas!(cfg::Dict{String,Any})
+  perf = _get(cfg, "performance", Dict{String,Any}())
+  blas_threads = _as_int(_get(perf, "blas_threads", 0))
+  if blas_threads > 0
+    BLAS.set_num_threads(blas_threads)
+  end
+  if as_bool(_get(perf, "show_thread_info", true))
+    println("BLAS threads: ", BLAS.get_num_threads())
+    println("Julia threads: ", Threads.nthreads())
+  end
+end
+
+function _max_abs_mismatch(net::Net)
+  V = buildVoltageVector(net)
+  Y = createYBUS(net = net, sparse = false, printYBUS = false)
+  Sspec = buildComplexSVec(net)
+  Scalc = V .* conj(Y * V)
+  mismatch = Sspec - Scalc
+  for slack in net.slackVec
+    mismatch[slack] = 0.0 + 0.0im
+  end
+  return maximum(abs.(real.(mismatch))), maximum(abs.(imag.(mismatch)))
+end
+
+function _network_kwargs(cfg::Dict{String,Any})
+  sn = _get(cfg, "synthetic_network", Dict{String,Any}())
+  return (
+    aspect_ratio = _as_float(_get(sn, "aspect_ratio", 1.0)),
+    base_mva = _as_float(_get(sn, "base_mva", 100.0)),
+    r = _as_float(_get(sn, "r", 0.01)),
+    x = _as_float(_get(sn, "x", 0.05)),
+    g = _as_float(_get(sn, "g", 0.0)),
+    b = _as_float(_get(sn, "b", 0.0)),
+    load_mw_per_right_corner = _as_float(_get(sn, "load_mw_per_right_corner", 50.0)),
+    load_mvar_per_right_corner = _as_float(_get(sn, "load_mvar_per_right_corner", 15.0)),
+    generation_balance = _as_float(_get(sn, "generation_balance", 0.995)),
+    vm_slack = _as_float(_get(sn, "vm_slack", 1.0)),
+    vm_flat = _as_float(_get(sn, "vm_flat", 1.0)),
+  )
+end
+
+function _print_ascii_plot(rows)
+  isempty(rows) && return nothing
+  max_ms = maximum(row.solve_ms for row in rows)
+  max_ms <= 0.0 && return nothing
+  println("\nASCII plot: nbus versus solve_ms")
+  for row in rows
+    width = max(1, round(Int, 40 * row.solve_ms / max_ms))
+    @printf("%8d | %s %.3f ms\n", row.nbus, repeat("█", width), row.solve_ms)
+  end
+  return nothing
+end
+
+function main(args = ARGS)
+  config_path, cli_limits, max_override = _parse_args(collect(args))
+  cfg = _copy_config_dict(DEFAULT_CONFIG)
+  resolved_config_path = _resolve_config_path(config_path)
+  if !isnothing(resolved_config_path)
+    println("Loading configuration: ", resolved_config_path)
+    merge_yaml_dict!(cfg, load_yaml_dict(resolved_config_path))
+  end
+  if !isempty(cli_limits)
+    cfg["bus_limits"] = cli_limits
+  end
+  if !isnothing(max_override)
+    cfg["bus_limits"] = [max_override]
+  end
+
+  _configure_blas!(cfg)
+  bus_limits = as_int_vector(cfg["bus_limits"])
+  solver = _get(cfg, "solver", Dict{String,Any}())
+  max_iter = _as_int(_get(solver, "max_iter", 25))
+  tol = _as_float(_get(solver, "tol", 1e-8))
+  verbose = _as_int(_get(solver, "verbose", 0))
+  flatstart = as_bool(_get(solver, "flatstart", false))
+  method = _as_symbol(_get(solver, "method", :rectangular))
+  opt_sparse = as_bool(_get(solver, "opt_sparse", true))
+
+  outdir = joinpath(@__DIR__, "_out")
+  mkpath(outdir)
+  logfile = joinpath(outdir, "synthetic_tiled_grid_pf_perf_" * Dates.format(now(), "yyyymmdd_HHMMSS") * ".log")
+
+  rows = NamedTuple[]
+  header = "Limit nbus rows cols branch_count converged iterations solve_ms max|ΔP| max|ΔQ| system_build_ms system_build_allocated_bytes total_case_runtime_ms"
+  open(logfile, "w") do io
+    println(io, "# Sparlectra synthetic tiled-grid PF benchmark")
+    println(io, "# timestamp = ", now())
+    println(io, header)
+
+    println("\n", header)
+    for limit in bus_limits
+      build_alloc = 0
+      net = nothing
+      meta = nothing
+      build_time = @elapsed begin
+        build_alloc = @allocated begin
+          net, meta = build_synthetic_tiled_grid_net(limit; _network_kwargs(cfg)...)
+        end
+      end
+      solve_time = @elapsed begin
+        iterations, erg, solver_elapsed = run_net_acpflow(net = net, max_ite = max_iter, tol = tol, verbose = verbose, opt_sparse = opt_sparse, method = method, show_results = false, opt_flatstart = flatstart)
+      end
+      max_dp, max_dq = _max_abs_mismatch(net)
+      total_runtime_ms = 1000.0 * (build_time + solve_time)
+      row = (
+        limit = limit,
+        nbus = meta.actual_buses,
+        rows = meta.rows,
+        cols = meta.cols,
+        branch_count = meta.branch_count,
+        converged = (erg == 0),
+        iterations = iterations,
+        solve_ms = 1000.0 * solver_elapsed,
+        max_dp = max_dp,
+        max_dq = max_dq,
+        system_build_ms = 1000.0 * build_time,
+        system_build_allocated_bytes = build_alloc,
+        total_case_runtime_ms = total_runtime_ms,
+      )
+      push!(rows, row)
+      @printf("%5d %5d %4d %4d %12d %9s %10d %8.3f %.3e %.3e %15.3f %28d %21.3f\n", row.limit, row.nbus, row.rows, row.cols, row.branch_count, string(row.converged), row.iterations, row.solve_ms, row.max_dp, row.max_dq, row.system_build_ms, row.system_build_allocated_bytes, row.total_case_runtime_ms)
+      @printf(io, "%5d %5d %4d %4d %12d %9s %10d %8.3f %.3e %.3e %15.3f %28d %21.3f\n", row.limit, row.nbus, row.rows, row.cols, row.branch_count, row.converged, row.iterations, row.solve_ms, row.max_dp, row.max_dq, row.system_build_ms, row.system_build_allocated_bytes, row.total_case_runtime_ms)
+    end
+  end
+
+  _print_ascii_plot(rows)
+  println("\nWrote log file: ", logfile)
+  return rows
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+  Base.invokelatest(main, ARGS)
+end

--- a/src/examples/exp_synthetic_tiled_grid_pf_perf.yaml.example
+++ b/src/examples/exp_synthetic_tiled_grid_pf_perf.yaml.example
@@ -1,0 +1,31 @@
+# Configuration example for Sparlectra synthetic tiled-grid power-flow benchmark.
+
+bus_limits: [100, 300, 500, 1000, 2000, 5000]
+
+solver:
+  max_iter: 25
+  tol: 1e-8
+  verbose: 0
+  flatstart: false
+  method: :rectangular
+  opt_sparse: true
+
+performance:
+  blas_threads: 4       # 0 = keep current BLAS thread setting
+  show_thread_info: true
+
+synthetic_network:
+  aspect_ratio: 1.0
+  base_mva: 100.0
+
+  r: 0.01
+  x: 0.05
+  g: 0.0
+  b: 0.0
+
+  load_mw_per_right_corner: 50.0
+  load_mvar_per_right_corner: 15.0
+  generation_balance: 0.995
+
+  vm_slack: 1.0
+  vm_flat: 1.0

--- a/src/synthetic_grids.jl
+++ b/src/synthetic_grids.jl
@@ -1,0 +1,159 @@
+# Copyright 2023–2026 Udo Schmitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+# file: src/synthetic_grids.jl
+
+"""
+    synthetic_tiled_grid_bus_index(row::Int, col::Int, cols::Int)::Int
+
+Return the deterministic row-major bus index for a synthetic tiled grid.
+Rows and columns are one-based, so `row = 1, col = 1` is the upper-left bus.
+"""
+function synthetic_tiled_grid_bus_index(row::Int, col::Int, cols::Int)::Int
+  return (row - 1) * cols + col
+end
+
+function _synthetic_tiled_grid_bus_name(row::Int, col::Int)::String
+  return @sprintf("B_%03d_%03d", row, col)
+end
+
+function _choose_tiled_grid_dims(max_buses::Int, aspect_ratio::Float64)::Tuple{Int,Int}
+  max_buses >= 4 || throw(ArgumentError("max_buses must be at least 4 so the tiled grid has at least 2 rows and 2 columns."))
+  aspect_ratio > 0.0 || throw(ArgumentError("aspect_ratio must be positive."))
+
+  best_rows = 2
+  best_cols = 2
+  best_area = 4
+  best_score = abs(best_cols / best_rows - aspect_ratio)
+
+  for rows in 2:max_buses
+    cols_max = max_buses ÷ rows
+    cols_max >= 2 || continue
+    for cols in 2:cols_max
+      area = rows * cols
+      score = abs(cols / rows - aspect_ratio)
+      if area > best_area || (area == best_area && score < best_score) || (area == best_area && score == best_score && rows < best_rows)
+        best_rows = rows
+        best_cols = cols
+        best_area = area
+        best_score = score
+      end
+    end
+  end
+
+  return best_rows, best_cols
+end
+
+function _add_synthetic_pi_line!(net::Net, from_bus::String, to_bus::String, r::Float64, x::Float64, g::Float64, b::Float64)
+  @assert from_bus != to_bus "from_bus and to_bus must differ"
+  from = geNetBusIdx(net = net, busName = from_bus)
+  to = geNetBusIdx(net = net, busName = to_bus)
+  vn_kV = getNodeVn(net.nodeVec[from])
+  acseg = ACLineSegment(vn_kv = vn_kV, from = from, to = to, length = 1.0, r = r, x = x, b = b, ratedS = nothing, paramsBasedOnLength = false, isPIModel = true)
+  acseg.g = g
+  push!(net.linesAC, acseg)
+  addBranch!(net = net, from = from, to = to, branch = acseg, vn_kV = vn_kV, status = 1, values_are_pu = true)
+  return nothing
+end
+
+"""
+    build_synthetic_tiled_grid_net(max_buses::Int; kwargs...) -> (net, metadata)
+
+Build a deterministic synthetic rectangular tiled-grid AC network.
+
+The topology has `rows * cols` buses, horizontal branches, vertical branches,
+and one diagonal branch in each rectangular tile from the upper-left bus to the
+lower-right bus. Branches are Sparlectra PI-model AC lines whose series
+impedance is `r + im*x` in p.u. and whose total shunt admittance is `g + im*b`
+in p.u.; Sparlectra's branch model splits that shunt half/half in flow and
+Y-bus calculations.
+
+Bus roles follow the APSLF benchmark convention: the upper-left bus is the
+slack bus, the lower-left bus has scheduled generation, and the upper-right and
+lower-right buses have scheduled PQ loads. Power metadata values are reported
+in MW/MVAr; line parameters and voltages are in per unit.
+
+# Keyword defaults
+`aspect_ratio = 1.0`, `base_mva = 100.0`, `r = 0.01`, `x = 0.05`,
+`g = 0.0`, `b = 0.0`, `load_mw_per_right_corner = 50.0`,
+`load_mvar_per_right_corner = 15.0`, `generation_balance = 0.995`,
+`vm_slack = 1.0`, `vm_flat = 1.0`.
+"""
+function build_synthetic_tiled_grid_net(max_buses::Int; aspect_ratio::Float64 = 1.0, base_mva::Float64 = 100.0, r::Float64 = 0.01, x::Float64 = 0.05, g::Float64 = 0.0, b::Float64 = 0.0, load_mw_per_right_corner::Float64 = 50.0, load_mvar_per_right_corner::Float64 = 15.0, generation_balance::Float64 = 0.995, vm_slack::Float64 = 1.0, vm_flat::Float64 = 1.0, vn_kV::Float64 = 110.0, name::Union{Nothing,String} = nothing)
+  rows, cols = _choose_tiled_grid_dims(max_buses, aspect_ratio)
+  actual_buses = rows * cols
+  net_name = isnothing(name) ? "synthetic_tiled_grid_$(rows)x$(cols)" : name
+  net = Net(name = net_name, baseMVA = base_mva, flatstart = false)
+
+  for row in 1:rows
+    for col in 1:cols
+      bus_name = _synthetic_tiled_grid_bus_name(row, col)
+      vm = (row == 1 && col == 1) ? vm_slack : vm_flat
+      addBus!(net = net, busName = bus_name, vn_kV = vn_kV, vm_pu = vm, va_deg = 0.0, oBusIdx = synthetic_tiled_grid_bus_index(row, col, cols))
+    end
+  end
+
+  for row in 1:rows
+    for col in 1:(cols-1)
+      _add_synthetic_pi_line!(net, _synthetic_tiled_grid_bus_name(row, col), _synthetic_tiled_grid_bus_name(row, col + 1), r, x, g, b)
+    end
+  end
+  for row in 1:(rows-1)
+    for col in 1:cols
+      _add_synthetic_pi_line!(net, _synthetic_tiled_grid_bus_name(row, col), _synthetic_tiled_grid_bus_name(row + 1, col), r, x, g, b)
+    end
+  end
+  for row in 1:(rows-1)
+    for col in 1:(cols-1)
+      _add_synthetic_pi_line!(net, _synthetic_tiled_grid_bus_name(row, col), _synthetic_tiled_grid_bus_name(row + 1, col + 1), r, x, g, b)
+    end
+  end
+
+  slack_bus = _synthetic_tiled_grid_bus_name(1, 1)
+  generation_bus = _synthetic_tiled_grid_bus_name(rows, 1)
+  load_buses = [_synthetic_tiled_grid_bus_name(1, cols), _synthetic_tiled_grid_bus_name(rows, cols)]
+  scheduled_load_mw = 2.0 * load_mw_per_right_corner
+  scheduled_load_mvar = 2.0 * load_mvar_per_right_corner
+  scheduled_generation_mw = generation_balance * scheduled_load_mw
+  scheduled_generation_mvar = generation_balance * scheduled_load_mvar
+
+  addProsumer!(net = net, busName = slack_bus, type = "EXTERNALNETWORKINJECTION", vm_pu = vm_slack, va_deg = 0.0, referencePri = slack_bus)
+  addProsumer!(net = net, busName = generation_bus, type = "GENERATOR", p = scheduled_generation_mw, q = scheduled_generation_mvar)
+  for bus_name in load_buses
+    addProsumer!(net = net, busName = bus_name, type = "ENERGYCONSUMER", p = load_mw_per_right_corner, q = load_mvar_per_right_corner)
+  end
+
+  result, msg = validate!(net = net)
+  result || error("Synthetic tiled-grid network validation failed: $(msg)")
+
+  expected_branch_count = rows * (cols - 1) + (rows - 1) * cols + (rows - 1) * (cols - 1)
+  metadata = (
+    requested_max_buses = max_buses,
+    actual_buses = actual_buses,
+    rows = rows,
+    cols = cols,
+    branch_count = length(net.branchVec),
+    expected_branch_count = expected_branch_count,
+    slack_bus = slack_bus,
+    generation_buses = [generation_bus],
+    load_buses = load_buses,
+    scheduled_generation_mw = scheduled_generation_mw,
+    scheduled_load_mw = scheduled_load_mw,
+    scheduled_generation_mvar = scheduled_generation_mvar,
+    scheduled_load_mvar = scheduled_load_mvar,
+    power_unit = "MW/MVAr",
+    line_parameter_unit = "p.u.",
+  )
+  metadata.branch_count == expected_branch_count || error("Synthetic branch count mismatch: got $(metadata.branch_count), expected $(expected_branch_count)")
+
+  return net, metadata
+end
+
+"""
+    build_tiled_grid_net(max_buses::Int; kwargs...) -> (net, metadata)
+
+Alias for [`build_synthetic_tiled_grid_net`](@ref).
+"""
+build_tiled_grid_net(max_buses::Int; kwargs...) = build_synthetic_tiled_grid_net(max_buses; kwargs...)

--- a/src/yamlparams.jl
+++ b/src/yamlparams.jl
@@ -1,0 +1,210 @@
+# Copyright 2023–2026 Udo Schmitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+# file: src/yamlparams.jl
+
+"""
+    parse_yaml_scalar(raw::AbstractString)
+
+Parse one scalar value from Sparlectra's small dependency-free YAML subset.
+
+This parser is intended for example and benchmark configuration files. It is
+not a general-purpose YAML implementation. Supported scalars are booleans,
+`null`/`~`, integers, floating-point numbers, symbols written as `:name`,
+quoted strings, unquoted strings, and one-line scalar lists such as
+`[100, 300, 500]`.
+"""
+function parse_yaml_scalar(raw::AbstractString)
+  s = strip(raw)
+  isempty(s) && return ""
+
+  if startswith(s, "[") && endswith(s, "]")
+    inner = strip(s[2:(end-1)])
+    isempty(inner) && return Any[]
+    return [parse_yaml_scalar(part) for part in _split_yaml_inline_list(inner)]
+  end
+
+  if (startswith(s, "\"") && endswith(s, "\"")) || (startswith(s, "'") && endswith(s, "'"))
+    return s[2:(end-1)]
+  end
+
+  lower = lowercase(s)
+  if lower in ("true", "yes", "on")
+    return true
+  elseif lower in ("false", "no", "off")
+    return false
+  elseif lower in ("null", "~")
+    return nothing
+  elseif startswith(s, ":") && length(s) > 1
+    return Symbol(s[2:end])
+  end
+
+  if occursin(r"^[+-]?\d+$", s)
+    return parse(Int, s)
+  end
+  if occursin(r"^[+-]?(?:\d+\.\d*|\.\d+|\d+)(?:[eE][+-]?\d+)?$", s)
+    return parse(Float64, s)
+  end
+
+  return s
+end
+
+function _split_yaml_inline_list(inner::AbstractString)::Vector{String}
+  parts = String[]
+  buf = IOBuffer()
+  qchar = '\0'
+  for ch in inner
+    if qchar != '\0'
+      if ch == qchar
+        qchar = '\0'
+      end
+      print(buf, ch)
+    elseif ch == '\'' || ch == '"'
+      qchar = ch
+      print(buf, ch)
+    elseif ch == ','
+      push!(parts, strip(String(take!(buf))))
+    else
+      print(buf, ch)
+    end
+  end
+  qchar == '\0' || error("Unterminated quote in YAML inline list: [$(inner)]")
+  push!(parts, strip(String(take!(buf))))
+  return parts
+end
+
+function _strip_yaml_comment(line::AbstractString)::String
+  buf = IOBuffer()
+  qchar = '\0'
+  for ch in line
+    if qchar != '\0'
+      if ch == qchar
+        qchar = '\0'
+      end
+      print(buf, ch)
+    elseif ch == '\'' || ch == '"'
+      qchar = ch
+      print(buf, ch)
+    elseif ch == '#'
+      break
+    else
+      print(buf, ch)
+    end
+  end
+  return String(take!(buf))
+end
+
+"""
+    load_yaml_dict(path::AbstractString)::Dict{String,Any}
+
+Load a simple YAML file into a `Dict{String,Any}`.
+
+Only the subset used by Sparlectra examples is supported: comments beginning
+with `#`, 2-space-indented nested dictionaries, scalar key-value pairs, and
+one-line scalar lists. Invalid indentation and unsupported lines throw clear
+errors. Use a full YAML package for general YAML documents.
+"""
+function load_yaml_dict(path::AbstractString)::Dict{String,Any}
+  root = Dict{String,Any}()
+  stack = Dict{Int,Dict{String,Any}}(0 => root)
+
+  for (lineno, rawline) in enumerate(eachline(path))
+    line = rstrip(_strip_yaml_comment(rawline))
+    isempty(strip(line)) && continue
+
+    indent_count = 0
+    for ch in line
+      ch == ' ' || break
+      indent_count += 1
+    end
+    indent_count % 2 == 0 || error("Invalid YAML indentation at $(path):$(lineno): indentation must use multiples of 2 spaces")
+
+    content = strip(line)
+    m = match(r"^([A-Za-z0-9_\-]+)\s*:\s*(.*)$", content)
+    isnothing(m) && error("Unsupported YAML line at $(path):$(lineno): $(strip(rawline))")
+
+    level = indent_count ÷ 2
+    haskey(stack, level) || error("Invalid YAML indentation at $(path):$(lineno): missing parent for indentation level $(level)")
+    parent = stack[level]
+    key = String(m.captures[1])
+    value_raw = String(m.captures[2])
+
+    if isempty(value_raw)
+      child = Dict{String,Any}()
+      parent[key] = child
+      stack[level + 1] = child
+      for k in collect(keys(stack))
+        if k > level + 1
+          delete!(stack, k)
+        end
+      end
+    else
+      parent[key] = parse_yaml_scalar(value_raw)
+      for k in collect(keys(stack))
+        if k > level
+          delete!(stack, k)
+        end
+      end
+    end
+  end
+
+  return root
+end
+
+"""
+    merge_yaml_dict!(dst::Dict{String,Any}, src::Dict{String,Any})
+
+Recursively merge YAML dictionaries from `src` into `dst` and return `dst`.
+Nested dictionaries are merged; non-dictionary values replace existing values.
+"""
+function merge_yaml_dict!(dst::Dict{String,Any}, src::Dict{String,Any})
+  for (key, value) in src
+    if haskey(dst, key) && dst[key] isa Dict{String,Any} && value isa Dict{String,Any}
+      merge_yaml_dict!(dst[key], value)
+    else
+      dst[key] = value
+    end
+  end
+  return dst
+end
+
+"""
+    as_bool(x)::Bool
+
+Convert YAML booleans or boolean-like strings (`true`, `false`, `yes`, `no`,
+`on`, `off`) to `Bool`. Invalid values throw an `ArgumentError`.
+"""
+function as_bool(x)::Bool
+  x isa Bool && return x
+  if x isa AbstractString
+    lower = lowercase(strip(x))
+    lower in ("true", "yes", "on") && return true
+    lower in ("false", "no", "off") && return false
+  end
+  throw(ArgumentError("Cannot convert $(repr(x)) to Bool; expected true/false, yes/no, or on/off."))
+end
+
+"""
+    as_int_vector(x)::Vector{Int}
+
+Convert an integer or a one-dimensional vector of integer values to
+`Vector{Int}`. Invalid values throw an `ArgumentError`.
+"""
+function as_int_vector(x)::Vector{Int}
+  if x isa Integer
+    return [Int(x)]
+  elseif x isa AbstractVector
+    values = Int[]
+    for item in x
+      if item isa Integer
+        push!(values, Int(item))
+      else
+        throw(ArgumentError("Cannot convert $(repr(x)) to Vector{Int}; every element must be an integer."))
+      end
+    end
+    return values
+  end
+  throw(ArgumentError("Cannot convert $(repr(x)) to Vector{Int}; expected an integer or vector of integers."))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ include("test_state_estimation.jl")
 include("test_voltage_dependent_control.jl")
 include("test_transformer_phase_shift.jl")
 include("test_tap_controller.jl")
+include("test_synthetic_grids.jl")
 
 function _print_test_progress(step::Int, total::Int, label::String)
   width = 30
@@ -56,6 +57,7 @@ end
     ("voltage_dependent_control", run_voltage_dependent_control_tests),
     ("transformer_phase_shift", run_transformer_phase_shift_tests),
     ("tap_controller", run_tap_controller_tests),
+    ("synthetic_grids", run_synthetic_grid_tests),
   ]
 
   total = length(test_steps)

--- a/test/test_synthetic_grids.jl
+++ b/test/test_synthetic_grids.jl
@@ -1,0 +1,89 @@
+# Copyright 2023–2026 Udo Schmitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+# file: test/test_synthetic_grids.jl
+
+function run_synthetic_grid_tests()
+  @testset "YAML subset parser" begin
+    @test parse_yaml_scalar("true") === true
+    @test parse_yaml_scalar("no") === false
+    @test parse_yaml_scalar("null") === nothing
+    @test parse_yaml_scalar("42") == 42
+    @test parse_yaml_scalar("1e-8") ≈ 1e-8
+    @test parse_yaml_scalar(":rectangular") === :rectangular
+    @test parse_yaml_scalar("'hello # not comment'") == "hello # not comment"
+    @test parse_yaml_scalar("[100, 300, 500]") == [100, 300, 500]
+    @test as_bool("on") === true
+    @test as_bool("off") === false
+    @test as_int_vector([4, 9, 16]) == [4, 9, 16]
+    @test_throws ArgumentError as_bool("maybe")
+    @test_throws ArgumentError as_int_vector([1, 2.5])
+
+    mktemp() do path, io
+      write(io, """
+      bus_limits: [4, 9, 16]
+      solver:
+        max_iter: 25
+        tol: 1e-8
+        method: :rectangular
+      synthetic_network:
+        aspect_ratio: 1.0 # comment
+        label: "demo # grid"
+      """)
+      close(io)
+      cfg = load_yaml_dict(path)
+      @test cfg["bus_limits"] == [4, 9, 16]
+      @test cfg["solver"]["max_iter"] == 25
+      @test cfg["solver"]["tol"] ≈ 1e-8
+      @test cfg["solver"]["method"] === :rectangular
+      @test cfg["synthetic_network"]["label"] == "demo # grid"
+    end
+
+    dst = Dict{String,Any}("solver" => Dict{String,Any}("tol" => 1e-6, "verbose" => 0), "keep" => 1)
+    src = Dict{String,Any}("solver" => Dict{String,Any}("tol" => 1e-8), "new" => true)
+    merge_yaml_dict!(dst, src)
+    @test dst["solver"]["tol"] ≈ 1e-8
+    @test dst["solver"]["verbose"] == 0
+    @test dst["keep"] == 1
+    @test dst["new"] === true
+
+    mktemp() do path, io
+      write(io, "root:\n   bad: 1\n")
+      close(io)
+      @test_throws ErrorException load_yaml_dict(path)
+    end
+  end
+
+  @testset "synthetic tiled grid builder" begin
+    net, meta = build_synthetic_tiled_grid_net(16; aspect_ratio = 1.0, b = 0.01, g = 0.001)
+    @test meta.rows >= 2
+    @test meta.cols >= 2
+    @test meta.actual_buses <= meta.requested_max_buses
+    expected = meta.rows * (meta.cols - 1) + (meta.rows - 1) * meta.cols + (meta.rows - 1) * (meta.cols - 1)
+    @test meta.branch_count == expected
+    @test length(net.nodeVec) == meta.actual_buses
+    @test length(net.branchVec) == expected
+    @test meta.slack_bus == "B_001_001"
+    @test meta.generation_buses == [@sprintf("B_%03d_%03d", meta.rows, 1)]
+    @test meta.load_buses == [@sprintf("B_%03d_%03d", 1, meta.cols), @sprintf("B_%03d_%03d", meta.rows, meta.cols)]
+    @test synthetic_tiled_grid_bus_index(meta.rows, meta.cols, meta.cols) == meta.actual_buses
+    @test geNetBusIdx(net = net, busName = meta.slack_bus) in net.slackVec
+    @test any(abs(calcBranchYshunt(branch)) > 0.0 for branch in net.branchVec)
+
+    ybus = createYBUS(net = net, sparse = false, printYBUS = false)
+    @test size(ybus) == (meta.actual_buses, meta.actual_buses)
+    @test count(!iszero, ybus) > 0
+
+    net2, meta2 = build_synthetic_tiled_grid_net(16; aspect_ratio = 1.0, b = 0.01, g = 0.001)
+    @test meta == meta2
+    @test net.busDict == net2.busDict
+
+    small_net, small_meta = build_synthetic_tiled_grid_net(9; aspect_ratio = 1.0)
+    iterations, erg, _etime = run_net_acpflow(net = small_net, max_ite = 25, tol = 1e-8, verbose = 0, opt_sparse = true, method = :rectangular, show_results = false)
+    @test erg == 0
+    @test iterations > 0
+    @test small_meta.branch_count == small_meta.rows * (small_meta.cols - 1) + (small_meta.rows - 1) * small_meta.cols + (small_meta.rows - 1) * (small_meta.cols - 1)
+  end
+end


### PR DESCRIPTION
### Motivation

- Provide a lightweight, dependency-free way to generate large, reproducible AC benchmark networks for solver scaling and diagnostics. 
- Allow example-driven configuration via a small YAML subset without pulling in a full YAML dependency. 

### Description

- Added a small YAML subset parser and utilities in `src/yamlparams.jl` with `parse_yaml_scalar`, `load_yaml_dict`, `merge_yaml_dict!`, `as_bool`, and `as_int_vector`. 
- Implemented a synthetic tiled-grid network builder in `src/synthetic_grids.jl` exposing `build_synthetic_tiled_grid_net`, `build_tiled_grid_net`, and `synthetic_tiled_grid_bus_index`, and wired these into the package exports and `include` list in `src/Sparlectra.jl`. 
- Added a runnable benchmark example `src/examples/exp_synthetic_tiled_grid_pf_perf.jl` and its example config `src/examples/exp_synthetic_tiled_grid_pf_perf.yaml.example`, plus documentation `docs/src/synthetic_grids.md` and links in `docs/make.jl`, `docs/src/index.md` and `docs/src/feature_matrix.md`. 
- Added automated tests `test/test_synthetic_grids.jl` and included them in `test/runtests.jl`, and updated the changelog `docs/src/changelog.md`.

### Testing

- Ran the full test suite via the package test runner (`pkg> test` / `test/runtests.jl`), which includes the new `test/test_synthetic_grids.jl` checks, and the suite completed successfully. 
- The synthetic-grid unit tests exercise the YAML parser, dictionary merging, dimension selection, topology/branch counts, Y-bus creation, and a small PF solve via `run_net_acpflow`, and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc8c02fb883309bb1a47e3069aecd)