### PR TITLE
Add branch-charging sweep, PV-bus inference diagnostics, and worst-offender reporting to FOR002 validator example

### DIFF
--- a/examples/validate_for002_testnetz13_v2.jl
+++ b/examples/validate_for002_testnetz13_v2.jl
@@ -75,6 +75,7 @@ struct CliOptions
   builder_pq_gen_controllers::Bool
   sweep_branch_b::Bool
   infer_pv_buses::Symbol
+  diagnose_active_flow::Bool
 end
 
 struct ModelRunResult
@@ -142,12 +143,15 @@ function _parse_cli_args(args::Vector{String})::CliOptions
   opt_flatstart = false
   qlimits_enabled = false
   sweep_branch_b = false
+  diagnose_active_flow = false
 
   for arg in args
     if arg == "--contingencies"
       run_contingencies = true
     elseif arg == "--sweep-branch-b"
       sweep_branch_b = true
+    elseif arg == "--diagnose-active-flow"
+      diagnose_active_flow = true
     elseif arg == "--no-matpower"
       run_matpower = false
     elseif arg == "--no-builder"
@@ -187,6 +191,7 @@ function _parse_cli_args(args::Vector{String})::CliOptions
       println("  --line-b-scale=X           diagnostic multiplier for AC-line branch b_pu before solving")
       println("  --trafo-b-scale=X          diagnostic multiplier for transformer branch b_pu before solving")
       println("  --sweep-branch-b           run compact base-case line/transformer branch-charging sweep")
+      println("  --diagnose-active-flow     write active-power and branch/tap diagnostic CSVs")
       println("  --infer-pv-buses=off|from-q-limits|from-gen-vg|all-generator-buses")
       println("                              diagnostic PV-bus inference mode; default off")
       println("  --matpower-ratio=normal|reciprocal")
@@ -254,6 +259,7 @@ function _parse_cli_args(args::Vector{String})::CliOptions
     builder_pq_gen_controllers,
     sweep_branch_b,
     infer_pv_buses,
+    diagnose_active_flow,
   )
 end
 
@@ -927,6 +933,7 @@ function _with_branch_b_sweep_point(opt::CliOptions, line_b_scale::Float64, traf
     true,
     opt.sweep_branch_b,
     opt.infer_pv_buses,
+    opt.diagnose_active_flow,
   )
 end
 
@@ -1257,12 +1264,269 @@ function _pv_bus_diagnostics_note(opt::CliOptions, rows::Vector{NamedTuple})::Un
   return nothing
 end
 
+function _bus_angle_deviation_rows(ref::For002Scenario, result::ModelRunResult)
+  calc = _bus_result_dict(result.report)
+  rows = NamedTuple[]
+  for key in sort(collect(keys(ref.buses)))
+    r = ref.buses[key]
+    c = get(calc, key, nothing)
+    c === nothing && continue
+    push!(rows, (bus_name = r.bus_name, d_va_deg = _angle_delta_deg(c.va_deg, r.va_deg), ref_va_deg = r.va_deg, calc_va_deg = c.va_deg))
+  end
+  return rows
+end
+
+function _branch_flow_deviation_rows(ref::For002Scenario, result::ModelRunResult, branch_labels::Vector{String})
+  refd = _reference_branch_dict(ref)
+  calcd = _branch_result_dict(result, branch_labels)
+  rows = NamedTuple[]
+  for key in sort(collect(keys(refd)); by = x -> (x[1], x[2], x[3]))
+    r = refd[key]
+    c = get(calcd, key, nothing)
+    c === nothing && continue
+    push!(
+      rows,
+      (
+        branch_index = c.branch_index,
+        label = c.label,
+        from_bus = c.from_name,
+        to_bus = c.to_name,
+        nr = c.nr,
+        d_p_MW = c.p_MW - r.p_MW,
+        d_q_MVar = c.q_MVar - r.q_MVar,
+        ref_p_MW = r.p_MW,
+        calc_p_MW = c.p_MW,
+        ref_q_MVar = r.q_MVar,
+        calc_q_MVar = c.q_MVar,
+      ),
+    )
+  end
+  return rows
+end
+
+function _slack_bus_power_deviation(ref::For002Scenario, result::ModelRunResult)
+  calc = _bus_result_dict(result.report)
+  for node in result.net.nodeVec
+    Sparlectra.getNodeType(node) == Sparlectra.Slack || continue
+    bus_name = get(_bus_name_by_idx(result.net), node.busIdx, string(node.busIdx))
+    r = get(ref.buses, _norm_name(bus_name), nothing)
+    c = get(calc, _norm_name(bus_name), nothing)
+    r === nothing || c === nothing || return (
+      bus_name = bus_name,
+      d_p_gen_MW = c.p_gen_MW - r.p_gen_MW,
+      d_q_gen_MVar = c.q_gen_MVar - r.q_gen_MVar,
+      ref_p_gen_MW = r.p_gen_MW,
+      calc_p_gen_MW = c.p_gen_MW,
+      ref_q_gen_MVar = r.q_gen_MVar,
+      calc_q_gen_MVar = c.q_gen_MVar,
+    )
+  end
+  return nothing
+end
+
+function _active_power_balance_rows(ref::For002Scenario, result::ModelRunResult)
+  rows = NamedTuple[]
+  ref_buses = ref.buses
+  for row in result.report.nodes
+    key = _norm_name(row.bus_name)
+    refrow = get(ref_buses, key, nothing)
+    node_idx = get(result.net.busDict, row.bus_name, 0)
+    bus_type = node_idx == 0 ? "" : String(Sparlectra.toString(Sparlectra.getNodeType(result.net.nodeVec[node_idx])))
+    bus_prosumers = node_idx == 0 ? Any[] : Sparlectra.getBusProsumers(result.net, node_idx)
+    regulated = any(ps -> ps.isRegulated, bus_prosumers)
+    is_slack_bus = node_idx != 0 && Sparlectra.getNodeType(result.net.nodeVec[node_idx]) == Sparlectra.Slack
+    push!(
+      rows,
+      (
+        model = result.model_name,
+        bus_name = row.bus_name,
+        bus_type = bus_type,
+        regulation_state = regulated,
+        p_gen_MW = row.p_gen_MW,
+        q_gen_MVar = row.q_gen_MVar,
+        p_load_MW = row.p_load_MW,
+        q_load_MVar = row.q_load_MVar,
+        net_p_injection_MW = row.p_gen_MW - row.p_load_MW,
+        net_q_injection_MVar = row.q_gen_MVar - row.q_load_MVar,
+        ref_p_gen_MW = refrow === nothing ? nothing : refrow.p_gen_MW,
+        ref_q_gen_MVar = refrow === nothing ? nothing : refrow.q_gen_MVar,
+        ref_p_load_MW = refrow === nothing ? nothing : refrow.p_load_MW,
+        ref_q_load_MVar = refrow === nothing ? nothing : refrow.q_load_MVar,
+        d_p_gen_MW = refrow === nothing ? nothing : row.p_gen_MW - refrow.p_gen_MW,
+        d_q_gen_MVar = refrow === nothing ? nothing : row.q_gen_MVar - refrow.q_gen_MVar,
+        d_p_load_MW = refrow === nothing ? nothing : row.p_load_MW - refrow.p_load_MW,
+        d_q_load_MVar = refrow === nothing ? nothing : row.q_load_MVar - refrow.q_load_MVar,
+        is_slack_bus = is_slack_bus,
+      ),
+    )
+  end
+  return rows
+end
+
+function _voltage_coupling_note(from_kv, to_kv)::String
+  if from_kv === missing || to_kv === missing
+    return "unknown voltage coupling"
+  end
+  if isapprox(max(from_kv, to_kv), 400.0; atol = 1.0) && isapprox(min(from_kv, to_kv), 230.0; atol = 1.0)
+    return "400/230-kV coupling"
+  elseif isapprox(from_kv, to_kv; atol = 1e-6)
+    return "same-voltage transformer"
+  else
+    return "other voltage coupling"
+  end
+end
+
+function _branch_parameter_rows(result::ModelRunResult, branch_labels::Vector{String}, top_p_indices::Set{Int}, top_angle_branch_indices::Set{Int})
+  names = _bus_name_by_idx(result.net)
+  rows = NamedTuple[]
+  for br in result.net.branchVec
+    idx = br.branchIdx
+    from_base_kv = result.net.nodeVec[br.fromBus].comp.cVN
+    to_base_kv = result.net.nodeVec[br.toBus].comp.cVN
+    push!(
+      rows,
+      (
+        model = result.model_name,
+        branch_index = idx,
+        branch_label = idx <= length(branch_labels) ? branch_labels[idx] : string(idx),
+        from_bus = get(names, br.fromBus, string(br.fromBus)),
+        to_bus = get(names, br.toBus, string(br.toBus)),
+        branch_kind = _branch_model_kind_label(result.net, br),
+        r_pu = br.r_pu,
+        x_pu = br.x_pu,
+        b_pu_after_effective_scaling = br.b_pu,
+        ratio = br.ratio,
+        angle = br.angle,
+        status = br.status,
+        from_base_kV = from_base_kv,
+        to_base_kV = to_base_kv,
+        is_top_p_flow_offender = idx in top_p_indices,
+        is_top_angle_offender = idx in top_angle_branch_indices,
+      ),
+    )
+  end
+  return rows
+end
+
+function _transformer_tap_rows(result::ModelRunResult, branch_labels::Vector{String}, branch_deviations::Vector{NamedTuple})
+  names = _bus_name_by_idx(result.net)
+  deviation_by_index = Dict(row.branch_index => row for row in branch_deviations)
+  rows = NamedTuple[]
+  for br in result.net.branchVec
+    _branch_diagnostic_kind(result.net, br) == :transformer || continue
+    idx = br.branchIdx
+    from_base_kv = result.net.nodeVec[br.fromBus].comp.cVN
+    to_base_kv = result.net.nodeVec[br.toBus].comp.cVN
+    dev = get(deviation_by_index, idx, nothing)
+    push!(
+      rows,
+      (
+        model = result.model_name,
+        branch_index = idx,
+        branch_label = idx <= length(branch_labels) ? branch_labels[idx] : string(idx),
+        from_bus = get(names, br.fromBus, string(br.fromBus)),
+        to_bus = get(names, br.toBus, string(br.toBus)),
+        from_base_kV = from_base_kv,
+        to_base_kV = to_base_kv,
+        ratio = br.ratio,
+        angle_deg = br.angle,
+        r_pu = br.r_pu,
+        x_pu = br.x_pu,
+        b_pu = br.b_pu,
+        d_p_MW = dev === nothing ? nothing : dev.d_p_MW,
+        d_q_MVar = dev === nothing ? nothing : dev.d_q_MVar,
+        coupling_note = _voltage_coupling_note(from_base_kv, to_base_kv),
+      ),
+    )
+  end
+  return rows
+end
+
+function _write_active_power_balance_diagnostics_csv(path::AbstractString, rows::Vector{NamedTuple})
+  open(path, "w") do io
+    println(io, "model,bus_name,bus_type,regulation_state,p_gen_MW,q_gen_MVar,p_load_MW,q_load_MVar,net_p_injection_MW,net_q_injection_MVar,ref_p_gen_MW,ref_q_gen_MVar,ref_p_load_MW,ref_q_load_MVar,d_p_gen_MW,d_q_gen_MVar,d_p_load_MW,d_q_load_MVar,is_slack_bus")
+    for row in rows
+      println(io, _csv_line(row.model, row.bus_name, row.bus_type, row.regulation_state, row.p_gen_MW, row.q_gen_MVar, row.p_load_MW, row.q_load_MVar, row.net_p_injection_MW, row.net_q_injection_MVar, row.ref_p_gen_MW, row.ref_q_gen_MVar, row.ref_p_load_MW, row.ref_q_load_MVar, row.d_p_gen_MW, row.d_q_gen_MVar, row.d_p_load_MW, row.d_q_load_MVar, row.is_slack_bus))
+    end
+  end
+  return path
+end
+
+function _write_branch_parameter_diagnostics_csv(path::AbstractString, rows::Vector{NamedTuple})
+  open(path, "w") do io
+    println(io, "model,branch_index,branch_label,from_bus,to_bus,branch_kind,r_pu,x_pu,b_pu_after_effective_scaling,ratio,angle,status,from_base_kV,to_base_kV,is_top_p_flow_offender,is_top_angle_offender")
+    for row in rows
+      println(io, _csv_line(row.model, row.branch_index, row.branch_label, row.from_bus, row.to_bus, row.branch_kind, row.r_pu, row.x_pu, row.b_pu_after_effective_scaling, row.ratio, row.angle, row.status, row.from_base_kV, row.to_base_kV, row.is_top_p_flow_offender, row.is_top_angle_offender))
+    end
+  end
+  return path
+end
+
+function _write_transformer_tap_diagnostics_csv(path::AbstractString, rows::Vector{NamedTuple})
+  open(path, "w") do io
+    println(io, "model,branch_index,branch_label,from_bus,to_bus,from_base_kV,to_base_kV,ratio,angle_deg,r_pu,x_pu,b_pu,d_p_MW,d_q_MVar,coupling_note")
+    for row in rows
+      println(io, _csv_line(row.model, row.branch_index, row.branch_label, row.from_bus, row.to_bus, row.from_base_kV, row.to_base_kV, row.ratio, row.angle_deg, row.r_pu, row.x_pu, row.b_pu, row.d_p_MW, row.d_q_MVar, row.coupling_note))
+    end
+  end
+  return path
+end
+
+function _write_active_flow_diagnostics(opt::CliOptions, ref::For002Scenario, base_results::Vector{ModelRunResult}, branch_labels::Vector{String})
+  active_rows = NamedTuple[]
+  branch_parameter_rows = NamedTuple[]
+  transformer_rows = NamedTuple[]
+  console_rows = NamedTuple[]
+  for result in base_results
+    branch_deviations = _branch_flow_deviation_rows(ref, result, branch_labels)
+    angle_deviations = _bus_angle_deviation_rows(ref, result)
+    top_p = first(sort(branch_deviations; by = row -> abs(row.d_p_MW), rev = true), min(10, length(branch_deviations)))
+    top_angles = first(sort(angle_deviations; by = row -> abs(row.d_va_deg), rev = true), min(10, length(angle_deviations)))
+    top_p_indices = Set(row.branch_index for row in top_p)
+    top_angle_buses = Set(_norm_name(row.bus_name) for row in top_angles)
+    top_angle_branch_indices = Set(
+      br.branchIdx for br in result.net.branchVec if
+      _norm_name(get(_bus_name_by_idx(result.net), br.fromBus, string(br.fromBus))) in top_angle_buses ||
+      _norm_name(get(_bus_name_by_idx(result.net), br.toBus, string(br.toBus))) in top_angle_buses
+    )
+    append!(active_rows, _active_power_balance_rows(ref, result))
+    append!(branch_parameter_rows, _branch_parameter_rows(result, branch_labels, top_p_indices, top_angle_branch_indices))
+    append!(transformer_rows, _transformer_tap_rows(result, branch_labels, branch_deviations))
+    push!(console_rows, (model = result.model_name, top_p = top_p, top_angles = top_angles, slack = _slack_bus_power_deviation(ref, result)))
+  end
+  active_csv = _write_active_power_balance_diagnostics_csv(joinpath(opt.output_dir, "active_power_balance_diagnostics.csv"), active_rows)
+  branch_csv = _write_branch_parameter_diagnostics_csv(joinpath(opt.output_dir, "branch_parameter_diagnostics.csv"), branch_parameter_rows)
+  transformer_csv = _write_transformer_tap_diagnostics_csv(joinpath(opt.output_dir, "transformer_tap_diagnostics.csv"), transformer_rows)
+  return (active_csv = active_csv, branch_csv = branch_csv, transformer_csv = transformer_csv, console_rows = console_rows)
+end
+
+function _print_active_flow_console_summary(diagnostics)
+  diagnostics === nothing && return nothing
+  println("Active-flow diagnostic summary")
+  for row in diagnostics.console_rows
+    println("  Model: ", row.model)
+    println("    Top branch |dP|:")
+    for br in row.top_p
+      @printf("      %-34s %s -> %s dP=% .6g MW dQ=% .6g MVar\n", br.label, br.from_bus, br.to_bus, br.d_p_MW, br.d_q_MVar)
+    end
+    println("    Top bus |dVa|:")
+    for bus in row.top_angles
+      @printf("      %-12s dVa=% .6g deg ref=% .6g calc=% .6g\n", bus.bus_name, bus.d_va_deg, bus.ref_va_deg, bus.calc_va_deg)
+    end
+    if row.slack !== nothing
+      @printf("    Slack %s dPgen=% .6g MW dQgen=% .6g MVar\n", row.slack.bus_name, row.slack.d_p_gen_MW, row.slack.d_q_gen_MVar)
+    end
+  end
+  println()
+  return nothing
+end
+
 function _scenario_file_prefix(result::ModelRunResult)::String
   scenario_tag = replace(result.scenario_name, r"[^A-Za-z0-9_.-]" => "_")
   return lowercase(result.model_name) * "_" * scenario_tag
 end
 
-function _write_summary(path::AbstractString, opt::CliOptions, ref_scenarios::Vector{For002Scenario}, branch_labels::Vector{String}, base_summaries::Vector{NamedTuple}, contingency_summaries::Vector{NamedTuple}, model_compare_file::Union{Nothing,String}, branch_b_diagnostic_csv::AbstractString, branch_b_sweep_csv::Union{Nothing,String}, worst_offenders_csv::Union{Nothing,String}, pv_bus_diagnostics_csv::Union{Nothing,String}, pv_bus_diagnostics_note::Union{Nothing,String})
+function _write_summary(path::AbstractString, opt::CliOptions, ref_scenarios::Vector{For002Scenario}, branch_labels::Vector{String}, base_summaries::Vector{NamedTuple}, contingency_summaries::Vector{NamedTuple}, model_compare_file::Union{Nothing,String}, branch_b_diagnostic_csv::AbstractString, branch_b_sweep_csv::Union{Nothing,String}, worst_offenders_csv::Union{Nothing,String}, pv_bus_diagnostics_csv::Union{Nothing,String}, pv_bus_diagnostics_note::Union{Nothing,String}, active_flow_diagnostics)
   open(path, "w") do io
     println(io, "# FOR002 validation summary")
     println(io)
@@ -1280,6 +1544,7 @@ function _write_summary(path::AbstractString, opt::CliOptions, ref_scenarios::Ve
     println(io, "- Transformer b scale: ", opt.trafo_b_scale)
     println(io, "- MATPOWER ratio: ", opt.matpower_ratio)
     println(io, "- Infer PV buses mode: ", opt.infer_pv_buses)
+    println(io, "- Diagnose active flow: ", opt.diagnose_active_flow)
     println(io, "- MATPOWER PQ generator controllers: ", opt.matpower_pq_gen_controllers)
     println(io, "- Builder PQ generator controllers: ", opt.builder_pq_gen_controllers)
     println(io, "- Builder controller handling: native-builder control is applied by clearing P(U)/Q(U) controllers on non-regulating generators after the builder returns; if none are present, the option is a no-op for that builder.")
@@ -1296,6 +1561,11 @@ function _write_summary(path::AbstractString, opt::CliOptions, ref_scenarios::Ve
     end
     if pv_bus_diagnostics_note !== nothing
       println(io, "- PV bus diagnostics note: ", pv_bus_diagnostics_note)
+    end
+    if active_flow_diagnostics !== nothing
+      println(io, "- Active power balance diagnostics CSV: `", active_flow_diagnostics.active_csv, "`")
+      println(io, "- Branch parameter diagnostics CSV: `", active_flow_diagnostics.branch_csv, "`")
+      println(io, "- Transformer tap diagnostics CSV: `", active_flow_diagnostics.transformer_csv, "`")
     end
     println(io)
     println(io, "## Solver settings")
@@ -1433,6 +1703,7 @@ function main(args = ARGS)
   println("  transformer b scale     = ", opt.trafo_b_scale)
   println("  branch b sweep          = ", opt.sweep_branch_b)
   println("  infer PV buses          = ", opt.infer_pv_buses)
+  println("  diagnose active flow    = ", opt.diagnose_active_flow)
   println("  MATPOWER ratio          = ", opt.matpower_ratio)
   println("  MATPOWER PQ controllers = ", opt.matpower_pq_gen_controllers)
   println("  builder PQ controllers  = ", opt.builder_pq_gen_controllers)
@@ -1498,6 +1769,8 @@ function main(args = ARGS)
   end
 
   worst_offenders_csv = isempty(base_results) ? nothing : _write_worst_offenders_csv(joinpath(opt.output_dir, "for002_worst_offenders.csv"), ref_base, base_results, branch_labels)
+  active_flow_diagnostics = opt.diagnose_active_flow ? _write_active_flow_diagnostics(opt, ref_base, base_results, branch_labels) : nothing
+  _print_active_flow_console_summary(active_flow_diagnostics)
 
   contingency_summaries = NamedTuple[]
   if opt.run_contingencies
@@ -1528,13 +1801,18 @@ function main(args = ARGS)
   end
 
   summary_path = joinpath(opt.output_dir, "for002_validation_summary.md")
-  _write_summary(summary_path, opt, ref_scenarios, branch_labels, base_summaries, contingency_summaries, model_compare_file, branch_b_diagnostic_csv, branch_b_sweep_csv, worst_offenders_csv, pv_bus_diagnostics_csv, pv_bus_diagnostics_note)
+  _write_summary(summary_path, opt, ref_scenarios, branch_labels, base_summaries, contingency_summaries, model_compare_file, branch_b_diagnostic_csv, branch_b_sweep_csv, worst_offenders_csv, pv_bus_diagnostics_csv, pv_bus_diagnostics_note, active_flow_diagnostics)
 
   println()
   println("Output files written to:")
   println("  summary                = ", summary_path)
   println("  branch b diagnostics   = ", branch_b_diagnostic_csv)
   println("  PV bus diagnostics     = ", pv_bus_diagnostics_csv)
+  if active_flow_diagnostics !== nothing
+    println("  active power balance  = ", active_flow_diagnostics.active_csv)
+    println("  branch parameters     = ", active_flow_diagnostics.branch_csv)
+    println("  transformer taps      = ", active_flow_diagnostics.transformer_csv)
+  end
   branch_b_sweep_csv !== nothing && println("  branch b sweep summary = ", branch_b_sweep_csv)
   worst_offenders_csv !== nothing && println("  worst offenders        = ", worst_offenders_csv)
   for s in base_summaries

--- a/examples/validate_for002_testnetz13_v2.jl
+++ b/examples/validate_for002_testnetz13_v2.jl
@@ -73,6 +73,8 @@ struct CliOptions
   matpower_ratio::Symbol
   matpower_pq_gen_controllers::Bool
   builder_pq_gen_controllers::Bool
+  sweep_branch_b::Bool
+  infer_pv_buses::Symbol
 end
 
 struct ModelRunResult
@@ -129,6 +131,7 @@ function _parse_cli_args(args::Vector{String})::CliOptions
     "matpower-ratio" => "normal",
     "matpower-pq-gen-controllers" => "true",
     "builder-pq-gen-controllers" => "true",
+    "infer-pv-buses" => "off",
   )
   line_b_scale_value = nothing
   trafo_b_scale_value = nothing
@@ -138,10 +141,13 @@ function _parse_cli_args(args::Vector{String})::CliOptions
   autodamp = true
   opt_flatstart = false
   qlimits_enabled = false
+  sweep_branch_b = false
 
   for arg in args
     if arg == "--contingencies"
       run_contingencies = true
+    elseif arg == "--sweep-branch-b"
+      sweep_branch_b = true
     elseif arg == "--no-matpower"
       run_matpower = false
     elseif arg == "--no-builder"
@@ -180,6 +186,9 @@ function _parse_cli_args(args::Vector{String})::CliOptions
       println("  --branch-b-scale=X         diagnostic multiplier for branch b_pu before solving")
       println("  --line-b-scale=X           diagnostic multiplier for AC-line branch b_pu before solving")
       println("  --trafo-b-scale=X          diagnostic multiplier for transformer branch b_pu before solving")
+      println("  --sweep-branch-b           run compact base-case line/transformer branch-charging sweep")
+      println("  --infer-pv-buses=off|from-q-limits|from-gen-vg|all-generator-buses")
+      println("                              diagnostic PV-bus inference mode; default off")
       println("  --matpower-ratio=normal|reciprocal")
       println("                              MATPOWER import transformer-ratio convention for this validator")
       println("  --matpower-pq-gen-controllers=true|false")
@@ -210,6 +219,8 @@ function _parse_cli_args(args::Vector{String})::CliOptions
   trafo_b_scale = trafo_b_scale_value === nothing ? branch_b_scale : parse(Float64, trafo_b_scale_value)
   matpower_ratio = Symbol(defaults["matpower-ratio"])
   matpower_ratio in (:normal, :reciprocal) || throw(ArgumentError("Unsupported --matpower-ratio=$(defaults["matpower-ratio"]); expected normal or reciprocal."))
+  infer_pv_buses = Symbol(defaults["infer-pv-buses"])
+  infer_pv_buses in (:off, Symbol("from-q-limits"), Symbol("from-gen-vg"), Symbol("all-generator-buses")) || throw(ArgumentError("Unsupported --infer-pv-buses=$(defaults["infer-pv-buses"]); expected off, from-q-limits, from-gen-vg, or all-generator-buses."))
   matpower_pq_gen_controllers = _parse_bool_option("--matpower-pq-gen-controllers", defaults["matpower-pq-gen-controllers"])
   builder_pq_gen_controllers = _parse_bool_option("--builder-pq-gen-controllers", defaults["builder-pq-gen-controllers"])
 
@@ -241,6 +252,8 @@ function _parse_cli_args(args::Vector{String})::CliOptions
     matpower_ratio,
     matpower_pq_gen_controllers,
     builder_pq_gen_controllers,
+    sweep_branch_b,
+    infer_pv_buses,
   )
 end
 
@@ -877,6 +890,137 @@ function _base_pass(bus_cmp, branch_cmp, totals, result::ModelRunResult, opt::Cl
          total_ok
 end
 
+_diagnostic_objective(bus_cmp, branch_cmp) =
+  bus_cmp.max_abs_d_v_kV +
+  10.0 * bus_cmp.max_abs_d_va_deg +
+  0.05 * bus_cmp.max_abs_d_q_gen_MVar +
+  0.05 * branch_cmp.max_abs_d_q_MVar
+
+function _with_branch_b_sweep_point(opt::CliOptions, line_b_scale::Float64, trafo_b_scale::Float64)::CliOptions
+  return CliOptions(
+    opt.for002_path,
+    opt.matpower_path,
+    opt.builder_path,
+    opt.builder_function,
+    opt.output_dir,
+    opt.run_matpower,
+    opt.run_builder,
+    false,
+    opt.maxiter,
+    opt.solver_tol,
+    opt.verbose,
+    opt.autodamp,
+    opt.opt_flatstart,
+    opt.qlimits_enabled,
+    opt.tol_v_kV,
+    opt.tol_vm_pu,
+    opt.tol_va_deg,
+    opt.tol_p_MW,
+    opt.tol_q_MVar,
+    opt.tol_branch_p_MW,
+    opt.tol_branch_q_MVar,
+    opt.branch_b_scale,
+    line_b_scale,
+    trafo_b_scale,
+    :normal,
+    true,
+    true,
+    opt.sweep_branch_b,
+    opt.infer_pv_buses,
+  )
+end
+
+function _run_branch_b_sweep(opt::CliOptions, ref_base::For002Scenario, model_builders::Vector{Tuple{String,Function}}, branch_labels::Vector{String})
+  line_scales = [0.30, 0.35, 0.40, 0.45, 0.50, 0.55]
+  trafo_scales = [0.0, 0.5, 1.0]
+  rows = NamedTuple[]
+  scratch_dir = joinpath(opt.output_dir, "_branch_b_sweep_details")
+  mkpath(scratch_dir)
+
+  for line_b_scale in line_scales, trafo_b_scale in trafo_scales
+    sweep_opt = _with_branch_b_sweep_point(opt, line_b_scale, trafo_b_scale)
+    metrics = Dict{String,NamedTuple}()
+    for (model_name, buildfn) in model_builders
+      result = _run_model(model_name, buildfn, sweep_opt, "base")
+      tag = "$(model_name)_line$(_case_tag(string(line_b_scale)))_trafo$(_case_tag(string(trafo_b_scale)))"
+      bus_cmp = _compare_bus_rows(ref_base, result, sweep_opt, joinpath(scratch_dir, tag * "_bus_comparison.csv"))
+      branch_cmp = _compare_branch_rows(ref_base, result, branch_labels, sweep_opt, joinpath(scratch_dir, tag * "_branch_comparison.csv"))
+      totals = _compare_totals(ref_base, result)
+      metrics[String(model_name)] = (
+        status = result.status,
+        max_abs_d_v_kV = bus_cmp.max_abs_d_v_kV,
+        max_abs_d_va_deg = bus_cmp.max_abs_d_va_deg,
+        max_abs_d_q_gen_MVar = bus_cmp.max_abs_d_q_gen_MVar,
+        max_abs_branch_d_p_MW = branch_cmp.max_abs_d_p_MW,
+        max_abs_branch_d_q_MVar = branch_cmp.max_abs_d_q_MVar,
+        total_d_p_loss_MW = totals.d_p_loss_MW,
+        total_d_q_loss_MVar = totals.d_q_loss_MVar,
+        objective = _diagnostic_objective(bus_cmp, branch_cmp),
+      )
+    end
+    missing_metrics = (status = missing, max_abs_d_v_kV = missing, max_abs_d_va_deg = missing, max_abs_d_q_gen_MVar = missing, max_abs_branch_d_p_MW = missing, max_abs_branch_d_q_MVar = missing, total_d_p_loss_MW = missing, total_d_q_loss_MVar = missing, objective = Inf)
+    matpower = get(metrics, "matpower", missing_metrics)
+    builder = get(metrics, "builder", missing_metrics)
+    push!(
+      rows,
+      (
+        line_b_scale = line_b_scale,
+        trafo_b_scale = trafo_b_scale,
+        matpower_status = matpower.status,
+        builder_status = builder.status,
+        matpower_max_abs_d_v_kV = matpower.max_abs_d_v_kV,
+        matpower_max_abs_d_va_deg = matpower.max_abs_d_va_deg,
+        matpower_max_abs_d_q_gen_MVar = matpower.max_abs_d_q_gen_MVar,
+        matpower_max_abs_branch_d_p_MW = matpower.max_abs_branch_d_p_MW,
+        matpower_max_abs_branch_d_q_MVar = matpower.max_abs_branch_d_q_MVar,
+        matpower_total_d_p_loss_MW = matpower.total_d_p_loss_MW,
+        matpower_total_d_q_loss_MVar = matpower.total_d_q_loss_MVar,
+        matpower_objective = matpower.objective,
+        builder_max_abs_d_v_kV = builder.max_abs_d_v_kV,
+        builder_max_abs_d_va_deg = builder.max_abs_d_va_deg,
+        builder_max_abs_d_q_gen_MVar = builder.max_abs_d_q_gen_MVar,
+        builder_max_abs_branch_d_p_MW = builder.max_abs_branch_d_p_MW,
+        builder_max_abs_branch_d_q_MVar = builder.max_abs_branch_d_q_MVar,
+        builder_total_d_p_loss_MW = builder.total_d_p_loss_MW,
+        builder_total_d_q_loss_MVar = builder.total_d_q_loss_MVar,
+        builder_objective = builder.objective,
+      ),
+    )
+  end
+  return rows
+end
+
+function _write_branch_b_sweep_summary_csv(path::AbstractString, rows::Vector{NamedTuple})
+  open(path, "w") do io
+    println(io, "line_b_scale,trafo_b_scale,matpower_status,builder_status,matpower_max_abs_d_v_kV,matpower_max_abs_d_va_deg,matpower_max_abs_d_q_gen_MVar,matpower_max_abs_branch_d_p_MW,matpower_max_abs_branch_d_q_MVar,matpower_total_d_p_loss_MW,matpower_total_d_q_loss_MVar,matpower_objective,builder_max_abs_d_v_kV,builder_max_abs_d_va_deg,builder_max_abs_d_q_gen_MVar,builder_max_abs_branch_d_p_MW,builder_max_abs_branch_d_q_MVar,builder_total_d_p_loss_MW,builder_total_d_q_loss_MVar,builder_objective")
+    for row in rows
+      println(io, _csv_line(row.line_b_scale, row.trafo_b_scale, row.matpower_status, row.builder_status, row.matpower_max_abs_d_v_kV, row.matpower_max_abs_d_va_deg, row.matpower_max_abs_d_q_gen_MVar, row.matpower_max_abs_branch_d_p_MW, row.matpower_max_abs_branch_d_q_MVar, row.matpower_total_d_p_loss_MW, row.matpower_total_d_q_loss_MVar, row.matpower_objective, row.builder_max_abs_d_v_kV, row.builder_max_abs_d_va_deg, row.builder_max_abs_d_q_gen_MVar, row.builder_max_abs_branch_d_p_MW, row.builder_max_abs_branch_d_q_MVar, row.builder_total_d_p_loss_MW, row.builder_total_d_q_loss_MVar, row.builder_objective))
+    end
+  end
+  return path
+end
+
+function _print_best_sweep_rows(rows::Vector{NamedTuple})
+  isempty(rows) && return nothing
+  println("Branch-b sweep objective: max_abs_d_v_kV + 10.0*max_abs_d_va_deg + 0.05*max_abs_d_q_gen_MVar + 0.05*max_abs_branch_d_q_MVar")
+  for (label, field) in (("MATPOWER", :matpower_objective), ("Builder", :builder_objective))
+    best = first(sort(rows; by = row -> getfield(row, field)))
+    @printf(
+      "  Best %-8s line_b_scale=%.2f trafo_b_scale=%.1f objective=%.6g max|dV|=%.6g kV max|dVa|=%.6g deg max|dQgen|=%.6g MVar max branch |dQ|=%.6g MVar\n",
+      label,
+      best.line_b_scale,
+      best.trafo_b_scale,
+      getfield(best, field),
+      getfield(best, Symbol(lowercase(label) * "_max_abs_d_v_kV")),
+      getfield(best, Symbol(lowercase(label) * "_max_abs_d_va_deg")),
+      getfield(best, Symbol(lowercase(label) * "_max_abs_d_q_gen_MVar")),
+      getfield(best, Symbol(lowercase(label) * "_max_abs_branch_d_q_MVar")),
+    )
+  end
+  println()
+  return nothing
+end
+
 function _compare_two_model_runs(a::ModelRunResult, b::ModelRunResult, path::AbstractString)
   ad = _bus_result_dict(a.report)
   bd = _bus_result_dict(b.report)
@@ -919,12 +1063,206 @@ function _compare_two_model_runs(a::ModelRunResult, b::ModelRunResult, path::Abs
   return path
 end
 
+function _worst_offender_rows(ref::For002Scenario, result::ModelRunResult, branch_labels::Vector{String}; top_n::Int = 40)
+  rows = NamedTuple[]
+  calc_buses = _bus_result_dict(result.report)
+  for key in sort(collect(keys(ref.buses)))
+    r = ref.buses[key]
+    c = get(calc_buses, key, nothing)
+    c === nothing && continue
+    bus_name = String(r.bus_name)
+    candidates = (
+      ("d_v_kV", c.v_kV - r.v_kV, r.v_kV, c.v_kV),
+      ("d_va_deg", _angle_delta_deg(c.va_deg, r.va_deg), r.va_deg, c.va_deg),
+      ("d_p_gen_MW", c.p_gen_MW - r.p_gen_MW, r.p_gen_MW, c.p_gen_MW),
+      ("d_q_gen_MVar", c.q_gen_MVar - r.q_gen_MVar, r.q_gen_MVar, c.q_gen_MVar),
+      ("d_p_load_MW", c.p_load_MW - r.p_load_MW, r.p_load_MW, c.p_load_MW),
+      ("d_q_load_MVar", c.q_load_MVar - r.q_load_MVar, r.q_load_MVar, c.q_load_MVar),
+    )
+    for (deviation_type, signed_deviation, reference_value, calculated_value) in candidates
+      push!(rows, (kind = "bus", model = result.model_name, element = bus_name, deviation_type = deviation_type, absolute_deviation = abs(signed_deviation), signed_deviation = signed_deviation, reference_value = reference_value, calculated_value = calculated_value))
+    end
+  end
+
+  ref_branches = _reference_branch_dict(ref)
+  calc_branches = _branch_result_dict(result, branch_labels)
+  for key in sort(collect(keys(ref_branches)); by = x -> (x[1], x[2], x[3]))
+    r = ref_branches[key]
+    c = get(calc_branches, key, nothing)
+    c === nothing && continue
+    element = isempty(c.nr) ? "$(c.from_name) -> $(c.to_name)" : "$(c.from_name) -> $(c.to_name) [$(c.nr)]"
+    candidates = (
+      ("d_p_MW", c.p_MW - r.p_MW, r.p_MW, c.p_MW),
+      ("d_q_MVar", c.q_MVar - r.q_MVar, r.q_MVar, c.q_MVar),
+      ("d_p_loss_MW", c.p_loss_MW - r.p_loss_MW, r.p_loss_MW, c.p_loss_MW),
+      ("d_q_loss_MVar", c.q_loss_MVar - r.q_loss_MVar, r.q_loss_MVar, c.q_loss_MVar),
+    )
+    for (deviation_type, signed_deviation, reference_value, calculated_value) in candidates
+      push!(rows, (kind = "branch", model = result.model_name, element = element, deviation_type = deviation_type, absolute_deviation = abs(signed_deviation), signed_deviation = signed_deviation, reference_value = reference_value, calculated_value = calculated_value))
+    end
+  end
+  sorted_rows = sort(rows; by = row -> row.absolute_deviation, rev = true)
+  return sorted_rows[1:min(top_n, length(sorted_rows))]
+end
+
+function _write_worst_offenders_csv(path::AbstractString, ref::For002Scenario, base_results::Vector{ModelRunResult}, branch_labels::Vector{String})
+  rows = NamedTuple[]
+  for result in base_results
+    append!(rows, _worst_offender_rows(ref, result, branch_labels))
+  end
+  rows = sort(rows; by = row -> row.absolute_deviation, rev = true)
+  open(path, "w") do io
+    println(io, "kind,model,element,deviation_type,absolute_deviation,signed_deviation,reference_value,calculated_value")
+    for row in rows
+      println(io, _csv_line(row.kind, row.model, row.element, row.deviation_type, row.absolute_deviation, row.signed_deviation, row.reference_value, row.calculated_value))
+    end
+  end
+  return path
+end
+
+function _matpower_generator_bus_metadata(mpc)
+  by_bus = Dict{Int,NamedTuple}()
+  size(mpc.gen, 2) >= 10 || return by_bus
+  @inbounds for g in axes(mpc.gen, 1)
+    size(mpc.gen, 2) >= 8 && Float64(mpc.gen[g, 8]) <= 0.0 && continue
+    bus = Int(mpc.gen[g, 1])
+    prev = get(by_bus, bus, (qmin = nothing, qmax = nothing, vg = nothing))
+    qmin = Float64(mpc.gen[g, 5])
+    qmax = Float64(mpc.gen[g, 4])
+    vg = size(mpc.gen, 2) >= 6 ? Float64(mpc.gen[g, 6]) : NaN
+    by_bus[bus] = (
+      qmin = prev.qmin === nothing ? qmin : prev.qmin + qmin,
+      qmax = prev.qmax === nothing ? qmax : prev.qmax + qmax,
+      vg = prev.vg === nothing && isfinite(vg) && vg > 0.0 ? vg : prev.vg,
+    )
+  end
+  return by_bus
+end
+
+function _first_valid_generator_vset(generators)::Union{Nothing,Float64}
+  for ps in generators
+    ps.vm_pu === nothing && continue
+    vm = Float64(ps.vm_pu)
+    isfinite(vm) && vm > 0.0 && return vm
+  end
+  return nothing
+end
+
+function _pv_inference_rows_and_apply!(net::Net, opt::CliOptions, model_name::AbstractString; mpc = nothing, apply::Bool = true)
+  mode = opt.infer_pv_buses
+  rows = NamedTuple[]
+  bus_names = _bus_name_by_idx(net)
+  matpower_meta = mpc === nothing ? Dict{Int,NamedTuple}() : _matpower_generator_bus_metadata(mpc)
+
+  for bus_idx in sort(collect(keys(bus_names)))
+    node = net.nodeVec[bus_idx]
+    prosumers = Sparlectra.getBusProsumers(net, bus_idx)
+    generators = [ps for ps in prosumers if Sparlectra.isGenerator(ps)]
+    isempty(generators) && continue
+
+    original_type = String(Sparlectra.toString(Sparlectra.getNodeType(node)))
+    original_regulated = any(ps -> ps.isRegulated, generators)
+    p_gen = sum((ps.pVal === nothing ? 0.0 : Float64(ps.pVal)) for ps in generators)
+    q_gen = sum((ps.qVal === nothing ? 0.0 : Float64(ps.qVal)) for ps in generators)
+    q_min_local = all(ps -> ps.minQ !== nothing, generators) ? sum(Float64(ps.minQ) for ps in generators) : nothing
+    q_max_local = all(ps -> ps.maxQ !== nothing, generators) ? sum(Float64(ps.maxQ) for ps in generators) : nothing
+    orig_bus = get(net.busOrigIdxDict, bus_idx, bus_idx)
+    raw_meta = get(matpower_meta, orig_bus, nothing)
+    q_min = raw_meta === nothing ? q_min_local : raw_meta.qmin
+    q_max = raw_meta === nothing ? q_max_local : raw_meta.qmax
+    vg = raw_meta === nothing ? nothing : raw_meta.vg
+    ps_vset = _first_valid_generator_vset(generators)
+    current_vm = isfinite(node._vm_pu) && node._vm_pu > 0.0 ? node._vm_pu : nothing
+
+    vset = nothing
+    should_infer = false
+    reason = "mode off"
+    if mode == :off
+      vset = vg === nothing ? ps_vset : vg
+    elseif Sparlectra.getNodeType(node) == Sparlectra.Slack
+      vset = vg === nothing ? something(ps_vset, current_vm) : vg
+      reason = "slack generator bus left unchanged"
+    elseif mode == Symbol("from-q-limits")
+      vset = vg === nothing ? ps_vset : vg
+      finite_limits = q_min !== nothing && q_max !== nothing && isfinite(q_min) && isfinite(q_max)
+      should_infer = finite_limits && vset !== nothing && isfinite(vset) && vset > 0.0
+      reason = should_infer ? "finite Q limits and voltage setpoint" : "missing finite Q limits or voltage setpoint"
+    elseif mode == Symbol("from-gen-vg")
+      vset = vg === nothing ? ps_vset : vg
+      should_infer = vset !== nothing && isfinite(vset) && vset > 0.0
+      reason = raw_meta === nothing ? "native generator voltage setpoint" : "MATPOWER GEN.VG voltage setpoint"
+    elseif mode == Symbol("all-generator-buses")
+      vset = something(vg, ps_vset, current_vm, 1.0)
+      should_infer = isfinite(vset) && vset > 0.0
+      reason = "diagnostic all non-slack generator buses"
+    end
+
+    if apply && should_infer
+      for ps in generators
+        ps.isRegulated = true
+        ps.vm_pu = vset
+      end
+      Sparlectra.setVmVa!(node = node, vm_pu = vset)
+    end
+
+    inferred_type = if should_infer
+      "PV"
+    else
+      original_type
+    end
+    push!(
+      rows,
+      (
+        model = String(model_name),
+        bus_name = bus_names[bus_idx],
+        original_bus_type = original_type,
+        original_regulation_state = original_regulated,
+        inferred_bus_type = inferred_type,
+        has_generator = true,
+        p_gen_MW = p_gen,
+        q_gen_MVar_before = q_gen,
+        q_min_MVar = q_min,
+        q_max_MVar = q_max,
+        voltage_setpoint_pu = vset,
+        inference_reason = reason,
+      ),
+    )
+  end
+
+  if apply && mode != :off
+    Sparlectra.refreshBusTypesFromProsumers!(net)
+    Sparlectra.buildQLimits!(net)
+  end
+  return rows
+end
+
+function _write_pv_bus_diagnostics_csv(path::AbstractString, rows::Vector{NamedTuple})
+  open(path, "w") do io
+    println(io, "model,bus_name,original_bus_type,original_regulation_state,inferred_bus_type,has_generator,p_gen_MW,q_gen_MVar_before,q_min_MVar,q_max_MVar,voltage_setpoint_pu,inference_reason")
+    for row in rows
+      println(io, _csv_line(row.model, row.bus_name, row.original_bus_type, row.original_regulation_state, row.inferred_bus_type, row.has_generator, row.p_gen_MW, row.q_gen_MVar_before, row.q_min_MVar, row.q_max_MVar, row.voltage_setpoint_pu, row.inference_reason))
+    end
+  end
+  return path
+end
+
+function _pv_bus_diagnostics_note(opt::CliOptions, rows::Vector{NamedTuple})::Union{Nothing,String}
+  opt.infer_pv_buses == :off && return nothing
+  builder_rows = [row for row in rows if row.model == "builder"]
+  isempty(builder_rows) && return "Native Builder PV inference was not evaluated because the Builder model path was disabled."
+  blocked = [row.bus_name for row in builder_rows if occursin("missing finite Q limits", row.inference_reason)]
+  if !isempty(blocked)
+    return "Native Builder from-q-limits inference was not technically feasible for buses without finite builder-side Q limits: " * join(blocked, ", ")
+  end
+  return nothing
+end
+
 function _scenario_file_prefix(result::ModelRunResult)::String
   scenario_tag = replace(result.scenario_name, r"[^A-Za-z0-9_.-]" => "_")
   return lowercase(result.model_name) * "_" * scenario_tag
 end
 
-function _write_summary(path::AbstractString, opt::CliOptions, ref_scenarios::Vector{For002Scenario}, branch_labels::Vector{String}, base_summaries::Vector{NamedTuple}, contingency_summaries::Vector{NamedTuple}, model_compare_file::Union{Nothing,String}, branch_b_diagnostic_csv::AbstractString)
+function _write_summary(path::AbstractString, opt::CliOptions, ref_scenarios::Vector{For002Scenario}, branch_labels::Vector{String}, base_summaries::Vector{NamedTuple}, contingency_summaries::Vector{NamedTuple}, model_compare_file::Union{Nothing,String}, branch_b_diagnostic_csv::AbstractString, branch_b_sweep_csv::Union{Nothing,String}, worst_offenders_csv::Union{Nothing,String}, pv_bus_diagnostics_csv::Union{Nothing,String}, pv_bus_diagnostics_note::Union{Nothing,String})
   open(path, "w") do io
     println(io, "# FOR002 validation summary")
     println(io)
@@ -941,10 +1279,24 @@ function _write_summary(path::AbstractString, opt::CliOptions, ref_scenarios::Ve
     println(io, "- Line b scale: ", opt.line_b_scale)
     println(io, "- Transformer b scale: ", opt.trafo_b_scale)
     println(io, "- MATPOWER ratio: ", opt.matpower_ratio)
+    println(io, "- Infer PV buses mode: ", opt.infer_pv_buses)
     println(io, "- MATPOWER PQ generator controllers: ", opt.matpower_pq_gen_controllers)
     println(io, "- Builder PQ generator controllers: ", opt.builder_pq_gen_controllers)
     println(io, "- Builder controller handling: native-builder control is applied by clearing P(U)/Q(U) controllers on non-regulating generators after the builder returns; if none are present, the option is a no-op for that builder.")
     println(io, "- Branch charging diagnostic CSV: `", branch_b_diagnostic_csv, "`")
+    if branch_b_sweep_csv !== nothing
+      println(io, "- Branch charging sweep summary CSV: `", branch_b_sweep_csv, "`")
+      println(io, "- Branch charging sweep objective: `max_abs_d_v_kV + 10.0 * max_abs_d_va_deg + 0.05 * max_abs_d_q_gen_MVar + 0.05 * max_abs_branch_d_q_MVar`")
+    end
+    if worst_offenders_csv !== nothing
+      println(io, "- Worst-offender deviations CSV: `", worst_offenders_csv, "`")
+    end
+    if pv_bus_diagnostics_csv !== nothing
+      println(io, "- PV bus diagnostics CSV: `", pv_bus_diagnostics_csv, "`")
+    end
+    if pv_bus_diagnostics_note !== nothing
+      println(io, "- PV bus diagnostics note: ", pv_bus_diagnostics_note)
+    end
     println(io)
     println(io, "## Solver settings")
     println(io, "- maxiter: ", opt.maxiter)
@@ -1021,7 +1373,7 @@ function _write_summary(path::AbstractString, opt::CliOptions, ref_scenarios::Ve
   return path
 end
 
-function _load_builder_function(builder_path::AbstractString, builder_function::AbstractString, opt::CliOptions)
+function _load_builder_function(builder_path::AbstractString, builder_function::AbstractString, opt::CliOptions, pv_bus_diagnostic_rows::Vector{NamedTuple})
   isfile(builder_path) || throw(ArgumentError("Native Sparlectra builder file not found: $builder_path"))
 
   # Julia 1.12 + Revise can otherwise see the freshly included builder method
@@ -1040,24 +1392,29 @@ function _load_builder_function(builder_path::AbstractString, builder_function::
       cleared = _clear_pq_gen_controllers!(net)
       cleared == 0 && @info "Builder PQ generator controller diagnostic requested, but no native-builder PQ generator P(U)/Q(U) controllers were present to clear."
     end
+    append!(pv_bus_diagnostic_rows, _pv_inference_rows_and_apply!(net, opt, "builder"; apply = true))
     return net
   end
 end
 
-function _load_matpower_builder(matpower_path::AbstractString, opt::CliOptions)
+function _load_matpower_builder(matpower_path::AbstractString, opt::CliOptions, pv_bus_diagnostic_rows::Vector{NamedTuple})
   isfile(matpower_path) || throw(ArgumentError("MATPOWER file not found: $matpower_path"))
   mpc = Sparlectra.MatpowerIO.read_case(matpower_path; legacy_compat = true)
-  return () -> Sparlectra.createNetFromMatPowerCase(
-    mpc = mpc,
-    log = false,
-    flatstart = false,
-    apply_bus_names = true,
-    apply_branch_names = true,
-    apply_branch_kind = true,
-    import_for001_contingencies = true,
-    matpower_ratio = opt.matpower_ratio,
-    enable_pq_gen_controllers = opt.matpower_pq_gen_controllers,
-  )
+  return () -> begin
+    net = Sparlectra.createNetFromMatPowerCase(
+      mpc = mpc,
+      log = false,
+      flatstart = false,
+      apply_bus_names = true,
+      apply_branch_names = true,
+      apply_branch_kind = true,
+      import_for001_contingencies = true,
+      matpower_ratio = opt.matpower_ratio,
+      enable_pq_gen_controllers = opt.matpower_pq_gen_controllers,
+    )
+    append!(pv_bus_diagnostic_rows, _pv_inference_rows_and_apply!(net, opt, "matpower"; mpc = mpc, apply = true))
+    return net
+  end
 end
 
 function main(args = ARGS)
@@ -1074,6 +1431,8 @@ function main(args = ARGS)
   println("  branch b scale          = ", opt.branch_b_scale)
   println("  line b scale            = ", opt.line_b_scale)
   println("  transformer b scale     = ", opt.trafo_b_scale)
+  println("  branch b sweep          = ", opt.sweep_branch_b)
+  println("  infer PV buses          = ", opt.infer_pv_buses)
   println("  MATPOWER ratio          = ", opt.matpower_ratio)
   println("  MATPOWER PQ controllers = ", opt.matpower_pq_gen_controllers)
   println("  builder PQ controllers  = ", opt.builder_pq_gen_controllers)
@@ -1085,19 +1444,35 @@ function main(args = ARGS)
   ref_base = ref_scenarios[1]
   branch_labels = _parse_matpower_string_vector(opt.matpower_path, "branch_name")
 
+  pv_bus_diagnostic_rows = NamedTuple[]
   model_builders = Tuple{String,Function}[]
   if opt.run_matpower
-    push!(model_builders, ("matpower", _load_matpower_builder(opt.matpower_path, opt)))
+    push!(model_builders, ("matpower", _load_matpower_builder(opt.matpower_path, opt, pv_bus_diagnostic_rows)))
   end
   if opt.run_builder
-    push!(model_builders, ("builder", _load_builder_function(opt.builder_path, opt.builder_function, opt)))
+    push!(model_builders, ("builder", _load_builder_function(opt.builder_path, opt.builder_function, opt, pv_bus_diagnostic_rows)))
   end
 
   branch_b_diagnostic_rows = _branch_b_diagnostic_rows(opt, model_builders, branch_labels)
   branch_b_diagnostic_csv = _write_branch_b_diagnostic_csv(joinpath(opt.output_dir, "branch_b_diagnostics.csv"), branch_b_diagnostic_rows)
   _print_branch_b_diagnostic_table(branch_b_diagnostic_rows)
   println("Branch charging diagnostic CSV: ", branch_b_diagnostic_csv)
+  first_pv_bus_diagnostic_rows = copy(pv_bus_diagnostic_rows)
+  pv_bus_diagnostics_csv = _write_pv_bus_diagnostics_csv(joinpath(opt.output_dir, "pv_bus_diagnostics.csv"), first_pv_bus_diagnostic_rows)
+  pv_bus_diagnostics_note = _pv_bus_diagnostics_note(opt, first_pv_bus_diagnostic_rows)
+  println("PV bus diagnostics CSV: ", pv_bus_diagnostics_csv)
+  pv_bus_diagnostics_note !== nothing && println("PV bus diagnostics note: ", pv_bus_diagnostics_note)
   println()
+
+  branch_b_sweep_csv = nothing
+  if opt.sweep_branch_b
+    println("[sweep] running compact branch charging scale sweep")
+    sweep_rows = _run_branch_b_sweep(opt, ref_base, model_builders, branch_labels)
+    branch_b_sweep_csv = _write_branch_b_sweep_summary_csv(joinpath(opt.output_dir, "branch_b_sweep_summary.csv"), sweep_rows)
+    _print_best_sweep_rows(sweep_rows)
+    println("Branch charging sweep summary CSV: ", branch_b_sweep_csv)
+    println()
+  end
 
   base_results = ModelRunResult[]
   base_summaries = NamedTuple[]
@@ -1121,6 +1496,8 @@ function main(args = ARGS)
     model_compare_file = joinpath(opt.output_dir, "matpower_vs_builder_bus_comparison.csv")
     _compare_two_model_runs(base_results[1], base_results[2], model_compare_file)
   end
+
+  worst_offenders_csv = isempty(base_results) ? nothing : _write_worst_offenders_csv(joinpath(opt.output_dir, "for002_worst_offenders.csv"), ref_base, base_results, branch_labels)
 
   contingency_summaries = NamedTuple[]
   if opt.run_contingencies
@@ -1151,12 +1528,15 @@ function main(args = ARGS)
   end
 
   summary_path = joinpath(opt.output_dir, "for002_validation_summary.md")
-  _write_summary(summary_path, opt, ref_scenarios, branch_labels, base_summaries, contingency_summaries, model_compare_file, branch_b_diagnostic_csv)
+  _write_summary(summary_path, opt, ref_scenarios, branch_labels, base_summaries, contingency_summaries, model_compare_file, branch_b_diagnostic_csv, branch_b_sweep_csv, worst_offenders_csv, pv_bus_diagnostics_csv, pv_bus_diagnostics_note)
 
   println()
   println("Output files written to:")
   println("  summary                = ", summary_path)
   println("  branch b diagnostics   = ", branch_b_diagnostic_csv)
+  println("  PV bus diagnostics     = ", pv_bus_diagnostics_csv)
+  branch_b_sweep_csv !== nothing && println("  branch b sweep summary = ", branch_b_sweep_csv)
+  worst_offenders_csv !== nothing && println("  worst offenders        = ", worst_offenders_csv)
   for s in base_summaries
     println("  ", s.model_name, " bus comparison     = ", s.bus_csv)
     println("  ", s.model_name, " branch comparison  = ", s.branch_csv)


### PR DESCRIPTION
### Motivation
- Improve diagnostics in the FOR002 validator example to help identify branch-charging related mismatches and generator/PV interpretation issues when comparing converted MATPOWER and native builder models to FOR002 references.
- Provide automated diagnostic CSVs and a sweep mode to explore compact branch charging scale parameters to find better conversion settings.

### Description
- Added CLI options `--sweep-branch-b` and `--infer-pv-buses=off|from-q-limits|from-gen-vg|all-generator-buses` and corresponding fields in `CliOptions` with validation and help text.
- Implemented a branch-charging sweep (`_run_branch_b_sweep`, `_with_branch_b_sweep_point`, `_diagnostic_objective`) that runs model builds over grid of line/trafo b scales and writes a summary CSV via `_write_branch_b_sweep_summary_csv` and prints best candidates via `_print_best_sweep_rows`.
- Added PV-bus inference diagnostics and optional application to built networks (`_pv_inference_rows_and_apply!`, helpers `_matpower_generator_bus_metadata`, `_first_valid_generator_vset`) and CSV writer `_write_pv_bus_diagnostics_csv`, and a short note generator `_pv_bus_diagnostics_note`.
- Added worst-offender collection and CSV export (`_worst_offender_rows`, `_write_worst_offenders_csv`) to highlight largest absolute deviations across buses and branches.
- Integrated PV diagnostics into model builder loaders (`_load_matpower_builder`, `_load_builder_function`) so inference rows are recorded when models are created, and threaded new outputs into `main` and the summary writer `_write_summary` so new CSVs and notes appear in the final report.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a455e7fd8988330baf602e7775dc0e9)