### PR TITLE
Fix solver timing and streamline test profiles

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -13,7 +13,10 @@
 
 ### Bug Fixes
 
-* Service and wall timing remain finite and meaningful on successful and failed API/Web UI runs.
+* API/Web UI runs now report pure numerical `Solver time` separately from service-envelope `Total time`, with no generic `Wall time` label.
+* Large-case summaries use `solver_elapsed_s` and no longer emit misleading `solving_powerflow_seconds`.
+* Test failure output is bounded, fast/extended/all profiles are distinct, generated directories are excluded from repository hygiene checks, and each test group reports elapsed time, allocated MiB, and GC time.
+* `.DAT` upload classification now uses parser-consistent DFT structure, keeping FOR002 references and outage-only or unknown files out of the runnable selector.
 * Failed runs retain their service phase timing records in `result.json` and `performance.log`.
 * The Web UI PowerFlow tolerance increment follows the current value instead of using browser-generic `step="any"` behavior.
 * Tagged or installed builds no longer display `commit unknown`; the commit element is omitted when unavailable.

--- a/docs/src/dft_format.md
+++ b/docs/src/dft_format.md
@@ -1,5 +1,7 @@
 # DFT legacy input format
 
+Sparlectra reports `Solver time` as time spent inside numerical PowerFlow solver invocation(s), while `Total time` is the complete API/Web UI service envelope.
+
 Sparlectra includes a native reader for the legacy DFT files used by the legacy validation Testnetz13 examples. The importer is intended to reproduce the legacy network-model semantics used by the matching FOR002 ground-load-flow reports while preserving source fields for audit and diagnostics.
 
 ## Overview

--- a/docs/src/powerflow_service.md
+++ b/docs/src/powerflow_service.md
@@ -69,7 +69,7 @@ abort requests. Cancellation is checked around case resolution, configuration
 and import work, solving, diagnostics, and artifact writing. Import and service
 work is reported with finer phases such as `reading_matpower_case`,
 `loading_julia_case`, `building_sparlectra_net`, `preparing_start_values`,
-`solving_powerflow`, and artifact-writing phases so large MATPOWER cases no
+`solver_orchestration`, and artifact-writing phases so large MATPOWER cases no
 longer appear only as a broad loading step. The rectangular
 solver checks before and after Y-bus construction and start projection, at
 every Newton iteration boundary, after Q-limit active-set work, and after each
@@ -178,7 +178,7 @@ Interpret the major loading phases as follows:
   case; very large literal Julia cases can take several minutes on cold runs.
 - `building_sparlectra_net`: `createNetFromMatPowerCase` is constructing the
   Sparlectra network from the parsed MATPOWER data.
-- `solving_powerflow`: the rectangular Newton solve is active; detailed Y-bus,
+- `solver_orchestration`: the service has entered the power-flow orchestration path; use `solver_elapsed_s` for pure numerical solver time; detailed Y-bus,
   Newton-iteration, Q-limit, and linear-solve aggregates are in
   `performance.log`.
 

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -141,6 +141,8 @@ julia --project=. test/runtests.jl fast --verbose
 julia --project=. test/runtests.jl extended --verbose
 ```
 
+The `fast` profile runs normal unit and focused integration tests. The `extended` profile runs only extended repository-hygiene, documentation-coverage, example, and fixture-heavy checks. The `all` profile runs fast followed by extended. Set `SPARLECTRA_TEST_GC_BETWEEN_GROUPS=1` to request a GC cycle after each completed group; per-group output reports elapsed seconds, allocated MiB, and GC seconds.
+
 The `extended` profile may include MATPOWER/example/output-heavy tests and native DTF/FOR002 diagnostic-example checks. These tests stay isolated from the default profile.
 
 Use `fast` during normal development. Use `extended` before merging changes that affect configuration, MATPOWER import, output formatting, performance reporting, or broader integration paths.

--- a/src/acpflow/execution.jl
+++ b/src/acpflow/execution.jl
@@ -58,7 +58,13 @@ function _execute_sparlectra_powerflow!(net::Net, cfg::SparlectraConfig; perform
   end
   timings = performance_profile isa AbstractDict ? get(performance_profile, :timings, nothing) : nothing
   row = timings isa AbstractDict ? get(timings, :solver_total, nothing) : nothing
-  solver_elapsed_s = row isa NamedTuple && hasproperty(row, :elapsed_s) ? Float64(row.elapsed_s) : nothing
+  solver_elapsed_s = row isa NamedTuple && hasproperty(row, :elapsed_s) ? max(0.0, Float64(row.elapsed_s)) : nothing
+  if solver_elapsed_s === nothing && performance_profile isa AbstractDict && haskey(performance_profile, :solver_total)
+    legacy_row = performance_profile[:solver_total]
+    solver_elapsed_s = legacy_row isa NamedTuple && hasproperty(legacy_row, :elapsed_s) ? max(0.0, Float64(legacy_row.elapsed_s)) :
+      legacy_row isa Number ? max(0.0, Float64(legacy_row)) : nothing
+  end
+  solver_elapsed_s === nothing && (solver_elapsed_s = max(0.0, Float64(elapsed_s)))
   if cfg.powerflow.islands.enabled
     status = rectangular_pf_status(net)
     _write_ac_island_diagnostics!(net, cfg.powerflow, performance_profile; status = status)

--- a/src/api/run_diagnostic_artifacts.jl
+++ b/src/api/run_diagnostic_artifacts.jl
@@ -18,12 +18,11 @@
 
 function _write_api_timing_summary(io::IO, result::SparlectraRunResult, config::SparlectraConfig, phases::AbstractDict = Dict{Symbol,Float64}())
   benchmark_median = result.performance_profile isa AbstractDict ? get(result.performance_profile, :benchmark_median_s, nothing) : nothing
-  representative_time = result.performance_profile isa AbstractDict ? get(result.performance_profile, :representative_elapsed_s, result.elapsed_s) : result.elapsed_s
   println(io, "Timing")
   println(io, "------")
-  println(io, "Solver time : ", result.solver_elapsed_s === nothing ? "n/a" : "$(round(result.solver_elapsed_s; digits = 6)) s")
+  result.solver_elapsed_s === nothing || println(io, "Solver time : ", round(result.solver_elapsed_s; digits = 6), " s")
   haskey(phases, :artifact_writing) && println(io, "Output time : ", round(Float64(phases[:artifact_writing]); digits = 6), " s")
-  println(io, "Wall time   : ", round(Float64(representative_time); digits = 6), " s")
+  haskey(phases, :total) && println(io, "Total time  : ", round(Float64(phases[:total]); digits = 6), " s")
   if config.benchmark.enabled
     println(io, "benchmark_median:     ", benchmark_median === nothing ? "n/a" : "$(round(Float64(benchmark_median); digits = 6)) s")
     println(io, "benchmark_samples:    ", config.benchmark.samples)

--- a/src/api/run_finalization.jl
+++ b/src/api/run_finalization.jl
@@ -58,13 +58,15 @@ function _write_large_case_timing_summary(io::IO, case_path::AbstractString, pha
     println(io, "n_bus: ", length(result.net.nodeVec))
     println(io, "n_branch: ", length(result.net.branchVec))
   end
+  if result !== nothing && result.solver_elapsed_s !== nothing
+    println(io, "solver_elapsed_s: ", round(Float64(result.solver_elapsed_s); digits = 6))
+  end
   for (label, phase) in (
     ("reading_matpower_case_seconds", "reading_matpower_case"),
     ("building_sparlectra_net_seconds", "building_sparlectra_net"),
     ("building_ybus_seconds", "building_ybus"),
     ("preparing_start_values_seconds", "preparing_start_values"),
     ("start_projection_seconds", "start_projection"),
-    ("solving_powerflow_seconds", "solving_powerflow"),
     ("artifact_seconds", "writing_artifacts"),
     ("total_service_seconds", "total_service"),
   )

--- a/src/results.jl
+++ b/src/results.jl
@@ -534,8 +534,8 @@ function printACPFlowResults(net::Net, ct::Float64, ite::Int, tol::Float64, toFi
   @printf(io, "Tolerance      : %.1e\n", tol)
   @printf(io, "Solver         :%15s\n", string(solver))
   if converged
-    println(io, "Solver time : ", isnothing(solver_time_s) ? "n/a" : @sprintf("%.6f s", solver_time_s))
-    println(io, "Wall time   : ", @sprintf("%.6f s", ct))
+    isnothing(solver_time_s) || println(io, "Solver time : ", @sprintf("%.6f s", solver_time_s))
+    println(io, "Total time  : ", @sprintf("%.6f s", ct))
   else
     @printf(io, "Status         :%10s\n", "Not Converged")
   end

--- a/src/webui/forms.jl
+++ b/src/webui/forms.jl
@@ -74,17 +74,17 @@ function _webui_classify_dat_content(path::AbstractString)::Symbol
   catch
     return :unknown_dat
   end
-  lines = split(text, '\n')
-  stripped = [strip(line) for line in lines if !isempty(strip(line))]
-  has_outages = any(==("AUSFALL"), stripped) && any(==("ENDE"), stripped)
-  has_size_card = length(stripped) >= 7 && length(split(stripped[7])) >= 4 &&
-    all(token -> tryparse(Float64, token) !== nothing, split(stripped[7])[1:4])
-  has_branch = any(line -> startswith(line, "L") || startswith(line, "T"), stripped)
-  has_bus = any(line -> startswith(line, "K"), stripped)
-  has_network = has_size_card && has_branch && has_bus
-  has_network && has_outages && return :dft_network_case_with_outages
-  has_network && return :dft_network_case
-  if has_outages || _is_for002_reference_dat(path) || occursin(r"(?i)(for002|reference|ausfall|outage|vergleich|result)", text)
+  try
+    case = DTFImporter.read_dtf(path; strict = false)
+    if case.size.NGES > 0 && length(case.buses) == case.size.NGES && length(case.branches) == case.size.LGES
+      return isempty(case.outages) ? :dft_network_case : :dft_network_case_with_outages
+    end
+  catch
+  end
+  has_outages = occursin(r"(?im)^\s*AUSFALL\s*$", text) && occursin(r"(?im)^\s*ENDE\s*$", text)
+  if has_outages
+    return :dft_outage_file
+  elseif _is_for002_reference_dat(path) || occursin(r"(?i)(for002|reference|vergleich|result)", text)
     return :dft_outage_or_reference
   end
   return :unknown_dat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,9 +15,7 @@ function print_test_progress_header(profile::Symbol)
   println("Test framework: ", profile)
 end
 
-function print_group_progress(i::Int, total::Int, name::AbstractString)
-  println("[", i, "/", total, "] ", name)
-end
+function print_group_progress(i::Int, total::Int, name::AbstractString) end
 
 function include_fast_tests()
   include("testgrid.jl")
@@ -33,11 +31,13 @@ function include_fast_tests()
 end
 
 function include_extended_tests()
+  include("testgrid.jl")
   include("testremove.jl")
   include("test_pv_voltage_residuals.jl")
   include("test_matpower_example.jl")
   include("test_synthetic_grids.jl")
   include("test_configuration_docs.jl")
+  include("test_repository_hygiene.jl")
   # Experimental large-case comparison tooling is excluded from normal profiles.
 end
 
@@ -63,8 +63,7 @@ function run_fast_profile_tests()
   @testset "Sparlectra.jl fast profile" begin
     total = length(groups)
     for (i, (name, runner)) in enumerate(groups)
-      print_group_progress(i, total, name)
-      quiet_test_output(runner)
+      run_profile_group(i, total, name, runner)
     end
   end
 end
@@ -80,35 +79,35 @@ function run_extended_profile_tests()
     ("matpower_examples", () -> run_entry(:run_matpower_example_tests)),
     ("synthetic_grids", () -> run_entry(:run_synthetic_grid_tests)),
     ("configuration_docs", () -> run_entry(:run_configuration_docs_tests)),
+    ("repository_hygiene", () -> run_entry(:run_repository_hygiene_tests)),
   ]
   @testset "Sparlectra.jl extended profile" begin
     total = length(groups)
     for (i, (name, runner)) in enumerate(groups)
-      print_group_progress(i, total, name)
-      quiet_test_output(runner)
+      run_profile_group(i, total, name, runner)
     end
   end
 end
 
-if TEST_PROFILE === :fast
-  print_test_progress_header(:fast)
-  include_fast_tests()
-  run_fast_profile_tests()
-elseif TEST_PROFILE === :extended
-  print_test_progress_header(:extended)
-  include_fast_tests()
-  include_extended_tests()
-  run_fast_profile_tests()
-  run_extended_profile_tests()
-elseif TEST_PROFILE === :all
-  print_test_progress_header(:all)
-  include_fast_tests()
-  include_extended_tests()
-  # At the moment, `all` is an alias for `extended`.
-  # Keep the profile for future all-only suites and CI matrix clarity.
-  run_fast_profile_tests()
-  run_extended_profile_tests()
-else
-  error("Unknown test profile=$(TEST_PROFILE). Allowed: fast, extended, all. Selection precedence: CLI arg, SPARLECTRA_TEST_PROFILE, default fast.")
+function main()
+  if TEST_PROFILE === :fast
+    print_test_progress_header(:fast)
+    include_fast_tests()
+    run_fast_profile_tests()
+  elseif TEST_PROFILE === :extended
+    print_test_progress_header(:extended)
+    include_extended_tests()
+    run_extended_profile_tests()
+  elseif TEST_PROFILE === :all
+    print_test_progress_header(:all)
+    include_fast_tests()
+    include_extended_tests()
+    run_fast_profile_tests()
+    run_extended_profile_tests()
+  else
+    error("Unknown test profile=$(TEST_PROFILE). Allowed: fast, extended, all. Selection precedence: CLI arg, SPARLECTRA_TEST_PROFILE, default fast.")
+  end
 end
+
+Base.invokelatest(main)
 return nothing

--- a/test/test_api.jl
+++ b/test/test_api.jl
@@ -406,7 +406,7 @@ power_flow:
       @test occursin("Original MATPOWER import options", run_log)
       @test occursin("Final effective MATPOWER import options", run_log)
       @test occursin("matpower_import.auto_profile: recommend", run_log)
-      @test occursin("Wall time   :", run_log)
+      @test occursin("Total time  :", run_log)
       @test occursin("Output time :", run_log)
       @test occursin("Solver time :", run_log)
       @test !occursin("representative_time:", run_log)

--- a/test/test_repository_hygiene.jl
+++ b/test/test_repository_hygiene.jl
@@ -1,0 +1,88 @@
+# Copyright 2023–2026 Udo Schmitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+using Test
+
+const _HYGIENE_ROOTS = ("docs/src", "src", "test", "examples")
+const _HYGIENE_EXCLUDED_PARTS = Set(["docs/build", "examples/_out", "results", "coverage", ".git", ".julia", "node_modules"])
+const _HYGIENE_EXTENSIONS = Set([".jl", ".md", ".toml", ".yaml", ".yml", ".json"])
+
+function _repository_root()
+  return normpath(joinpath(@__DIR__, ".."))
+end
+
+function _is_hygiene_excluded(rel::AbstractString)::Bool
+  rel_norm = replace(rel, '\\' => '/')
+  for part in _HYGIENE_EXCLUDED_PARTS
+    rel_norm == part && return true
+    startswith(rel_norm, part * "/") && return true
+  end
+  occursin(r"(^|/)(tmp|temp|\.tmp)(/|$)"i, rel_norm) && return true
+  return false
+end
+
+function _tracked_hygiene_files(repo::AbstractString)::Vector{String}
+  files = String[]
+  git_dir = joinpath(repo, ".git")
+  if isdir(git_dir)
+    out = read(`git -C $repo ls-files`, String)
+    append!(files, split(chomp(out), '\n'))
+  else
+    for root in _HYGIENE_ROOTS
+      absroot = joinpath(repo, root)
+      isdir(absroot) || continue
+      for (dir, _, names) in walkdir(absroot)
+        for name in names
+          push!(files, relpath(joinpath(dir, name), repo))
+        end
+      end
+    end
+  end
+  return sort!(unique(filter(files) do rel
+    rel = replace(rel, '\\' => '/')
+    any(root -> rel == root || startswith(rel, root * "/"), _HYGIENE_ROOTS) || return false
+    _is_hygiene_excluded(rel) && return false
+    lowercase(splitext(rel)[2]) in _HYGIENE_EXTENSIONS
+  end))
+end
+
+function _bounded_hygiene_failure(hits::Vector{String}; limit::Int = 20)::String
+  shown = first(hits, min(limit, length(hits)))
+  lines = ["repository hygiene found $(length(hits)) forbidden terminology hit(s):"]
+  append!(lines, shown)
+  extra = length(hits) - length(shown)
+  extra > 0 && push!(lines, "... $(extra) additional hits omitted")
+  msg = join(lines, '\n')
+  return sizeof(msg) > 16 * 1024 ? String(take!(IOBuffer(codeunits(msg)[1:16 * 1024]))) : msg
+end
+
+function run_repository_hygiene_tests()
+  @testset "repository hygiene" begin
+    repo = _repository_root()
+    forbidden_terms = ["schae" * "fer", "DTF" * "/FOR001", "FOR001" * "/DTF", "FOR001" * " / DTF", "DTF" * " format", "FOR001" * " format", "native DTF" * " path", "DTF" * " outage"]
+    hits = String[]
+    for rel in _tracked_hygiene_files(repo)
+      rel == "test/test_repository_hygiene.jl" && continue
+      text = read(joinpath(repo, rel), String)
+      for term in forbidden_terms
+        occursin(Regex(term, "i"), text) || continue
+        push!(hits, "$(rel): $(term)")
+      end
+    end
+    if !isempty(hits)
+      error(_bounded_hygiene_failure(hits))
+    end
+    @test true
+  end
+end

--- a/test/test_runner_helpers.jl
+++ b/test/test_runner_helpers.jl
@@ -24,28 +24,66 @@ function sparlectra_test_verbose(args = ARGS, env = ENV)::Bool
   return lowercase(strip(get(env, "SPARLECTRA_TEST_VERBOSE", ""))) in ("1", "true", "yes", "on")
 end
 
-function quiet_test_output(f::Function; verbose::Bool = sparlectra_test_verbose())
+const QUIET_TEST_OUTPUT_MAX_BYTES = 64 * 1024
+const QUIET_TEST_OUTPUT_MAX_LINES = 200
+
+function _bounded_test_output_excerpt(path::AbstractString; max_bytes::Int = QUIET_TEST_OUTPUT_MAX_BYTES, max_lines::Int = QUIET_TEST_OUTPUT_MAX_LINES)
+  isfile(path) || return ""
+  total_bytes = filesize(path)
+  text = open(path, "r") do io
+    read(io, String; maxbytes = min(Int(total_bytes), max_bytes))
+  end
+  lines = split(text, '\n'; keepempty = true)
+  omitted_lines = max(length(lines) - max_lines, 0)
+  if length(lines) > max_lines
+    keep_head = max_lines ÷ 2
+    keep_tail = max_lines - keep_head
+    lines = vcat(lines[1:keep_head], ["... $(omitted_lines) captured lines omitted ..."], lines[end - keep_tail + 1:end])
+  end
+  omitted_bytes = max(total_bytes - sizeof(text), 0)
+  omitted_bytes > 0 && push!(lines, "... $(omitted_bytes) captured bytes omitted ...")
+  return join(lines, '\n')
+end
+
+function quiet_test_output(f::Function; verbose::Bool = sparlectra_test_verbose(), group::AbstractString = "test group")
   verbose && return Base.invokelatest(f)
   path = tempname()
   result = nothing
-  captured = ""
+  failed = false
   try
     open(path, "w+") do io
       result = redirect_stdio(stdout = io) do
         Base.invokelatest(f)
       end
-      seekstart(io)
-      captured = read(io, String)
     end
-  catch
-    isfile(path) && (captured = read(path, String))
-    !isempty(captured) && print(captured)
+  catch err
+    if err isa InterruptException
+      println(stderr, "Interrupted while running ", group, "; captured output excerpt follows.")
+      excerpt = _bounded_test_output_excerpt(path)
+      !isempty(excerpt) && print(excerpt)
+      rethrow()
+    end
+    failed = true
+    excerpt = _bounded_test_output_excerpt(path)
+    !isempty(excerpt) && print(excerpt)
     rethrow()
   finally
     ispath(path) && rm(path; force = true)
   end
-  if occursin("Test Failed", captured) || occursin("Error During Test", captured)
-    print(captured)
-  end
+  failed && print(_bounded_test_output_excerpt(path))
   return result
+end
+
+function run_profile_group(i::Int, total::Int, name::AbstractString, runner::Function)
+  print("[", i, "/", total, "] ", name, " ... ")
+  timed = try
+    @timed quiet_test_output(runner; group = name)
+  catch err
+    err isa InterruptException && (println("INTERRUPTED"); rethrow())
+    println("FAIL")
+    rethrow()
+  end
+  @printf("PASS %.3f s, %.1f MiB allocated, %.3f s GC\n", timed.time, timed.bytes / 1024.0^2, timed.gctime)
+  get(ENV, "SPARLECTRA_TEST_GC_BETWEEN_GROUPS", "0") in ("1", "true", "yes", "on") && GC.gc()
+  return timed.value
 end

--- a/test/test_webui.jl
+++ b/test/test_webui.jl
@@ -683,7 +683,7 @@ settings:
         write(warmup_m, "function mpc = warmup_internal\nend\n")
         write(warmup_jl, "nothing\n")
         write(generated_cache, "nothing\n")
-        write(for001, "P\nT\nN\nX\nY\n110\n2 1 0 0 SLACK\nL 1 A PV SLACK 1.0 2.0 0.0 0.0\nK 1 1 1 PV 110 0 0 0 10 2 -5 5\nK 2 2 1 SLACK 110 0 0 0 20 3 -10 10\n")
+        write(for001, "P\nT\nN\nX\nY\n110\n2 1 0 0 SLACK\nL1A  PV       SLACK   1.0 2.0 0.0 0.0\n11   PV      110 0 0 0 10 2 -5 5\n21   SLACK   110 0 0 0 20 3 -10 10\n")
         write(for002, "legacy reference\n")
         write(for002_variant, "legacy reference variant\n")
         for ext in ("csv", "json", "yaml", "log", "md")
@@ -869,7 +869,7 @@ settings:
         refreshed = String(Sparlectra.route_sparlectra_webui("GET", "/powerflow"; output_root, runtime).body)
         @test occursin("<option value=\"case_upload.m\"", refreshed)
 
-        dat_response = Sparlectra.route_sparlectra_webui("POST", "/powerflow/import-cases", Dict("casefiles" => [upload("FOR001.DAT", "P\nT\nN\nX\nY\n110\n2 1 0 0 SLACK\nL 1 A PV SLACK 1.0 2.0 0.0 0.0\nK 1 1 1 PV 110 0 0 0 10 2 -5 5\nK 2 2 1 SLACK 110 0 0 0 20 3 -10 10\n")]); output_root, runtime)
+        dat_response = Sparlectra.route_sparlectra_webui("POST", "/powerflow/import-cases", Dict("casefiles" => [upload("FOR001.DAT", "P\nT\nN\nX\nY\n110\n2 1 0 0 SLACK\nL1A  PV       SLACK   1.0 2.0 0.0 0.0\n11   PV      110 0 0 0 10 2 -5 5\n21   SLACK   110 0 0 0 20 3 -10 10\n")]); output_root, runtime)
         @test dat_response.status == 303
         @test isfile(joinpath(case_directory, "FOR001.DAT"))
         @test Sparlectra._webui_casefile_options_in_directory(case_directory) == ["case_upload.m", "FOR001.DAT"]
@@ -1129,27 +1129,6 @@ settings:
         unsafe_route = Sparlectra.route_sparlectra_webui("GET", "/docs/" * Sparlectra._webui_urlencode(unsafe_page))
         @test unsafe_route.status == 404
       end
-    end
-
-    @testset "canonical DFT terminology guard" begin
-      repo_root = normpath(joinpath(@__DIR__, ".."))
-      forbidden_terms = ["schae" * "fer", "DTF" * "/FOR001", "FOR001" * "/DTF", "FOR001" * " / DTF", "DTF" * " format", "FOR001" * " format", "native DTF" * " path", "DTF" * " outage"]
-      hits = String[]
-      for root in ("docs", "src", "test", "examples")
-        for (dir, _, files) in walkdir(joinpath(repo_root, root))
-          for file in files
-            path = joinpath(dir, file)
-            text = read(path, String)
-            rel = relpath(path, repo_root)
-            rel == "test/test_webui.jl" && continue
-            for term in forbidden_terms
-              occursin(Regex(term, "i"), text) || continue
-              push!(hits, "$(rel): $(term)")
-            end
-          end
-        end
-      end
-      @test isempty(hits)
     end
 
     mktempdir() do tmpdir
@@ -1518,12 +1497,13 @@ result = get_powerflow_result(run_id)
 @test result["output_dir"] == joinpath(abspath(output_root), run_id)
 @test !ispath(joinpath(tmpdir, "outside-runs"))
       run_log_text = read(joinpath(result["output_dir"], "run.log"), String)
-      @test occursin("Wall time", run_log_text)
+      @test !occursin("Wall time", run_log_text)
       @test !occursin("Unknown Sparlectra configuration key: power_flow.qlimits.enforcement_mode", run_log_text)
-      @test occursin("Wall time   :", run_log_text)
+      @test occursin("Total time  :", run_log_text)
       @test occursin("Output time :", run_log_text)
       @test occursin("Solver time :", run_log_text)
-      @test !occursin("Solver time    :unavailable", run_log_text)
+      @test !occursin("Solver time: n/a", run_log_text)
+      @test !occursin("solving_powerflow_seconds", run_log_text)
       @test !occursin("Representative wall time", run_log_text)
       @test !occursin("representative_time:", run_log_text)
       @test !occursin("solver_time:          n/a", run_log_text)


### PR DESCRIPTION
### Motivation
- Provide a single trustworthy user-facing `Solver time` that measures only numerical PowerFlow solver invocations and stop exposing ambiguous `Wall time`/phase-derived timings.
- Prevent noisy / unbounded test output and keep repository-wide hygiene scans out of the fast profile so generated docs and example output cannot break normal runs.
- Make test profiles distinct and measurable, and classify uploaded `.DAT` files using the real DFT parser instead of the brittle `K`-line heuristic.

### Description
- Implement `solver_elapsed_s` sourced from the performance-profile `:solver_total` envelope measured around the actual solver entry (aggregate of per-invocation solver rows, with conservative fallbacks) so successful and numerical-failure runs report finite solver times while pre-solver failures leave `solver_elapsed_s = nothing`; main change in `src/acpflow/execution.jl`.  The value is propagated through `SparlectraRunResult` and `result` artifacts. (`start` SHA: `8461736`, `final` SHA: `4354245`, branch `v0.8.9`).
- Simplify public timing labels and outputs: print only `Solver time`, `Output time`, and `Total time` where available; remove generic `Wall time`, avoid printing `Solver time : n/a`, and stop emitting `solving_powerflow_seconds` in large-case summaries; updates in `src/api/run_diagnostic_artifacts.jl`, `src/results.jl`, and `src/api/run_finalization.jl` (also writes `solver_elapsed_s` into large-case summary).  Benchmark/representative profiling remains available in `performance_profile` internals but is not used as the user-facing solver time.
- Replace the `.DAT` classifier heuristic with a parser-consistent approach that attempts `DTFImporter.read_dtf(...; strict=false)` and classifies files as `:dft_network_case`, `:dft_network_case_with_outages`, `:dft_outage_file`, `:dft_outage_or_reference`, or `:unknown_dat` based on the parsed structure; updated `src/webui/forms.jl` and adjusted test fixtures in `test/test_webui.jl` to use fixed-column DFT rows that `DTFImporter` understands.
- Rework the test runner and captured-output helpers: add bounded test-capture with an excerpt cap (64 KiB / 200 lines), per-group timing/allocation/GC reporting, optional `SPARLECTRA_TEST_GC_BETWEEN_GROUPS=1` GC between groups, and `run_profile_group` to print concise per-group metrics; move repository hygiene checks into `test/test_repository_hygiene.jl` (excluded from fast), make `fast`/`extended`/`all` profiles distinct, and invoke the top-level runner safely with `Base.invokelatest(main)` to avoid Julia 1.12 world-age warnings (`test/runtests.jl`, `test/test_runner_helpers.jl`).
- Added `test/test_repository_hygiene.jl` which scans only source-controlled text-like files under `docs/src`, `src`, `test`, and `examples` and explicitly excludes generated directories (`docs/build`, `examples/_out`, `results`, `coverage`, `.git`, `.julia`, `node_modules`); failure output is bounded to at most 20 shown hits and ~16 KiB total message.  (Changed files summary: `docs/src/changelog.md`, `docs/src/dft_format.md`, `docs/src/powerflow_service.md`, `docs/src/tests.md`, `src/acpflow/execution.jl`, `src/api/run_diagnostic_artifacts.jl`, `src/api/run_finalization.jl`, `src/results.jl`, `src/webui/forms.jl`, `test/runtests.jl`, `test/test_api.jl`, `test/test_runner_helpers.jl`, `test/test_webui.jl`, added `test/test_repository_hygiene.jl`).

### Testing
- Commands executed (focused and full profiles) and results:
  - `julia --project=. -e 'using Sparlectra'` — PASS (package loads).
  - `julia --project=. -e 'using Test, Sparlectra; include("test/test_repository_hygiene.jl"); run_repository_hygiene_tests()'` — PASS (hygiene test ran and passed locally).
  - `julia --project=. -e 'using Test, Sparlectra; include("test/test_api.jl"); run_api_tests()'` — PASS; API/webui-related tests passed (`GUI-ready Sparlectra API | 414/414`, local service tests passed).
  - `julia --project=. -e 'using Test, Sparlectra; include("test/test_webui.jl"); run_webui_tests()'` — PASS (`Local PowerFlow Web UI | 1452/1452`).
  - `julia --project=. test/runtests.jl fast` — PASS; full fast profile passed (`Sparlectra.jl fast profile | 2973/2973`). Per-group runtime / allocation / GC from the final fast run: core_model: 128.321 s, 9473.3 MiB, 5.071 s GC; powerflow_rectangular: 47.016 s, 1055.9 MiB, 0.954 s GC; configuration: 13.617 s, 507.9 MiB, 0.232 s GC; matpower_metadata: 5.975 s, 579.5 MiB, 0.242 s GC; programmatic_api: 137.928 s, 3260.6 MiB, 2.295 s GC; webui: 87.016 s, 2712.3 MiB, 2.012 s GC; state_estimation: 11.803 s, 590.0 MiB, 0.143 s GC; controls: 14.101 s, 468.0 MiB, 0.170 s GC.
  - `julia --project=. test/runtests.jl extended` — PASS (`Sparlectra.jl extended profile | 465/465`).
  - `julia --project=. test/runtests.jl all` — PASS (fast followed by extended; both passed).
  - `julia --project=docs docs/make.jl` — PASS (Documenter completed render; note: external registry download produced a 403 in this environment but the doc build completed with local packages available).
  - `git diff --check` — PASS (no whitespace/trailing errors reported).
- Observed/behaviour notes:
  - `solver_elapsed_s` is always finite and >= 0.0 for runs where the numerical solver actually started; if a run fails before the numerical solver starts the field remains `nothing`/JSON `null` and no `Solver time` line is printed.
  - The Web UI and `run.log` now present `Solver time` and `Total time` only (and `Output time` in detailed views), with no `Wall time` or `Solver time : n/a` text.
  - The `.DAT` classifier now only treats parsed runnable DFT networks as selectable primary cases; FOR002-like reference files and outage-only files are not offered as runnable cases.
  - The test harness no longer emits Julia 1.12 world-age warnings when running `julia --project=. test/runtests.jl fast` because the top-level profile dispatcher is invoked via `Base.invokelatest`.
- Push / CI note: attempted `git push -u origin v0.8.9` failed locally because this checkout has no `origin` remote configured; the commit is present locally (`4354245`) and can be pushed with `git remote add origin <URL>` followed by `git push -u origin v0.8.9` by the maintainer/CI environment.

If you want, I can (a) open a concise changelog entry/PR description (this message is suitable), (b) run any additional focused timing regression tests you prefer, or (c) adjust the `.DAT` fallback classification behavior (for example to prefer filename hints) — tell me which next step you prefer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a564a2dae3c8330b30cd5b2a0cc7c62)