### PR TITLE
Sysimage page: show progress from the button, not from the build process

### DIFF
--- a/docs/src/webui.md
+++ b/docs/src/webui.md
@@ -133,9 +133,18 @@ when it was built is still incomplete for any path its workload never
 touched, and a refresh folds whatever compiled at run time into the trace.
 
 The build runs as a separate background process. It survives a browser
-reload and a Web UI shutdown, reports its phase on the page while it works,
-and only replaces the image file at the very end, so the session that
-started it keeps running throughout. The running process keeps the image it
+reload and a Web UI shutdown, and only replaces the image file at the very
+end, so the session that started it keeps running throughout.
+
+While it works, the page shows which of the four steps is running, what that
+step is currently doing, and how long the build has been going, and it
+refreshes itself every two seconds. The counter starts with the button, not
+with the build process: Julia needs seconds to boot before it can report
+anything, and a page that sits still for that long reads as broken. When the
+build ends, the page reloads once and shows the result, a size and a duration
+for a successful build, or the reason and the tail of the build log for a
+failed one. There is no notification outside that page: navigate away and you
+have to come back to it to see the outcome. The running process keeps the image it
 booted from, though: after a successful refresh the page says so and asks
 for a restart, which is the point where the new image takes effect. Details
 of the build are in `sysimage_build.log` next to the image; see

--- a/src/webui/sysimage.jl
+++ b/src/webui/sysimage.jl
@@ -224,19 +224,71 @@ end
 # (killed, crashed hard, machine rebooted) rather than merely busy.
 const _SYSIMAGE_BUILD_STALE_SECONDS = 60.0
 
+# The `starting` state has no heartbeat yet: it is written before the build
+# process exists, and the entry stands until that process has booted Julia and
+# written its own first entry. On a cold Windows start that takes tens of
+# seconds, so this window is deliberately much wider than the running one.
+const _SYSIMAGE_BUILD_STARTING_SECONDS = 180.0
+
 """
     sysimage_build_active(; output_root) -> Bool
 
-Whether a sysimage build is running right now. A build that stopped updating
-its progress file for more than a minute counts as gone, not as active: a
-crashed builder must never lock the refresh button forever.
+Whether a sysimage build is running right now, which includes the seconds
+between pressing the button and the build process reporting for the first
+time. A build that stopped updating its progress file counts as gone, not as
+active: a crashed builder must never lock the refresh button forever.
 """
 function sysimage_build_active(; output_root::AbstractString = default_webui_output_root())::Bool
   progress = read_sysimage_build_progress(; output_root)
   progress === nothing && return false
-  get(progress, "state", "") == "running" || return false
+  state = get(progress, "state", "")
+  state in ("running", "starting") || return false
   age = _sysimage_build_age(progress)
-  return age === nothing || age < _SYSIMAGE_BUILD_STALE_SECONDS
+  age === nothing && return true
+  return age < (state == "starting" ? _SYSIMAGE_BUILD_STARTING_SECONDS : _SYSIMAGE_BUILD_STALE_SECONDS)
+end
+
+"""
+    _write_sysimage_build_progress(output_root; state, phase, message)
+
+Write a minimal progress entry from the Web UI side.
+
+This exists for the gap between pressing the refresh button and the build
+process being alive: the page only polls while a build is active, and until
+2026-09-07 "active" required the child's first progress entry. Julia needs
+seconds to boot before it can write one, tens of seconds on a cold Windows,
+and during that window the page sat there looking dead (reported by the
+maintainer, who asked whether there is a status display at all).
+
+The state written here is `starting`, not `running`, and that distinction is
+load-bearing: the build script refuses to start when it finds a FRESH
+`running` entry, so writing `running` here would make the Web UI block the
+very build it just launched.
+"""
+function _write_sysimage_build_progress(output_root::AbstractString; state::AbstractString, phase::AbstractString, message::AbstractString = "")
+  esc(v) = replace(String(v), "\\" => "\\\\", "\"" => "\\\"", "\n" => " ")
+  path = webui_sysimage_progress_path(output_root)
+  try
+    mkpath(dirname(path))
+    open(path, "w") do io
+      println(io, "state = \"", esc(state), "\"")
+      println(io, "step = 0")
+      println(io, "steps = 4")
+      println(io, "phase = \"", esc(phase), "\"")
+      println(io, "detail = \"\"")
+      println(io, "message = \"", esc(message), "\"")
+      println(io, "elapsed_seconds = 0.0")
+      println(io, "updated_at = ", round(time(); digits = 1))
+      println(io, "pid = 0")
+      println(io, "log = \"", esc(webui_sysimage_build_log_path(output_root)), "\"")
+    end
+  catch err
+    # expected failure: an unwritable or full state directory. The build still
+    # runs, only its progress cannot be shown, so this is reported and not
+    # turned into a failed rebuild.
+    @warn "Could not write the sysimage build progress file; the build runs, but the page cannot show its progress." path exception = err
+  end
+  return nothing
 end
 
 """
@@ -265,11 +317,18 @@ function start_sysimage_rebuild!(; output_root::AbstractString = default_webui_o
   isfile(script) || return (started = false, message = "The build script is missing at $(script); a registry installation without tools/ cannot rebuild the image.", log = log)
   exe = joinpath(Sys.BINDIR, Base.julia_exename())
   cmd = Cmd(`$(exe) --startup-file=no --project=$(pkgroot) $(script)`; dir = pkgroot)
+  # BEFORE spawning: the page polls only while a build is active, and the child
+  # needs seconds to boot before it can report anything. Writing the entry
+  # first also means a spawn that throws leaves a truthful `failed` entry
+  # rather than a phantom build.
+  _write_sysimage_build_progress(output_root; state = "starting", phase = "starting the build process")
   try
     # Progress and log go to files, so the child needs no streams of its own.
     run(pipeline(detach(cmd); stdout = devnull, stderr = devnull); wait = false)
   catch err
-    return (started = false, message = "Could not start the build: $(sprint(showerror, err))", log = log)
+    reason = "Could not start the build: $(sprint(showerror, err))"
+    _write_sysimage_build_progress(output_root; state = "failed", phase = "starting the build process", message = reason)
+    return (started = false, message = reason, log = log)
   end
   return (started = true, message = "The sysimage build has started. It runs in the background and takes a few minutes.", log = log)
 end

--- a/test/test_webui.jl
+++ b/test/test_webui.jl
@@ -1362,6 +1362,27 @@ function run_webui_fast_tests()
         @test !occursin("cannot be read", Sparlectra.render_webui_sysimage_page(output_root = out))
         _progress_file("failed", round(time(); digits = 1))
 
+        # The seconds between the button and the build process reporting for
+        # the first time (2026-09-07): the page only polls while a build is
+        # active, and "active" used to require the CHILD's first entry. Julia
+        # needs seconds to boot before it can write one, tens of seconds on a
+        # cold Windows, and the page sat there looking dead meanwhile.
+        rm(progress; force = true)
+        Sparlectra._write_sysimage_build_progress(out; state = "starting", phase = "starting the build process")
+        @test Sparlectra.sysimage_build_active(output_root = out) == true
+        starting_page = Sparlectra.render_webui_sysimage_page(output_root = out)
+        @test occursin("data-refresh-url=\"/webui/sysimage?autorefresh=1\"", starting_page)
+        @test occursin("starting the build process", starting_page)
+        @test !occursin("/webui/sysimage/rebuild", starting_page)
+        # The state must be `starting`, never `running`: tools/build_sysimage.jl
+        # refuses to start when it finds a fresh `running` entry, so writing
+        # `running` here would make the Web UI block the very build it just
+        # launched.
+        @test Sparlectra.read_sysimage_build_progress(output_root = out)["state"] == "starting"
+        # a start that never produced a process is gone after the wider window
+        _progress_file("starting", round(time() - 3 * 3600; digits = 1))
+        @test Sparlectra.sysimage_build_active(output_root = out) == false
+
         # route smoke: the page is reachable
         response = Sparlectra.route_sparlectra_webui("GET", "/webui/sysimage"; output_root = out)
         @test response.status == 200


### PR DESCRIPTION
Reported while trying the refresh button: *is there a status display at all?*
There is, and it did not come up for the first ten to twenty seconds.

## The gap

The page polls only while a build is active, and "active" required the build
process to have written its first progress entry. Julia needs seconds to boot
before it can write one, tens of seconds on a cold Windows start. In that
window the page showed `The sysimage build has started` and then sat still,
which reads as a dead page.

## The fix

`start_sysimage_rebuild!` writes the first progress entry itself, **before**
spawning, so the page picks it up on the very next poll. A spawn that throws
overwrites it with a truthful `failed` entry instead of leaving a phantom
build behind.

The state written is `starting`, not `running`, and that distinction is
load-bearing: `tools/build_sysimage.jl` refuses to start when it finds a fresh
`running` entry, so writing `running` here would make the Web UI block the very
build it just launched. `starting` also gets a wider staleness window, three
minutes against one, because it carries no heartbeat: nothing refreshes it
until the build process takes over.

## Verification

- Web UI test group: 702/702 (696 before, plus 6 new assertions)
- fast profile: 7180/7180
- docs build: clean

New tests: a `starting` entry counts as active and makes the page poll and show
its phase without offering a second build; the written state must be `starting`
and never `running`, which is the property the build script's guard depends on;
and a start that never produced a process is gone after the wider window.

`docs/src/webui.md` now states what the display shows, that the counter starts
with the button rather than with the build process, and that there is no
notification outside that page.
