### PR TITLE
Start: check the environment before the sysimage question, and resolve before instantiating

### DIFF
--- a/docs/src/webui.md
+++ b/docs/src/webui.md
@@ -68,6 +68,16 @@ julia --project=. start_webui.jl
 `start_webui.jl` is the single maintained developer launcher and delegates
 startup and default-path behavior to `start_sparlectra_webui`.
 
+Before anything else it compares the direct dependencies in `Project.toml`
+against `Manifest.toml`, which costs two TOML reads and no package load. When
+one is missing, or when there is no manifest, it resolves and instantiates the
+environment once and says so; otherwise it stays silent. `Manifest.toml` is not
+tracked, so this covers both a fresh clone and a manifest left over from an
+older Sparlectra that never learned about a dependency added since. The check
+runs BEFORE the [sysimage](sysimage.md) question on purpose: nobody should be
+asked whether to spend minutes on a build while the checkout itself cannot be
+loaded.
+
 For end users the repository root additionally ships platform scripts:
 `start_webui.sh` / `start_webui.bat` (start; point at the install script
 when Julia is missing) and `tools/install_webui.sh` / `tools/install_webui.bat`

--- a/start_webui.jl
+++ b/start_webui.jl
@@ -25,7 +25,15 @@
 # no package load. Julia can only take an image at process start (-J), so a
 # process that wants one has to start itself again.
 include(joinpath(@__DIR__, "tools", "sysimage_launcher.jl"))
-using .SysimageLauncher: handle_sysimage
+using .SysimageLauncher: handle_sysimage, unresolved_dependencies, repair_environment
+
+# The environment FIRST, then the sysimage question. A user who is about to be
+# asked whether to spend minutes on a build should not be asked on top of a
+# broken checkout.
+let project_dir = abspath(@__DIR__), missing_deps = Base.invokelatest(unresolved_dependencies, project_dir)
+  isempty(missing_deps) || Base.invokelatest(repair_environment, project_dir,
+    "The package environment is not resolved: " * join(missing_deps, ", ") * ".")
+end
 
 handle_sysimage(copy(ARGS), @__FILE__, abspath(@__DIR__))
 
@@ -51,27 +59,14 @@ handle_sysimage(copy(ARGS), @__FILE__, abspath(@__DIR__))
 # call instantiate alone, so it turned one unhelpful error into another
 # (reported from a Windows 11 checkout, 2026-09-07). `resolve` rewrites the
 # manifest from Project.toml and covers the missing-manifest case as well.
+# Second line of defence. The check above reads TOML and therefore sees only
+# what TOML can show; a depot with a missing artifact, a half-written package
+# directory or a compat conflict that only surfaces on load gets here instead.
 try
   @eval using Sparlectra
 catch err
-  println("Preparing the package environment; this happens once after a checkout or a dependency change.")
-  println("(", first(sprint(showerror, err), 160), ")")
-  @eval using Pkg
-  pkgm = Base.invokelatest(getfield, @__MODULE__, :Pkg)
-  try
-    Base.invokelatest(pkgm.resolve)
-    Base.invokelatest(pkgm.instantiate)
-  catch resolve_err
-    println()
-    println("Could not prepare the dependencies of this checkout.")
-    println("Run this once in the checkout directory and start again:")
-    println("    julia --project=. -e \"using Pkg; Pkg.resolve(); Pkg.instantiate()\"")
-    println()
-    println("If that fails too, delete Manifest.toml and repeat. It is not tracked,")
-    println("and a manifest left over from an older Sparlectra is the usual reason.")
-    println()
-    rethrow(resolve_err)
-  end
+  Base.invokelatest(repair_environment, abspath(@__DIR__),
+    "Loading Sparlectra failed (" * first(sprint(showerror, err), 160) * ").")
   @eval using Sparlectra
 end
 

--- a/start_webui.jl
+++ b/start_webui.jl
@@ -31,29 +31,44 @@ handle_sysimage(copy(ARGS), @__FILE__, abspath(@__DIR__))
 
 # --- package environment -----------------------------------------------------
 # `using Sparlectra` needs a RESOLVED environment, and Manifest.toml is not
-# tracked, so a fresh checkout has none. Julia does not say that in a way a
-# user can act on: the dependency scan fails deep inside Base with
+# tracked. Two situations lead here, and they need different remedies:
+#
+#   * a fresh checkout has no manifest at all;
+#   * an OLD manifest is present and predates a dependency change, so it never
+#     learned about a package the Project.toml now requires.
+#
+# Julia names neither in a way a user can act on. The dependency scan fails
+# deep inside Base with
 #
 #   KeyError: key Base.PkgId(UUID("19ecf91d-..."), "AnalyticLoadFlow") not found
 #
-# and a stacktrace through Base.Precompilation (reported from a Windows 11
-# checkout, 2026-09-07). Nothing in that names the actual problem, which is
-# simply that the dependencies were never installed. Resolve once and retry,
-# so the first start after a clone works without the user knowing about Pkg.
+# and a stacktrace through Base.Precompilation.
+#
+# RESOLVE, then instantiate, and in that order. `instantiate` installs what the
+# manifest lists and cannot add a package the manifest never mentioned: on a
+# stale manifest it fails with "AnalyticLoadFlow is a direct dependency, but
+# does not appear in the manifest ... run Pkg.resolve()". This block used to
+# call instantiate alone, so it turned one unhelpful error into another
+# (reported from a Windows 11 checkout, 2026-09-07). `resolve` rewrites the
+# manifest from Project.toml and covers the missing-manifest case as well.
 try
   @eval using Sparlectra
 catch err
-  println("Resolving the package environment; this happens once after a fresh checkout.")
-  println("(", first(sprint(showerror, err), 120), ")")
+  println("Preparing the package environment; this happens once after a checkout or a dependency change.")
+  println("(", first(sprint(showerror, err), 160), ")")
   @eval using Pkg
   pkgm = Base.invokelatest(getfield, @__MODULE__, :Pkg)
   try
+    Base.invokelatest(pkgm.resolve)
     Base.invokelatest(pkgm.instantiate)
   catch resolve_err
     println()
-    println("Could not install the dependencies of this checkout.")
+    println("Could not prepare the dependencies of this checkout.")
     println("Run this once in the checkout directory and start again:")
-    println("    julia --project=. -e \"using Pkg; Pkg.instantiate()\"")
+    println("    julia --project=. -e \"using Pkg; Pkg.resolve(); Pkg.instantiate()\"")
+    println()
+    println("If that fails too, delete Manifest.toml and repeat. It is not tracked,")
+    println("and a manifest left over from an older Sparlectra is the usual reason.")
     println()
     rethrow(resolve_err)
   end

--- a/test/test_webui.jl
+++ b/test/test_webui.jl
@@ -1254,7 +1254,64 @@ function run_webui_fast_tests()
       @test occursin("topbar-info-menu", Sparlectra.render_webui_error(404, "not found"))
     end
 
-    @testset "start_webui.jl resolves before it instantiates" begin
+    @testset "the environment is checked before the sysimage question" begin
+      # Regression 2026-09-07 (Windows 11). A checkout carried a Manifest.toml
+      # from before AnalyticLoadFlow became a required dependency. The start
+      # asked whether to build a sysimage FIRST, the user declined, and only
+      # then did `using Sparlectra` fail with a KeyError deep in
+      # Base.Precompilation. Answering yes would have been worse: the build
+      # works in the separate @sparlectra-sysimage-build environment and would
+      # have spent eleven minutes before the checkout's own manifest turned
+      # out to be the problem.
+      #
+      # unresolved_dependencies answers that from two TOML reads, with no
+      # package load, which is what lets it run before the question.
+      launcher = Module(:LauncherEnvCheck)
+      Base.include(launcher, joinpath(Sparlectra.SPARLECTRA_ROOT, "tools", "sysimage_launcher.jl"))
+      SL = getfield(launcher, :SysimageLauncher)
+      unresolved(dir) = Base.invokelatest(Base.invokelatest(getfield, SL, :unresolved_dependencies), dir)
+
+      # this very checkout is resolvable, so the check stays silent
+      @test isempty(unresolved(Sparlectra.SPARLECTRA_ROOT))
+
+      mktempdir() do dir
+        json = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+        toml = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+        # a manifest that predates a dependency: exactly the reported case
+        stale = joinpath(dir, "stale")
+        mkpath(stale)
+        write(joinpath(stale, "Project.toml"), "[deps]\nJSON = \"$(json)\"\nTOML = \"$(toml)\"\n")
+        write(joinpath(stale, "Manifest.toml"), "julia_version = \"$(VERSION)\"\nmanifest_format = \"2.0\"\n\n[deps]\n[[deps.TOML]]\nuuid = \"$(toml)\"\n")
+        @test unresolved(stale) == ["JSON"]
+
+        # a fresh checkout has no manifest at all
+        fresh = joinpath(dir, "fresh")
+        mkpath(fresh)
+        write(joinpath(fresh, "Project.toml"), "[deps]\nJSON = \"$(json)\"\n")
+        @test unresolved(fresh) == ["<no Manifest.toml>"]
+
+        # a complete manifest is silent
+        good = joinpath(dir, "good")
+        mkpath(good)
+        write(joinpath(good, "Project.toml"), "[deps]\nTOML = \"$(toml)\"\n")
+        write(joinpath(good, "Manifest.toml"), "julia_version = \"$(VERSION)\"\nmanifest_format = \"2.0\"\n\n[deps]\n[[deps.TOML]]\nuuid = \"$(toml)\"\n")
+        @test isempty(unresolved(good))
+
+        # an unreadable manifest counts as unresolved, not as fine: the
+        # environment cannot be trusted either way
+        broken = joinpath(dir, "broken")
+        mkpath(broken)
+        write(joinpath(broken, "Project.toml"), "[deps]\n")
+        write(joinpath(broken, "Manifest.toml"), "kaputt = [[[")
+        broken_result = redirect_stdout(devnull) do
+          unresolved(broken)
+        end
+        @test length(broken_result) == 1
+        @test occursin("unreadable", broken_result[1])
+      end
+    end
+
+    @testset "the repair resolves before it instantiates" begin
       # Regression 2026-09-07 (Windows 11). A checkout carried a Manifest.toml
       # from before AnalyticLoadFlow became a required dependency. `using
       # Sparlectra` failed with a KeyError deep in Base.Precompilation, the
@@ -1268,7 +1325,7 @@ function run_webui_fast_tests()
       # this test guards, and a text check is the honest tool for it: the
       # recovery lives at the top level of a script, which cannot be called
       # without starting a Web UI.
-      script = read(joinpath(Sparlectra.SPARLECTRA_ROOT, "start_webui.jl"), String)
+      script = read(joinpath(Sparlectra.SPARLECTRA_ROOT, "tools", "sysimage_launcher.jl"), String)
       resolve_at = findfirst("pkgm.resolve", script)
       instantiate_at = findfirst("pkgm.instantiate", script)
       @test resolve_at !== nothing

--- a/test/test_webui.jl
+++ b/test/test_webui.jl
@@ -1254,6 +1254,31 @@ function run_webui_fast_tests()
       @test occursin("topbar-info-menu", Sparlectra.render_webui_error(404, "not found"))
     end
 
+    @testset "start_webui.jl resolves before it instantiates" begin
+      # Regression 2026-09-07 (Windows 11). A checkout carried a Manifest.toml
+      # from before AnalyticLoadFlow became a required dependency. `using
+      # Sparlectra` failed with a KeyError deep in Base.Precompilation, the
+      # recovery block caught it and ran Pkg.instantiate, and instantiate
+      # cannot add a package the manifest never mentioned: it failed with
+      # "AnalyticLoadFlow is a direct dependency, but does not appear in the
+      # manifest ... run Pkg.resolve()". One unhelpful error became another.
+      #
+      # Verified in a throwaway environment: instantiate alone reproduces that
+      # message, resolve followed by instantiate succeeds. The order is what
+      # this test guards, and a text check is the honest tool for it: the
+      # recovery lives at the top level of a script, which cannot be called
+      # without starting a Web UI.
+      script = read(joinpath(Sparlectra.SPARLECTRA_ROOT, "start_webui.jl"), String)
+      resolve_at = findfirst("pkgm.resolve", script)
+      instantiate_at = findfirst("pkgm.instantiate", script)
+      @test resolve_at !== nothing
+      @test instantiate_at !== nothing
+      @test first(resolve_at) < first(instantiate_at)
+      # and the advice printed on failure has to name the same two calls, or a
+      # user who runs it by hand hits exactly the error we just fixed
+      @test occursin("Pkg.resolve(); Pkg.instantiate()", script)
+    end
+
     @testset "sysimage validity: launcher and package agree" begin
       # Sparlectra.webui_sysimage_problem answers the same question for the
       # Web UI's sysimage page that SysimageLauncher.sysimage_problem answers

--- a/tools/sysimage_launcher.jl
+++ b/tools/sysimage_launcher.jl
@@ -13,9 +13,9 @@
 # limitations under the License.
 #
 # file: tools/sysimage_launcher.jl
-# purpose: the sysimage decision every Sparlectra launcher shares: is there a
-#          usable image, should one be built, and relaunching the process
-#          through it. Deliberately a module on plain Base (TOML and SHA are
+# purpose: the decisions every Sparlectra launcher has to make BEFORE the
+#          package can be loaded: is this checkout's environment resolvable
+#          at all, and is there a usable sysimage to relaunch through. Deliberately a module on plain Base (TOML and SHA are
 #          stdlib): start_webui.jl includes it BEFORE `using Sparlectra`,
 #          because the whole point is to decide whether this process should
 #          be replaced by one that starts from the image. Being a module also
@@ -26,7 +26,7 @@ module SysimageLauncher
 using TOML
 using SHA
 
-export handle_sysimage
+export handle_sysimage, unresolved_dependencies, repair_environment
 
 const REBUILD_FLAG = "--rebuild-sysimage"
 const NO_IMAGE_FLAG = "--no-sysimage"
@@ -168,6 +168,72 @@ function relaunch_with_sysimage(image::AbstractString, script::AbstractString, p
     0
   end
   exit(code)
+end
+
+"""
+    unresolved_dependencies(project_dir) -> Vector{String}
+
+Direct dependencies of `Project.toml` that `Manifest.toml` does not know, or
+`["<no Manifest.toml>"]` when there is no manifest at all. Empty means the
+environment can be loaded.
+
+Two TOML reads, no package load, a few milliseconds. That cheapness is the
+point: it runs BEFORE the sysimage question, and the order matters. Answering
+"no" to that question and then walking into an unloadable environment is what
+happened on a Windows 11 checkout (2026-09-07); answering "yes" would have been
+worse, because the build works in the SEPARATE @sparlectra-sysimage-build
+environment and would have spent eleven minutes before the checkout's own
+manifest turned out to be the problem.
+"""
+function unresolved_dependencies(project_dir::AbstractString)::Vector{String}
+  project = joinpath(project_dir, "Project.toml")
+  manifest = joinpath(project_dir, "Manifest.toml")
+  isfile(project) || return String[]
+  isfile(manifest) || return ["<no Manifest.toml>"]
+  deps, known = try
+    d = get(TOML.parsefile(project), "deps", Dict{String,Any}())
+    m = TOML.parsefile(manifest)
+    # manifest_format 2.0 nests everything under [deps]; 1.0 puts the packages
+    # at the top level next to the metadata keys
+    n = haskey(m, "deps") ? keys(m["deps"]) : setdiff(keys(m), ("julia_version", "manifest_format", "project_hash", "manifest_version"))
+    (keys(d), n)
+  catch err
+    # expected failure: a truncated or hand-edited TOML. Saying "unresolved"
+    # here is right - the environment cannot be trusted either way - and the
+    # repair below reports what Pkg makes of it.
+    println("Could not read the package environment (", first(sprint(showerror, err), 120), "); trying to repair it.")
+    return ["<unreadable Project.toml or Manifest.toml>"]
+  end
+  return sort!([String(d) for d in deps if !(d in known)])
+end
+
+"""
+Bring the environment into a loadable state, printing only when something is
+actually wrong. `resolve` before `instantiate`, in that order: instantiate
+installs what the manifest lists and cannot add a package the manifest never
+mentioned.
+"""
+function repair_environment(project_dir::AbstractString, reason::AbstractString)
+  println(reason)
+  println("Resolving the package environment; this happens once after a checkout or a dependency change.")
+  @eval using Pkg
+  pkgm = Base.invokelatest(getfield, @__MODULE__, :Pkg)
+  try
+    Base.invokelatest(pkgm.resolve)
+    Base.invokelatest(pkgm.instantiate)
+    println("Package environment resolved.")
+  catch err
+    println()
+    println("Could not prepare the dependencies of this checkout.")
+    println("Run this once in the checkout directory and start again:")
+    println("    julia --project=. -e \"using Pkg; Pkg.resolve(); Pkg.instantiate()\"")
+    println()
+    println("If that fails too, delete Manifest.toml and repeat. It is not tracked,")
+    println("and a manifest left over from an older Sparlectra is the usual reason.")
+    println()
+    rethrow(err)
+  end
+  return nothing
 end
 
 """


### PR DESCRIPTION
Reported from a Windows 11 checkout: the start asked whether to build a
sysimage, the answer was no, and then it died with a Pkg error **after** the
recovery block had already run.

```
Sysimage: the sysimage is older than ...\src.
Build the sysimage now? [Y/n] n
Starting without a sysimage: ...
Resolving the package environment; this happens once after a fresh checkout.
(KeyError: key Base.PkgId(Base.UUID("19ecf91d-..."), "AnalyticLoadFlow") not found)

Could not install the dependencies of this checkout.
ERROR: LoadError: `AnalyticLoadFlow` is a direct dependency, but does not appear
in the manifest. ... run `Pkg.resolve()` to populate the manifest.
```

Two defects, one after the other.

## 1. The repair did the wrong thing

The checkout carried a `Manifest.toml` from before AnalyticLoadFlow became a
required dependency. The recovery block caught the load failure and ran
`Pkg.instantiate`, and instantiate cannot add a package the manifest never
mentioned. One unhelpful error turned into another, and the second told the
user to run exactly the call the recovery block had left out. The comment above
that block said "resolve once and retry" all along; only the code did not.

Now `Pkg.resolve()` and then `Pkg.instantiate()`. Resolve rewrites the manifest
from `Project.toml`, so both situations that lead here are covered: a fresh
checkout with no manifest, and an old manifest that predates a dependency
change.

Proof, in a throwaway environment whose manifest is missing one direct
dependency:

```
instantiate alone     : `JSON` is a direct dependency, but does not appear in the manifest...
resolve + instantiate : JSON v1.8.0 loaded
```

## 2. The repair ran too late

The sysimage question came first. Answering no walked into the Pkg error;
answering yes would have been worse, because the build works in the separate
`@sparlectra-sysimage-build` environment and could have spent eleven minutes
before the checkout's own manifest turned out to be the problem.

`unresolved_dependencies` compares the direct dependencies of `Project.toml`
against `Manifest.toml`: two TOML reads, no package load, a few milliseconds.
That cheapness is what lets it run BEFORE the question. It reports a missing
manifest, a manifest that never learned about a dependency added since, and an
unreadable one. Anything it cannot see stays with the load-failure path, which
is now the second line of defence for a broken depot or a compat conflict that
only surfaces on load.

Both functions live in the launcher module rather than at the top level of the
script. That is where the other pre-load decision already lives, and it is the
difference between code that can be tested and code that can only be tested by
starting a Web UI.

## Verification

- Web UI test group: 712/712 (702 before, plus 10 new assertions)
- docs build: clean
- the four cases exercised directly: this checkout (silent), a manifest missing
  one dependency (names it), no manifest at all, and an unreadable manifest

The fast profile cannot reach this change: `start_webui.jl` and the launcher
module are referenced only from the Web UI test files, which are extended-only.
