### PR TITLE
Docs: restore four docstrings detached by a blank line

### DIFF
--- a/src/adapters/matpower/FetchMatpowerCase.jl
+++ b/src/adapters/matpower/FetchMatpowerCase.jl
@@ -334,7 +334,6 @@ Ensure a MATPOWER-compatible case file exists locally.
 
 Returns the local path to the requested case file.
 """
-
 function ensure_casefile(casefile::AbstractString; outdir::Union{Nothing,AbstractString} = nothing, overwrite::Bool = false, to_jl::Bool = true)::String
 
   # 1) If user passed an existing file path, just use it.

--- a/src/network.jl
+++ b/src/network.jl
@@ -801,7 +801,6 @@ Parameters:
 - `vn_kV::Union{Nothing,Float64} = nothing`: Nominal voltage of the branch in kV (default is nothing).
 - `values_are_pu = false`: Boolean indicating if the values are in per unit (default is false).
 """
-
 function addBranch!(; net::Net, from::Int, to::Int, branch::AbstractBranch, status::Integer = 1, ratio = nothing, side = nothing, vn_kV = nothing, values_are_pu::Bool = false, from_status::Union{Nothing,Integer} = nothing, to_status::Union{Nothing,Integer} = nothing)
   @assert from != to "From and to bus must be different"
   idBrunch = length(net.branchVec) + 1

--- a/src/powerflow_rectangular/rectangular_network_solver.jl
+++ b/src/powerflow_rectangular/rectangular_network_solver.jl
@@ -288,7 +288,6 @@ polar formulations.
 - `mismatch_rectangular()`: Core mismatch function for PQ/PV constraints
 - `build_rectangular_jacobian_pq_pv()`: Analytic Jacobian construction
 """
-
 function runpf_rectangular!(
   net::Net;
   method::Symbol = :rectangular,

--- a/src/stateestimation/measurements.jl
+++ b/src/stateestimation/measurements.jl
@@ -519,7 +519,6 @@ Selection rules:
 These pseudo-measurements are the current way to encode equality constraints
 `P_inj = 0` and `Q_inj = 0` in the WLS estimator.
 """
-
 function addZeroInjectionMeasurements!(measurements::Vector; net::Net, sigma::Real = ZERO_INJECTION_SIGMA, busNames::Union{Nothing,Vector{String}} = nothing, busIdxs::Union{Nothing,Vector{Int}} = nothing, active::Bool = true, idPrefix::AbstractString = "ZI")
   selected = if !isnothing(busIdxs)
     copy(busIdxs)


### PR DESCRIPTION
The Documentation workflow fails on main: Documenter cannot resolve `[`ensure_casefile`](@ref)` on three pages and aborts before rendering, so Pages is never deployed and the site shows the failing badge.

Cause: a blank line between the closing `"""` and the `function` line. Julia then leaves the string as a standalone expression and the binding stays undocumented, silently, with no error at load time.

The same blank line sat at three older sites, so `addBranch!`, `addZeroInjectionMeasurements!` and the keyword method of `runpf_rectangular!` had lost their docstrings too.

Verified locally: `docs/make.jl` runs clean, no unresolved references, and all four bindings are documented again.