### PR TITLE
Release 0.11.0: compare two runs, and a configuration trap in the solver call

### DIFF
--- a/.github/scripts/prepare_registration_issue.jl
+++ b/.github/scripts/prepare_registration_issue.jl
@@ -46,7 +46,11 @@ function parseChangelog(path::AbstractString)::Vector{ChangelogEntry}
     version = VersionNumber(m.captures[1])
     date = m.captures[2]
     bodyStart = m.offset + ncodeunits(m.match)
-    bodyStop = i < length(matches) ? matches[i+1].offset : ncodeunits(text)
+    # up to the character BEFORE the next heading: including its offset drags
+    # that heading's leading '#' into the notes, and those notes are what
+    # JuliaRegistrator copies into the registry pull request (seen while
+    # preparing 0.11.0, as a stray empty heading above "Breaking changes")
+    bodyStop = i < length(matches) ? prevind(text, matches[i+1].offset) : ncodeunits(text)
     body = strip(text[bodyStart:bodyStop])
     push!(entries, ChangelogEntry(version, date, body))
   end

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sparlectra"
 uuid = "31ce9bba-fd9d-44a1-b005-f5f509afda38"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Udo Schmitz"]
 description = "load flow calculation using newton-raphson"
 

--- a/data/scf/sp_case14.scf.json
+++ b/data/scf/sp_case14.scf.json
@@ -1685,7 +1685,7 @@
     },
     "meta": {
       "case_name": "sp_case14",
-      "created_by": "Sparlectra 0.10.0",
+      "created_by": "Sparlectra 0.11.0",
       "f_nom": 50.0,
       "intended_calculations": ["power_flow", "state_estimation", "short_circuit", "contingency", "scenarios"],
       "notes": "Self-built Sparlectra demo network; the bus count in the name does not make it the IEEE case of that size, and no data was taken from MATPOWER, DTF or any other source.",

--- a/data/scf/sp_case188.scf.json
+++ b/data/scf/sp_case188.scf.json
@@ -13324,7 +13324,7 @@
     },
     "meta": {
       "case_name": "sp_case188",
-      "created_by": "Sparlectra 0.10.0",
+      "created_by": "Sparlectra 0.11.0",
       "f_nom": 50.0,
       "intended_calculations": ["power_flow", "state_estimation", "short_circuit", "contingency", "scenarios"],
       "notes": "Self-built Sparlectra demo network; the bus count in the name does not make it the IEEE case of that size, and no data was taken from MATPOWER, DTF or any other source.",

--- a/data/scf/sp_case5.scf.json
+++ b/data/scf/sp_case5.scf.json
@@ -603,7 +603,7 @@
     },
     "meta": {
       "case_name": "sp_case5",
-      "created_by": "Sparlectra 0.10.0",
+      "created_by": "Sparlectra 0.11.0",
       "f_nom": 50.0,
       "intended_calculations": ["power_flow", "state_estimation", "short_circuit", "contingency", "scenarios"],
       "notes": "Self-built Sparlectra demo network; the bus count in the name does not make it the IEEE case of that size, and no data was taken from MATPOWER, DTF or any other source.",

--- a/data/scf/sp_case60.scf.json
+++ b/data/scf/sp_case60.scf.json
@@ -6651,7 +6651,7 @@
     },
     "meta": {
       "case_name": "sp_case60",
-      "created_by": "Sparlectra 0.10.0",
+      "created_by": "Sparlectra 0.11.0",
       "f_nom": 50.0,
       "intended_calculations": ["power_flow", "state_estimation", "short_circuit", "contingency", "scenarios"],
       "notes": "Self-built Sparlectra demo network; the bus count in the name does not make it the IEEE case of that size, and no data was taken from MATPOWER, DTF or any other source.",

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,3 +1,19 @@
+# Version 0.11.0 - 2026-09-10
+
+Two runs side by side, and a configuration trap in the solver call.
+
+## Highlights
+
+- **Compare two runs.** Run history has a selection column and a **Compare selected runs** button. The comparison page shows where the two runs differ: configuration keys with both values, buses where Q limits engaged, total active and reactive losses, and the largest voltage deviation between the results. Until now this took two browser tabs and a good memory.
+- **A grid is solved under the configuration it was imported with.** `runpf!` without an explicit configuration used the globally active one, not the grid's. Importing a grid with its own configuration and then solving it returned a result under foreign settings, without a warning and without a visible difference in the call. A passed configuration still wins.
+- **Non-physical generator states appear in the result.** When a machine sits at its Q limit while the voltage is on the wrong side of its setpoint, the classic result print now names bus, side, voltage, setpoint, Q and limit. On case118 this is the one line that separates the enforcement methods.
+
+## Usability
+
+- **Q limit handling is one control.** Checkbox and mode sat in different places of the form. A mode selected with handling switched off did nothing and looked like it did something. Both are together now, and the mode accepts `off`.
+- **Diagnostics report a diagnosis.** The self test deliberately runs one step from the stored voltages; the residual is its result. It was rendered as a failed power flow, so every diagnosis looked like a crash. History and result page now say "diagnosed".
+- **Case input format names SCF and power-grid-model.** The same importer reads both formats; now they can be named that way.
+
 # Version 0.10.0 - 2026-09-06
 
 ## New

--- a/docs/src/webui.md
+++ b/docs/src/webui.md
@@ -461,6 +461,11 @@ when one is offered. The **Case input format** selector defaults to
 and — where the FOR001 markers are unambiguous — native DTF input. Selecting
 **CGMES (ENTSO-E, folder or ZIP)** forces the CGMES importer; the option is
 preselected automatically when the chosen case is a `.zip` or a directory.
+**Sparlectra Case Format (.scf.json)** and **power-grid-model JSON
+(input.json)** name the same reader: the `sparlectra` block of an SCF file is
+optional, so a plain power-grid-model dataset loads as well. *Auto* already
+resolves every `.json` to that reader, so the two entries matter when the file
+extension does not say what the file is.
 The native DTF path is experimental/internal and intended for diagnostics and
 validation, not the primary workflow. For the
 selected-outage-records mode, the **Selected DTF outage labels/indices** field
@@ -616,6 +621,15 @@ form is not a reference.
 Programmatically, the same behavior is available as
 [`run_fixed_reference_self_check`](@ref).
 
+Because the self-check takes exactly one step, a diagnose run practically
+never converges, and that is its point: the remaining residual is the
+measurement. The run history and the result page therefore label a finished
+diagnose run **diagnosed** on a neutral badge rather than as a failed power
+flow, with the raw status in the badge's tooltip, and the result page states
+in one line why the numbers below it show one iteration and a non-zero
+mismatch. A diagnose run that could not run at all keeps the failure
+vocabulary.
+
 ### Short circuit action
 
 The **Short circuit** button next to Diagnose evaluates the balanced
@@ -661,6 +675,14 @@ The **Non-convergence handling** block under Advanced options exposes
 `power_flow.rescue` (retry ladder for failed AC solves) and
 `power_flow.dc.fallback` (standalone DC result when AC has no solution) —
 see [Power-Flow Configuration](powerflow_configuration.md).
+
+The **Q-limit handling** block holds both controls that decide the behavior:
+the checkbox for `power_flow.qlimits.enabled` and the enforcement-mode
+selector. They belong together because a mode chosen while the handling is
+switched off has no effect while still reading like a setting. The selector
+therefore also offers **off**, which switches the handling off, and it shows
+`off` whenever the handling is off, so the form cannot state a mode the run
+will not use.
 
 The **Export detailed result CSV files** checkbox is off by default because
 large networks can produce large files. When enabled for a successful run, it
@@ -812,6 +834,28 @@ status text, status badge, solver summary fields, and actions. Green, yellow,
 red, gray, and blue badges distinguish successful, warning/partial, failed,
 unknown, and running states while retaining visible text for accessibility.
 Older indexes without timestamps use the `result.json` modification time.
+
+### Comparing two runs
+
+Two runs of the same case under different settings are the usual way to look at
+a Q-limit enforcement mode, a solver choice or a start strategy. Tick the
+**Compare** box on two rows and press **Compare selected runs**; the page at
+`/powerflow/compare` puts them next to each other:
+
+- case file, status, converged flag, iterations and final mismatch side by side,
+  with a link to each result page;
+- the configuration keys the two runs actually disagree on, read from the
+  `effective_config.yaml` each run wrote (the `_config_sources` bookkeeping is
+  left out, so one difference is listed once);
+- the buses each run clamped, from `q_limit_events.csv`, and which buses only
+  one of the two clamped;
+- the largest voltage deviation and the ten buses that differ most, when both
+  runs wrote `bus_voltages_complex.csv` (that file needs the detailed result
+  CSV export).
+
+Everything shown comes from what the runs themselves wrote, so runs from an
+earlier session compare as well as fresh ones. Exactly two runs are required;
+anything else answers with a message rather than a half-filled page.
 
 Each registered run has a **Delete** action, and **Delete all runs** removes all
 safely registered runs for the current configured root. These actions update

--- a/src/Sparlectra.jl
+++ b/src/Sparlectra.jl
@@ -524,6 +524,8 @@ export
   printQLimitLog,
   printPVQLimitsTable,                    # Print PV Q-limit diagnostics.
   printFinalLimitValidation,              # Print final Q-limit validation.
+  qvCharacteristicViolations,             # Generators at a Q-limit on the wrong voltage side (non-physical solution).
+  printQVCharacteristicCheck,             # Print that check; part of the result print and the run report.
   validate_q_limit_signs!,                # Validate Q-limit sign conventions.
   logQLimitHit!,
   lastQLimitIter,

--- a/src/api/run_api.jl
+++ b/src/api/run_api.jl
@@ -341,7 +341,13 @@ const DTF_FOR001_UNSUPPORTED_DCLINE_MESSAGE = "DC lines are currently not suppor
 
 function _normalize_case_format(value)::Symbol
   format = value isa Symbol ? value : Symbol(lowercase(strip(String(value))))
-  format in (:auto, :matpower, :dtf_for001, :cgmes, :scf) || throw(ArgumentError("case_format must be auto, matpower, dtf_for001, cgmes, or scf; got $(repr(value))."))
+  # `pgm` is an accepted spelling of `scf`, not a second reader: a
+  # power-grid-model `input.json` and a Sparlectra `.scf.json` go through the
+  # same importer, and the `sparlectra` block is optional there
+  # (`scf_import.jl:85-97`). Callers who have a PGM file should not have to
+  # know that it is read by something called SCF.
+  format === :pgm && return :scf
+  format in (:auto, :matpower, :dtf_for001, :cgmes, :scf) || throw(ArgumentError("case_format must be auto, matpower, dtf_for001, cgmes, scf, or pgm; got $(repr(value))."))
   return format
 end
 

--- a/src/api/run_diagnostic_artifacts.jl
+++ b/src/api/run_diagnostic_artifacts.jl
@@ -349,7 +349,11 @@ function _write_final_q_limit_validation(io::IO, result::SparlectraRunResult)
     println(io, "  Final PV/REF Q-limit validation: OK")
     println(io, "  PV/REF Q-limit violations: 0")
     println(io, "  Outer-loop selected violations, if any, are reported in the event sections above.")
-    return (q_violations = 0, v_violations = 0)
+    # A clean Q-limit validation says the limits were ENFORCED; it says
+    # nothing about whether the enforced state is physical. This is the path
+    # a normal converged run takes, so the Q-V check has to run here too.
+    qv = printQVCharacteristicCheck(result.net; io = io, converged = true)
+    return (q_violations = 0, v_violations = 0, qv_violations = length(qv))
   end
   return printFinalLimitValidation(result.net; io, converged = result.numerical_converged)
 end

--- a/src/import/case_import.jl
+++ b/src/import/case_import.jl
@@ -46,6 +46,15 @@ struct ImportedCase
   provenance::Dict{String,Any}
   studies::NamedTuple
   overrides::Dict{String,Any}
+
+  # The imported network carries the configuration it was built with, so a
+  # later `runpf!(net; ...)` without an explicit `config` solves it under that
+  # configuration instead of the globally active one. One inner constructor
+  # covers every format path, so no importer can forget it.
+  function ImportedCase(net::Net, config::SparlectraConfig, format::Symbol, provenance::Dict{String,Any}, studies::NamedTuple, overrides::Dict{String,Any})
+    net._import_config = config
+    return new(net, config, format, provenance, studies, overrides)
+  end
 end
 
 const _EMPTY_CASE_STUDIES = (contingencies = Dict{String,Any}(), short_circuit = Dict{String,Any}())

--- a/src/limits.jl
+++ b/src/limits.jl
@@ -381,7 +381,119 @@ function printFinalLimitValidation(net::Net; q_headroom::Float64 = 0.20, io::IO 
     end
   end
 
-  return (q_violations = length(qrows), v_violations = length(vrows))
+  qv = printQVCharacteristicCheck(net; io = io, converged = converged)
+
+  return (q_violations = length(qrows), v_violations = length(vrows), qv_violations = length(qv))
+end
+
+"""
+    _qv_effective_qgen(net, bus) -> Float64
+
+The reactive generation at `bus` as the Q-V check must read it. Neither single
+source is right on its own:
+
+- `node._qƩGen` carries the value the solver clamped a PV bus to, including
+  the active-set path, but stays 0 for a machine under Q(U) control;
+- `_effective_bus_power_components` evaluates the Q(U) characteristic (and the
+  classic outer loop's clamp, which it writes to the prosumer), but falls back
+  to `_qƩGen` only on Slack and PV buses, not on a bus that was switched to PQ.
+
+So: a Q(U) machine is read from its characteristic, everything else from the
+bus aggregate where the solver left one.
+"""
+function _qv_effective_qgen(net::Net, bus::Int)::Float64
+  node = net.nodeVec[bus]
+  controlled = any(ps -> getPosumerBusIndex(ps) == bus && has_qu_controller(ps), net.prosumpsVec)
+  if !controlled && !isnothing(node._qƩGen)
+    return Float64(node._qƩGen)
+  end
+  _, q_gen, _, _ = _effective_bus_power_components(net, bus)
+  return Float64(q_gen)
+end
+
+"""
+    qvCharacteristicViolations(net; band_pu = 1e-4) -> Vector{NamedTuple}
+
+Generators that ended a solve AT a reactive limit while their voltage sits on
+the WRONG side of their own setpoint:
+
+- `Q = Qmax` with `Vm > Vset`, or
+- `Q = Qmin` with `Vm < Vset`.
+
+Such a point satisfies the power-flow equations and still contradicts the
+physical Q-V characteristic: a machine that is already at its upper reactive
+limit cannot hold a voltage that is above its setpoint. The literature calls
+this a *non-physical* solution (Zeng, Chiang, Neves, Alberto, IJEPES 147
+(2023) 108905) or an *anomalous* one (Sundaresh, Rao 2015), and it is a
+property of the PV/PQ switching strategy, not of the network.
+
+Each row carries `(bus, side, vm_pu, vset_pu, dv_pu, q_MVAr, limit_MVAr,
+significant)`. `dv_pu` is `Vm - Vset` and therefore signed; `significant` is
+`abs(dv_pu) > band_pu`. The band exists because a converged solve leaves
+voltages within its tolerance of the setpoint, so a bus that sits ON its
+setpoint can fall to either side by rounding. Report BOTH counts: the raw one
+is the literature's definition, the significant one is what a reader can act
+on.
+
+Returns an empty vector when no bus hit a limit, and also when the state does
+not come from a converged solve (`converged = false` at the call site).
+"""
+function qvCharacteristicViolations(net::Net; band_pu::Float64 = 1.0e-4)
+  rows = NamedTuple[]
+  isempty(net.qLimitEvents) && return rows
+  vset = _bus_voltage_setpoints_from_prosumers(net)
+  qmin_pu, qmax_pu = getQLimits_pu(net)
+  for (bus, side) in net.qLimitEvents
+    (1 <= bus <= length(net.nodeVec) && bus <= length(vset)) || continue
+    node = net.nodeVec[bus]
+    isnothing(node._vm_pu) && continue
+    isfinite(vset[bus]) || continue
+    limit_pu = side === :max ? (bus <= length(qmax_pu) ? qmax_pu[bus] : Inf) : (bus <= length(qmin_pu) ? qmin_pu[bus] : -Inf)
+    isfinite(limit_pu) || continue
+    limit_mvar = limit_pu * net.baseMVA
+    q = _qv_effective_qgen(net, bus)
+    isfinite(q) || continue
+    # only a bus that really sits ON the limit can be non-physical; a stale
+    # event whose machine has moved back inside its band is not a violation
+    isapprox(q, limit_mvar; atol = 1.0e-6 * max(1.0, abs(limit_mvar))) || continue
+    vm = Float64(node._vm_pu)
+    dv = vm - vset[bus]
+    wrong_side = (side === :max && dv > 0.0) || (side === :min && dv < 0.0)
+    wrong_side || continue
+    push!(rows, (bus = bus, side = side, vm_pu = vm, vset_pu = vset[bus], dv_pu = dv,
+      q_MVAr = q, limit_MVAr = limit_mvar, significant = abs(dv) > band_pu))
+  end
+  sort!(rows; by = r -> r.bus)
+  return rows
+end
+
+"""
+    printQVCharacteristicCheck(net; io=stdout, band_pu=1e-4, converged=true) -> Vector{NamedTuple}
+
+Print the [`qvCharacteristicViolations`](@ref) of the current solution and
+return them. On a non-converged solve the check is skipped with a note: the
+state is not a solution, so the question does not apply.
+"""
+function printQVCharacteristicCheck(net::Net; io::IO = stdout, band_pu::Float64 = 1.0e-4, converged::Bool = true)
+  if !converged
+    println(io, "  Q-V characteristic: skipped (no converged solution).")
+    return NamedTuple[]
+  end
+  rows = qvCharacteristicViolations(net; band_pu = band_pu)
+  if isempty(rows)
+    println(io, "  Q-V characteristic: no non-physical generator states.")
+    return rows
+  end
+  strong = count(r -> r.significant, rows)
+  @printf(io, "  Q-V characteristic: %d non-physical generator state(s), %d beyond %.0e pu.\n", length(rows), strong, band_pu)
+  println(io, "  A machine at its reactive limit whose voltage sits on the wrong side of its")
+  println(io, "  setpoint solves the equations but contradicts the physical Q-V curve.")
+  println(io, "  Bus │ Side │        Vm │      Vset │        dV │  Q [MVAr] │ limit [MVAr]")
+  for r in rows
+    @printf(io, " %4d │ %-4s │ %9.5f │ %9.5f │ %+9.5f │ %9.3f │ %12.3f%s\n",
+      r.bus, String(r.side), r.vm_pu, r.vset_pu, r.dv_pu, r.q_MVAr, r.limit_MVAr, r.significant ? "" : "  (within band)")
+  end
+  return rows
 end
 
 """

--- a/src/network.jl
+++ b/src/network.jl
@@ -143,9 +143,19 @@ mutable struct Net
   # internals including closures (condition-estimate thunk), not model data.
   _rectangular_pf_status::Any
   _dc_pf_status::Any
+  # The configuration this network was BUILT with (`import_case` fills it).
+  # `runpf!(net; ...)` without an explicit `config` uses it instead of the
+  # globally active configuration, so a net imported under one configuration
+  # is not silently solved under another. Found 2026-09-08: a whole
+  # measurement series ran with the package defaults although every net had
+  # been imported with an explicit configuration, and nothing said so; the
+  # tell was identical residuals to the last digit across settings that must
+  # differ. Same skip rule as the two status fields above: solver/session
+  # state, not model data.
+  _import_config::Any
 
   #! format: off
-  function Net(; name::String, baseMVA::Float64, vmin_pu::Float64 = 0.9, vmax_pu::Float64 = 1.1, cooldown_iters::Int = 0, q_hyst_pu::Float64 = 0.0, flatstart::Bool = false, bus_shunt_model = :admittance)    
+  function Net(; name::String, baseMVA::Float64, vmin_pu::Float64 = 0.9, vmax_pu::Float64 = 1.1, cooldown_iters::Int = 0, q_hyst_pu::Float64 = 0.0, flatstart::Bool = false, bus_shunt_model = :admittance)
     shunt_model = normalize_bus_shunt_model(bus_shunt_model)
     
     new(name, # name
@@ -187,7 +197,8 @@ mutable struct Net
         NativeShortCircuitData(),                  # sc_sources
         HvdcLink[],                                # hvdcLinks
         nothing,                                   # _rectangular_pf_status
-        nothing)                                   # _dc_pf_status
+        nothing,                                   # _dc_pf_status
+        nothing)                                   # _import_config
   end
   #! format: on
   function Base.show(io::IO, net::Net)

--- a/src/powerflow_rectangular/rectangular_network_solver.jl
+++ b/src/powerflow_rectangular/rectangular_network_solver.jl
@@ -1577,6 +1577,28 @@ runpf!(net::Net, config::SparlectraConfig; kwargs...) = _runpf_with_config!(
 )
 
 """
+    _runpf_effective_config(net, config) -> Union{Nothing,PowerFlowConfig,SparlectraConfig}
+
+Which configuration a `runpf!(net; ...)` call actually solves under. Precedence:
+
+1. an explicitly passed `config`,
+2. the configuration the net was IMPORTED with (`Net._import_config`),
+3. the globally active configuration.
+
+Step 2 exists since 0.10.1. Before it, a net imported under an explicit
+configuration was solved under the global one, silently: the Q-limit
+enforcement mode, the tolerance and even "Q limits off" never reached the
+solver, and every run looked plausible. The tell was identical residuals to
+the last digit across settings that cannot produce the same answer.
+"""
+function _runpf_effective_config(net::Net, config)
+  config === nothing || return config
+  carried = net._import_config
+  (carried isa SparlectraConfig || carried isa PowerFlowConfig) && return carried
+  return nothing
+end
+
+"""
     runpf!(net, maxIte, tol, verbose; method, kwargs...) -> (iterations, result)
     runpf!(net; config, kwargs...)
 
@@ -1584,12 +1606,24 @@ Run the Newton-Raphson power flow on the network. The positional form takes
 the solver options as keywords; the config form reads them from a
 configuration and passes the run-level values (flat start, Q-limit
 switching) explicitly.
+
+Without an explicit `config` the net's own imported configuration is used
+(see [`_runpf_effective_config`](@ref)), and only if the net carries none
+does the globally active configuration apply.
 """
 function runpf!(net::Net; config::Union{Nothing,PowerFlowConfig,SparlectraConfig} = nothing, kwargs...)
   # Keep this entry strict: only runtime-only knobs are accepted as kwargs.
   # All solver-behavior options must come from config objects for consistency.
   runtime_keys = Set((:verbose, :damp, :pv_table_rows, :validate_limits_after_pf, :q_limit_violation_headroom, :qlimit_lock_reason, :performance_profile))
-  cfg0 = config === nothing ? powerflow_config() : (config isa SparlectraConfig ? config.powerflow : config)
+  effective = _runpf_effective_config(net, config)
+  cfg0 = effective === nothing ? powerflow_config() : (effective isa SparlectraConfig ? effective.powerflow : effective)
+  # A full SparlectraConfig also carries the island fan-out switches; forward
+  # them exactly as the two-argument method does, so both ways of supplying
+  # the same configuration behave alike.
+  parallel = effective isa SparlectraConfig ?
+             (; islands_parallel_enabled = effective.runtime.parallel.enabled,
+    islands_parallel_max_tasks = parallel_max_tasks(effective.runtime.parallel),
+    islands_parallel_min_work_items = effective.runtime.parallel.min_work_items) : NamedTuple()
 
   if !isempty(kwargs)
     raw = Dict{String,Any}(String(k) => v for (k, v) in pairs(kwargs))
@@ -1604,12 +1638,13 @@ function runpf!(net::Net; config::Union{Nothing,PowerFlowConfig,SparlectraConfig
         q_limit_violation_headroom = Float64(get(raw, "q_limit_violation_headroom", 0.0)),
         qlimit_lock_reason = Symbol(get(raw, "qlimit_lock_reason", :manual)),
         performance_profile = get(raw, "performance_profile", nothing),
+        parallel...,
       )
     else
       throw(ArgumentError("runpf!: solver options must be supplied through PowerFlowConfig or set_sparlectra_config!; only runtime keywords $(collect(runtime_keys)) are accepted."))
     end
   end
-  return _runpf_with_config!(net, cfg0)
+  return _runpf_with_config!(net, cfg0; parallel...)
 end
 
 """

--- a/src/results.jl
+++ b/src/results.jl
@@ -1189,6 +1189,12 @@ function printACPFlowResults(
   printHvdcPairControllerSummary(io, net)
   # full UPFC controllers (#326) print only when present as well.
   printUpfcFullControllerSummary(io, net)
+  # Q-V characteristic of the machines that ended at a reactive limit. A
+  # solution can satisfy the equations and still be non-physical (Q at Qmax
+  # with the voltage ABOVE the setpoint, or Q at Qmin with it below), and
+  # nothing else in this report would say so. Prints one line when there is
+  # nothing to report, so its absence is never mistaken for a clean result.
+  printQVCharacteristicCheck(net; io = io, converged = converged)
   if toFile
     close(io)
     #println("Results have been written to $(joinpath(path, filename))")

--- a/src/webui/forms.jl
+++ b/src/webui/forms.jl
@@ -781,7 +781,9 @@ function _webui_case_form_defaults(casefile::AbstractString, case_directory)::Di
   raw_format = get(block, "case_format", nothing)
   if raw_format !== nothing
     fmt = lowercase(strip(String(raw_format)))
-    fmt in ("auto", "matpower", "dtf_for001", "cgmes") && (values["case_format"] = fmt)
+    # scf and pgm name the same reader; both are accepted so the choice
+    # made in the form survives the save (see _normalize_case_format)
+    fmt in ("auto", "matpower", "dtf_for001", "cgmes", "scf", "pgm") && (values["case_format"] = fmt)
   end
   return values
 end
@@ -1115,6 +1117,15 @@ function powerflow_webui_request(form::AbstractDict; default_output_root::Abstra
       # clearing any numeric field would fail the run with a parse error.
       raw isa AbstractString && isempty(strip(raw)) && continue
       overrides[config_key] = _webui_parse_form_value(raw, type, field)
+    end
+    # "off" in the enforcement-mode control means "no Q-limit handling". The
+    # control pair (checkbox + mode) reads as one setting, and a mode picked
+    # while the handling is off does nothing while looking like it does
+    # (reported from a live session 2026-09-08).
+    mode_key = "power_flow.qlimits.enforcement_mode"
+    if haskey(overrides, mode_key) && lowercase(strip(String(overrides[mode_key]))) == "off"
+      delete!(overrides, mode_key)
+      overrides["power_flow.qlimits.enabled"] = false
     end
   end
   # The tolerance is ONE value with a unit, not two competing fields: the

--- a/src/webui/handlers.jl
+++ b/src/webui/handlers.jl
@@ -1011,7 +1011,9 @@ function handle_case_options_save(form::AbstractDict; output_root::AbstractStrin
   end
   form_updates = Dict{String,Any}()
   fmt = lowercase(strip(String(something(_webui_form_value(form, "case_format", ""), ""))))
-  fmt in ("auto", "matpower", "dtf_for001", "cgmes") && (form_updates["case_format"] = fmt)
+  # scf and pgm name the same reader; both are accepted so the choice
+  # made in the form survives the save (see _normalize_case_format)
+  fmt in ("auto", "matpower", "dtf_for001", "cgmes", "scf", "pgm") && (form_updates["case_format"] = fmt)
   written = try
     _webui_merge_case_config_write(source, keep, form_updates; on_unreadable = err -> record_webui_operation!(operation_log, "case_options_save_replaced_unreadable"; route, method = "POST", user_action = true, casefile = case, status = "replaced", message = sprint(showerror, err)))
   catch err
@@ -1542,6 +1544,27 @@ end
 
 function handle_powerflow_history(output_root::AbstractString)::SparlectraWebUIResponse
   return _webui_html(render_powerflow_history(list_powerflow_runs(output_root), output_root; active_run = get_active_webui_powerflow_job()))
+end
+
+"""
+    handle_powerflow_compare(run_ids) -> SparlectraWebUIResponse
+
+Two finished runs side by side. Exactly two ids are required, and both must be
+loadable; anything else is answered with a message instead of a half-filled
+page, because a comparison against a missing run is worse than none.
+"""
+function handle_powerflow_compare(run_ids::Vector{String})::SparlectraWebUIResponse
+  ids = [String(strip(id)) for id in run_ids if !isempty(strip(id))]
+  if length(ids) != 2
+    return _webui_html(render_webui_error(400,
+      "Comparing needs exactly two runs; $(length(ids)) were selected. Go back to the run history, tick two rows and press Compare."); status = 400)
+  end
+  a = get_webui_powerflow_job(ids[1])
+  b = get_webui_powerflow_job(ids[2])
+  for (id, entry) in zip(ids, (a, b))
+    get(entry, "reason", "") == "run_not_found" && return _webui_html(render_webui_error(404, "Run $(id) was not found."); status = 404)
+  end
+  return _webui_html(render_powerflow_compare(a, b))
 end
 
 function handle_webui_operation_log(output_root::AbstractString; download::Bool = false)::SparlectraWebUIResponse

--- a/src/webui/routes.jl
+++ b/src/webui/routes.jl
@@ -55,6 +55,25 @@ function _webui_split_target(target::AbstractString)
   return parts[1], length(parts) == 2 ? _webui_parse_pairs(parts[2]) : Dict{String,String}()
 end
 
+"""
+    _webui_query_values(target, key) -> Vector{String}
+
+Every value a repeated query key carries, in order. `_webui_parse_pairs` keeps
+only the last one because it returns a `Dict`; a set of checkboxes with one
+name (the run comparison) needs them all.
+"""
+function _webui_query_values(target::AbstractString, key::AbstractString)::Vector{String}
+  parts = split(String(target), '?'; limit = 2)
+  length(parts) == 2 || return String[]
+  out = String[]
+  for pair in split(parts[2], '&')
+    kv = split(pair, '='; limit = 2)
+    _webui_urldecode(kv[1]) == key || continue
+    push!(out, length(kv) == 2 ? _webui_urldecode(kv[2]) : "")
+  end
+  return out
+end
+
 function _powerflow_config_notice(config_file::AbstractString)
   isempty(strip(config_file)) && return nothing
   isfile(config_file) || return nothing
@@ -329,6 +348,13 @@ function route_sparlectra_webui(method::AbstractString, target::AbstractString, 
   elseif verb == "GET" && path == "/powerflow/history"
     _webui_log_route!(log_root, "history_opened", verb, path; status = "opened")
     return handle_powerflow_history(output_root)
+  elseif verb == "GET" && path == "/powerflow/compare"
+    # the checkboxes of the history table all carry the name "run", so the
+    # values have to be read from the raw query, not from the pair dictionary
+    selected = _webui_query_values(target, "run")
+    response = handle_powerflow_compare(selected)
+    _webui_log_route!(log_root, "runs_compared", verb, path; status = response.status, run_id = join(selected, ","))
+    return response
   elseif verb == "POST" && path == "/powerflow/refresh"
     handle_powerflow_refresh(output_root)
     _webui_log_route!(log_root, "history_refreshed", verb, path; status = "succeeded")

--- a/src/webui/views.jl
+++ b/src/webui/views.jl
@@ -58,6 +58,21 @@ function _webui_case_import_message(imported::Vector{String}, rejected)::String
   return isempty(header) ? join(lines, " · ") : header * ": " * join(lines, " · ")
 end
 
+"""
+    _webui_qlimit_mode_selection(profile_values) -> String
+
+Which entry the Q-limit enforcement-mode control shows. The pair of controls
+(a checkbox for `power_flow.qlimits.enabled`, a select for the mode) reads as
+one setting to a user, and a mode picked while the handling is off does
+nothing: the select therefore shows "off" in that state, and picking "off"
+turns the handling off (see the form override mapping).
+"""
+function _webui_qlimit_mode_selection(profile_values)
+  enabled = _webui_form_bool(get(profile_values, "power_flow_qlimits_enabled", _webui_option_default("power_flow_qlimits_enabled")))
+  enabled || return "off"
+  return _webui_selected(profile_values, "power_flow_qlimits_enforcement_mode", _webui_option_default("power_flow_qlimits_enforcement_mode"))
+end
+
 function _webui_select(name, values, selected, extra_attrs::AbstractString = "")
   options = join((_webui_option(value, replace(_webui_form_string(value), '_' => ' '), selected) for value in values), "")
   attrs = isempty(extra_attrs) ? "" : " $(extra_attrs)"
@@ -1042,7 +1057,8 @@ $(dat_hint_html)
 <details$(dtf_details_attrs)>
 <summary>Input format</summary>
 <fieldset>
-<label>$(_webui_field_label("case_format", "Case input format"))<select name="case_format"><option value="auto"$(_webui_form_string(case_format_value) == "auto" ? " selected" : "")>Auto</option><option value="matpower"$(_webui_form_string(case_format_value) == "matpower" ? " selected" : "")>MATPOWER</option><option value="dtf_for001"$(_webui_form_string(case_format_value) == "dtf_for001" ? " selected" : "")>DTF diagnostics (experimental/internal)</option><option value="cgmes"$(_webui_form_string(case_format_value) == "cgmes" ? " selected" : "")>CGMES (ENTSO-E, folder or ZIP)</option></select></label>
+<label>$(_webui_field_label("case_format", "Case input format"))<select name="case_format"><option value="auto"$(_webui_form_string(case_format_value) == "auto" ? " selected" : "")>Auto</option><option value="matpower"$(_webui_form_string(case_format_value) == "matpower" ? " selected" : "")>MATPOWER</option><option value="dtf_for001"$(_webui_form_string(case_format_value) == "dtf_for001" ? " selected" : "")>DTF diagnostics (experimental/internal)</option><option value="cgmes"$(_webui_form_string(case_format_value) == "cgmes" ? " selected" : "")>CGMES (ENTSO-E, folder or ZIP)</option><option value="scf"$(_webui_form_string(case_format_value) == "scf" ? " selected" : "")>Sparlectra Case Format (.scf.json)</option><option value="pgm"$(_webui_form_string(case_format_value) == "pgm" ? " selected" : "")>power-grid-model JSON (input.json)</option></select></label>
+<p class="field-help">SCF and power-grid-model JSON are read by the same importer; the <code>sparlectra</code> block is optional, so a plain power-grid-model dataset loads as well. <em>Auto</em> already resolves every <code>.json</code> to that reader, so these two entries only matter when the extension does not say it.</p>
 $(_webui_adapter_options_html(:cgmes, profile_values))
 <p class="field-help" data-cgmes-start-values-field>CGMES only: <em>Flat start</em> lets the solver earn the solution itself; <em>Imported SV state</em> starts Newton-Raphson from the delivery's own SvVoltage solution (competing start-value machines are forced off). The SV comparison check (<code>sv_compare.csv</code>) runs either way.</p>
 </fieldset>
@@ -1086,7 +1102,6 @@ function _webui_settings_sections_html(; profile_values, config_default, profile
   return """
 <label data-ac-only-field title=\"Convergence bound for the largest single bus mismatch (active and reactive alike). Readable in physical units as tol times the case base: 1e-8 pu equals 1 W at a 100 MVA base.\">$(_webui_field_label("power_flow_tol", "Tolerance"))<span class=\"tolerance-field\"><input name=\"power_flow_tol\" type=\"text\" autocomplete=\"off\" spellcheck=\"false\" data-tolerance-input value=\"$(_webui_input_value(profile_values, "power_flow_tol", _webui_option_default("power_flow_tol")))\"><span class=\"tolerance-spin\"><button type=\"button\" class=\"tolerance-spin-up\" data-tolerance-direction=\"up\" aria-label=\"Increase tolerance exponent\">&#9650;</button><button type=\"button\" class=\"tolerance-spin-down\" data-tolerance-direction=\"down\" aria-label=\"Decrease tolerance exponent\">&#9660;</button></span></span></label><label data-ac-only-field class=\"tolerance-unit\" title=\"The unit of the tolerance value. MW states the convergence bound physically: the run converts it with the case's own base (1 MW at a 100 MVA base is 1e-2 pu, 0.001 MW is 1 kW). pu states it per unit, the classical form. The value field to the left holds the number either way.\">$(_webui_field_label("power_flow_tol_unit", "Unit"))<select name=\"power_flow_tol_unit\"><option value=\"pu\"$(_webui_input_value(profile_values, "power_flow_tol_unit", _webui_option_default("power_flow_tol_unit")) == "MW" ? "" : " selected")>pu</option><option value=\"MW\"$(_webui_input_value(profile_values, "power_flow_tol_unit", _webui_option_default("power_flow_tol_unit")) == "MW" ? " selected" : "")>MW</option></select></label>
 <label data-nr-only-field>$(_webui_field_label("power_flow_max_iter", "Maximum iterations"))<input name=\"power_flow_max_iter\" type=\"number\" min=\"1\" value=\"$(_webui_input_value(profile_values, "power_flow_max_iter", _webui_option_default("power_flow_max_iter")))\"></label>
-<label class=\"check\"><input name=\"power_flow_qlimits_enabled\" type=\"hidden\" value=\"false\"><input name=\"power_flow_qlimits_enabled\" type=\"checkbox\" value=\"true\"$(_webui_checked(profile_values, "power_flow_qlimits_enabled", _webui_option_default("power_flow_qlimits_enabled")))>$(_webui_field_label("power_flow_qlimits_enabled", "Q-limit handling enabled"))</label>
 <fieldset class=\"distributed-slack-options\" data-nr-only-field>
 <legend>Distributed slack</legend>
 <label class=\"check span-2\"><input name=\"power_flow_distributed_slack_enabled\" type=\"hidden\" value=\"false\"><input name=\"power_flow_distributed_slack_enabled\" type=\"checkbox\" value=\"true\"$(_webui_checked(profile_values, "power_flow_distributed_slack_enabled", _webui_option_default("power_flow_distributed_slack_enabled")))>$(_webui_field_label("power_flow_distributed_slack_enabled", "Distribute active-power slack over participating generators"))</label>
@@ -1131,7 +1146,9 @@ $(config_maintenance)
 </details>
 <details class=\"span-2 step-control-options\" data-ac-only-field>
 <summary>Q-limit handling</summary>
-<label data-nr-only-field>$(_webui_field_label("power_flow_qlimits_enforcement_mode", "Q-limit enforcement mode"))$(_webui_select("power_flow_qlimits_enforcement_mode", _webui_option_allowed_values("power_flow_qlimits_enforcement_mode"), _webui_selected(profile_values, "power_flow_qlimits_enforcement_mode", _webui_option_default("power_flow_qlimits_enforcement_mode"))))</label>
+<label class=\"check\"><input name=\"power_flow_qlimits_enabled\" type=\"hidden\" value=\"false\"><input name=\"power_flow_qlimits_enabled\" type=\"checkbox\" value=\"true\"$(_webui_checked(profile_values, "power_flow_qlimits_enabled", _webui_option_default("power_flow_qlimits_enabled")))>$(_webui_field_label("power_flow_qlimits_enabled", "Q-limit handling enabled"))</label>
+<label data-nr-only-field>$(_webui_field_label("power_flow_qlimits_enforcement_mode", "Q-limit enforcement mode"))$(_webui_select("power_flow_qlimits_enforcement_mode", vcat(["off"], collect(_webui_option_allowed_values("power_flow_qlimits_enforcement_mode"))), _webui_qlimit_mode_selection(profile_values)))</label>
+<p class=\"field-help span-2\">\"off\" switches Q-limit handling off; it is the same thing as clearing the box above, offered here because a mode picked while the handling is off does nothing and looks like it does.</p>
 </details>
 <details class="span-2 solver-mode-options" open>
 <summary>$(_webui_field_label("power_flow_solver", "Solver"))</summary>
@@ -2082,7 +2099,9 @@ function render_powerflow_result(result::AbstractDict)::String
   rows = join(("<tr><th>$(_webui_escape(field))</th><td>$(_webui_escape(_webui_result_value(result, field)))</td></tr>" for field in _WEBUI_RESULT_FIELDS), "")
   status = lowercase(string(get(result, "status", "unknown")))
   active = status in _WEBUI_ACTIVE_RUN_STATUSES
-  status_badge = "<span class=\"status-badge $(webui_status_class(result))\">$(_webui_escape(status))</span>"
+  diagnose_probe = _webui_is_completed_diagnose(result)
+  status_text = diagnose_probe ? "diagnosed" : status
+  status_badge = "<span class=\"status-badge $(webui_status_class(result))\" title=\"$(_webui_escape(status))\">$(_webui_escape(status_text))</span>"
   final_outcome_value = get(result, "final_outcome", nothing)
   stored_solver = final_outcome_value isa AbstractDict ? String(get(final_outcome_value, "solver", "")) : ""
   meta_for_mode = get(result, "metadata", Dict{String,Any}())
@@ -2146,6 +2165,10 @@ function render_powerflow_result(result::AbstractDict)::String
   metadata = get(result, "metadata", Dict{String,Any}())
   override_source = String(get(result, "config_override_source", get(metadata, "config_override_source", "")))
   runtime_notice = override_source == "user_yaml" ? "<div class=\"alert warning\"><strong>Web UI settings ignored.</strong> This run used YAML/default configuration values because the run was submitted with Web UI settings ignored.</div>" : ""
+  # A diagnose run is a one-step residual probe. Without this line the page
+  # reads like a crashed power flow, and the residual it measured (which IS
+  # the answer) looks like the symptom of one.
+  diagnose_probe && (runtime_notice *= "<div class=\"alert info\"><strong>This is a diagnosis, not a solve.</strong> The self-check takes exactly one step from the case's own stored voltages (<code>max_iter = 1</code>, no rescue, Q-limit handling off), so a remaining residual is the RESULT and not a failure. The numbers below therefore show one iteration and a non-zero mismatch by design; <code>diagnose.log</code> names the worst bus and what to do about it.</div>")
   return _webui_layout(_webui_result_page_title(result), "<section class=\"panel\">$(result_summary)$(runtime_notice)<table class=\"details\">$(rows)</table>$(active_hint)$(links)$(se_chain_section)</section>$(n1_table_section)$(se_tap_section)$(se_topology_section)$(save_section)"; show_back = true, refresh_url)
 end
 
@@ -2248,9 +2271,38 @@ function render_powerflow_artifacts(run_id::AbstractString, artifacts)::String
   return _webui_layout("Artifacts", table; show_back = true)
 end
 
+"""
+    _webui_is_completed_diagnose(run) -> Bool
+
+A Diagnose run that did its job. The self-check takes exactly ONE step from the
+case's own stored voltages (`max_iter = 1`, no rescue), so a remaining residual
+is its RESULT, not its failure: that residual is the diagnosis. Reported as a
+failed power flow it is unusable, because every diagnosis then looks like a
+crash (reported from a live session 2026-09-08).
+
+A diagnose run that could not run at all keeps the failure vocabulary; only the
+"completed, did not converge" combination is a finished probe.
+"""
+function _webui_is_completed_diagnose(run::AbstractDict)::Bool
+  # The history rows carry `run_mode` from the index; a result page does not,
+  # so the self-check configuration the diagnose flow writes is the marker
+  # there. Both paths have to agree, or the badge and the page contradict.
+  is_diagnose = lowercase(string(get(run, "run_mode", ""))) == "diagnose"
+  if !is_diagnose
+    artifacts = get(run, "artifacts", nothing)
+    is_diagnose = artifacts isa AbstractVector &&
+                  any(a -> a isa AbstractDict && String(get(a, "name", "")) == "diagnose_self_check_config.yaml", artifacts)
+  end
+  is_diagnose || return false
+  status = lowercase(string(get(run, "status", "")))
+  run_status = lowercase(string(get(run, "run_status", "")))
+  return status == "not_converged" || run_status == "completed_nonconverged"
+end
+
 function webui_status_class(run::AbstractDict)::String
   status = lowercase(string(get(run, "status", "unknown")))
   success = get(run, "success", nothing)
+  _webui_is_completed_diagnose(run) && return "status-info"
   status in ("running", "pending", "queued", "aborting") && return "status-running"
   status in ("aborted", "aborted_unknown", "interrupted", "cancelled", "canceled") && return "status-aborted"
   status in ("warning", "partial", "questionable") && return "status-warning"
@@ -2273,9 +2325,13 @@ function render_powerflow_history(runs, output_root::AbstractString; active_run 
   rows = join((begin
     run_id = string(get(run, "run_id", ""))
     available = get(run, "available", false)
+    # Two runs of the same case under different settings are the normal way to
+    # look at a Q-limit mode or a solver choice; the history could list them
+    # but not put them side by side. The checkbox feeds /powerflow/compare.
+    pick = available ? "<td><input type=\"checkbox\" name=\"run\" value=\"$(_webui_escape(run_id))\" aria-label=\"Select run $(_webui_escape(run_id)) for comparison\"></td>" : "<td></td>"
     link = available ? "<a href=\"/powerflow/result/$(_webui_urlencode(run_id))\">$(_webui_escape(run_id))</a>" : _webui_escape(run_id)
-    status = string(get(run, "status", "unknown"))
-    status_badge = "<span class=\"status-badge $(webui_status_class(run))\">$(_webui_escape(status))</span>"
+    status = _webui_is_completed_diagnose(run) ? "diagnosed" : string(get(run, "status", "unknown"))
+    status_badge = "<span class=\"status-badge $(webui_status_class(run))\" title=\"$(_webui_escape(string(get(run, "status", ""))))\">$(_webui_escape(status))</span>"
     delete_form = "<form method=\"post\" action=\"/powerflow/delete/$(_webui_urlencode(run_id))\" class=\"delete-run-form\"><button type=\"submit\" class=\"danger-button\">Delete</button></form>"
     abort_form = lowercase(status) in ("queued", "running") ? "<form method=\"post\" action=\"/powerflow/abort/$(_webui_urlencode(run_id))\"><button type=\"submit\" class=\"danger-button\">Abort</button></form>" : ""
     # run kind (SE phase 5): "" = plain power flow, also what pre-0.10 index
@@ -2284,10 +2340,295 @@ function render_powerflow_history(runs, output_root::AbstractString; active_run 
     kind_label = isempty(kind) ? "powerflow" : kind
     fields = (_webui_run_timestamp(run), link, status_badge, kind_label, available, _webui_run_method(run, String(get(run, "solver", ""))), get(run, "iterations", ""), get(run, "final_mismatch", ""), get(run, "casefile", ""), get(run, "config_file", ""))
     cells = "<td>$(_webui_escape(fields[1]))</td><td>$(fields[2])</td><td>$(fields[3])</td>" * join(("<td>$(_webui_escape(field))</td>" for field in fields[4:end]), "")
-    "<tr>$(cells)<td>$(abort_form)$(delete_form)</td></tr>"
+    "<tr>$(pick)$(cells)<td>$(abort_form)$(delete_form)</td></tr>"
   end for run in ordered_runs), "")
-  content = "$(_webui_active_run_banner(active_run))<section class=\"panel history-actions\"><p><strong>Output root:</strong> <code>$(_webui_escape(output_root))</code></p><div class=\"actions\"><form method=\"post\" action=\"/powerflow/refresh\"><button type=\"submit\">Refresh registry</button></form><form method=\"post\" action=\"/powerflow/delete_all\"><button type=\"submit\" class=\"danger-button\">Delete all runs</button></form></div></section>\n<section class=\"panel\"><table><thead><tr><th>Date/Time</th><th>Run ID</th><th>Status</th><th>Kind</th><th>Available</th><th>Solver</th><th>Iterations</th><th>Final mismatch</th><th>Case file</th><th>Config file</th><th>Delete</th></tr></thead><tbody>$(rows)</tbody></table></section>"
+  # The compare button submits the surrounding form; the handler is the place
+  # that insists on exactly two runs, so the page stays usable without JS.
+  compare_hint = "<p class=\"field-hint\">Tick two runs and press Compare to see them side by side: status, iterations, residual, the configuration keys that differ, the Q-limit events and, where both runs wrote bus voltages, the largest voltage deviation.</p>"
+  content = "$(_webui_active_run_banner(active_run))<section class=\"panel history-actions\"><p><strong>Output root:</strong> <code>$(_webui_escape(output_root))</code></p><div class=\"actions\"><form method=\"post\" action=\"/powerflow/refresh\"><button type=\"submit\">Refresh registry</button></form><form method=\"post\" action=\"/powerflow/delete_all\"><button type=\"submit\" class=\"danger-button\">Delete all runs</button></form></div></section>\n<section class=\"panel\"><form method=\"get\" action=\"/powerflow/compare\">$(compare_hint)<div class=\"actions\"><button type=\"submit\" class=\"secondary-button\">Compare selected runs</button></div><table><thead><tr><th>Compare</th><th>Date/Time</th><th>Run ID</th><th>Status</th><th>Kind</th><th>Available</th><th>Solver</th><th>Iterations</th><th>Final mismatch</th><th>Case file</th><th>Config file</th><th>Delete</th></tr></thead><tbody>$(rows)</tbody></table></form></section>"
   return _webui_layout("Run history", content; show_back = true)
+end
+
+"""
+    _webui_compare_config_diff(a_dir, b_dir) -> Vector{Tuple{String,String,String}}
+
+The configuration keys two runs disagree on, read from the `effective_config.yaml`
+each run writes. Line based on purpose: the file is the record of what a run
+actually used, and a line diff needs no schema knowledge and cannot go stale
+when the configuration grows a section.
+"""
+function _webui_compare_config_diff(a_dir::AbstractString, b_dir::AbstractString)
+  read_keys(dir) = begin
+    path = joinpath(dir, "effective_config.yaml")
+    out = Dict{String,String}()
+    isfile(path) || return out
+    # indent stack, so a nested key gets its real dotted path: a plain
+    # "remember the last section" would concatenate every section it ever saw
+    stack = Tuple{Int,String}[]
+    for line in eachline(path)
+      isempty(strip(line)) && continue
+      startswith(strip(line), "#") && continue
+      indent = length(line) - length(lstrip(line))
+      m = match(r"^\s*([A-Za-z0-9_.]+):\s*(.*)$", line)
+      m === nothing && continue
+      key, value = String(m.captures[1]), strip(String(m.captures[2]))
+      while !isempty(stack) && stack[end][1] >= indent
+        pop!(stack)
+      end
+      prefix = isempty(stack) ? "" : string(join((s[2] for s in stack), "."), ".")
+      if isempty(value)
+        push!(stack, (indent, key))
+        continue
+      end
+      out[string(prefix, key)] = value
+    end
+    return out
+  end
+  a = read_keys(a_dir)
+  b = read_keys(b_dir)
+  rows = Tuple{String,String,String}[]
+  for key in sort(collect(union(keys(a), keys(b))))
+    # `_config_sources` records where each value came from. It mirrors every
+    # difference a second time, which reads like two findings instead of one.
+    startswith(key, "_config_sources.") && continue
+    va = get(a, key, "-")
+    vb = get(b, key, "-")
+    va == vb || push!(rows, (key, va, vb))
+  end
+  return rows
+end
+
+"""
+    _webui_compare_qlimit_buses(dir) -> Vector{Int} or nothing
+
+Clamped buses of a run, from the `q_limit_events.csv` it wrote. The file
+follows the run's CSV format like every other artifact (its writer takes the
+same `format` argument), so it is read by column name rather than by position.
+"""
+function _webui_compare_qlimit_buses(dir::AbstractString)
+  table = _webui_compare_csv_table(joinpath(dir, "q_limit_events.csv"))
+  table === nothing && return nothing
+  buses = Int[]
+  for row in table.rows
+    bus = tryparse(Int, strip(get(row, "bus", "")))
+    bus === nothing || push!(buses, bus)
+  end
+  return sort!(unique!(buses))
+end
+
+"""
+    _webui_compare_split_csv(line, delimiter) -> Vector{String}
+
+One CSV line into its fields, honoring quoted fields. The detailed export
+quotes any cell that contains the delimiter, which the `excel_us` format
+produces for every grouped number (`"1,234.5"` in a comma-delimited file).
+"""
+function _webui_compare_split_csv(line::AbstractString, delimiter::Char)::Vector{String}
+  fields = String[]
+  buffer = IOBuffer()
+  in_quotes = false
+  i = firstindex(line)
+  while i <= lastindex(line)
+    c = line[i]
+    if in_quotes
+      if c == '"'
+        # a doubled quote inside a quoted field is one literal quote
+        if i < lastindex(line) && line[nextind(line, i)] == '"'
+          print(buffer, '"')
+          i = nextind(line, i)
+        else
+          in_quotes = false
+        end
+      else
+        print(buffer, c)
+      end
+    elseif c == '"'
+      in_quotes = true
+    elseif c == delimiter
+      push!(fields, String(take!(buffer)))
+    else
+      print(buffer, c)
+    end
+    i = nextind(line, i)
+  end
+  push!(fields, String(take!(buffer)))
+  return fields
+end
+
+"""
+    _webui_compare_csv_table(path) -> NamedTuple or nothing
+
+A detailed-export CSV as named rows, in whichever of the three formats the run
+was written with. The delimiter comes from the header line and settles the
+number format with it (`run_api.jl`: `technical` = `,` and `.`; `excel_de` =
+`;`, `,` decimals, `.` grouping; `excel_us` = `,`, `.` decimals, `,` grouping),
+so one rule reads all three. Getting this wrong is not loud: a comma-splitting
+reader on a semicolon file finds no columns at all and the page then claims the
+two runs have nothing in common (reported 2026-09-08).
+"""
+function _webui_compare_csv_table(path::AbstractString)
+  isfile(path) || return nothing
+  lines = readlines(path)
+  isempty(lines) && return nothing
+  head = strip(lines[1])
+  delimiter = count(==(';'), head) > count(==(','), head) ? ';' : ','
+  decimal = delimiter == ';' ? ',' : '.'
+  thousands = delimiter == ';' ? '.' : ','
+  header = _webui_compare_split_csv(head, delimiter)
+  rows = Vector{Dict{String,String}}()
+  for line in Iterators.drop(lines, 1)
+    isempty(strip(line)) && continue
+    parts = _webui_compare_split_csv(strip(line), delimiter)
+    length(parts) == length(header) || continue
+    push!(rows, Dict(header[k] => parts[k] for k in eachindex(header)))
+  end
+  return (rows = rows, decimal = decimal, thousands = thousands)
+end
+
+"A number as the detailed export wrote it, in the format that table uses."
+function _webui_compare_number(text::AbstractString, decimal::Char, thousands::Char)
+  cleaned = replace(strip(text), string(thousands) => "")
+  decimal == '.' || (cleaned = replace(cleaned, decimal => '.'))
+  return tryparse(Float64, cleaned)
+end
+
+"""
+    _webui_compare_voltages(dir) -> Dict or nothing
+
+Bus voltages of a run from `bus_voltages_complex.csv` (detailed CSV export),
+keyed by the bus index, which is what two runs of the same case share. The bus
+name travels along for the table, because an index alone says nothing to
+someone reading the page.
+"""
+function _webui_compare_voltages(dir::AbstractString)
+  table = _webui_compare_csv_table(joinpath(dir, "bus_voltages_complex.csv"))
+  table === nothing && return nothing
+  out = Dict{String,NamedTuple{(:vm, :va, :name),Tuple{Float64,Float64,String}}}()
+  for row in table.rows
+    bus = strip(get(row, "bus", ""))
+    vm = _webui_compare_number(get(row, "vm_pu", ""), table.decimal, table.thousands)
+    va = _webui_compare_number(get(row, "va_deg", ""), table.decimal, table.thousands)
+    (isempty(bus) || vm === nothing || va === nothing) && continue
+    # the case's own name if it has one, otherwise the index it is keyed by
+    name = strip(get(row, "original_bus_name", ""))
+    isempty(name) && (name = strip(get(row, "bus_name", "")))
+    out[String(bus)] = (vm = vm, va = va, name = isempty(name) ? String(bus) : String(name))
+  end
+  return isempty(out) ? nothing : out
+end
+
+"""
+    _webui_compare_losses(dir) -> NamedTuple or nothing
+
+Total branch losses of a run, summed over the `p_loss_MW`/`q_loss_MVar` columns
+the run wrote into `branch_flows.csv`. The sum is the only arithmetic this page
+does; every number in it is otherwise read as written.
+"""
+function _webui_compare_losses(dir::AbstractString)
+  table = _webui_compare_csv_table(joinpath(dir, "branch_flows.csv"))
+  table === nothing && return nothing
+  p = 0.0
+  q = 0.0
+  n = 0
+  for row in table.rows
+    dp = _webui_compare_number(get(row, "p_loss_MW", ""), table.decimal, table.thousands)
+    dq = _webui_compare_number(get(row, "q_loss_MVar", ""), table.decimal, table.thousands)
+    dp === nothing && continue
+    p += dp
+    q += dq === nothing ? 0.0 : dq
+    n += 1
+  end
+  return n == 0 ? nothing : (p_MW = p, q_MVAr = q, branches = n)
+end
+
+"""
+    render_powerflow_compare(a, b) -> String
+
+Two finished runs side by side. Everything shown comes from what the runs
+themselves wrote; nothing is recomputed, so the page also works for runs from
+an earlier session.
+"""
+function render_powerflow_compare(a::AbstractDict, b::AbstractDict)::String
+  id(r) = string(get(r, "run_id", ""))
+  cell(r, key, default = "-") = _webui_escape(string(get(r, key, default)))
+  head = string(
+    "<section class=\"panel\"><h2>Two runs side by side</h2><table><thead><tr><th>Property</th>",
+    "<th>A: $(cell(a, "run_id"))</th><th>B: $(cell(b, "run_id"))</th></tr></thead><tbody>",
+  )
+  for (label, key) in (("Case file", "casefile"), ("Status", "status"), ("Converged", "converged"),
+    ("Iterations", "iterations"), ("Final mismatch", "final_mismatch"), ("Config file", "config_file"))
+    head *= "<tr><td>$(_webui_escape(label))</td><td>$(cell(a, key))</td><td>$(cell(b, key))</td></tr>"
+  end
+  head *= "</tbody></table><p class=\"actions\"><a href=\"/powerflow/result/$(_webui_urlencode(id(a)))\">Open A</a> &middot; <a href=\"/powerflow/result/$(_webui_urlencode(id(b)))\">Open B</a></p></section>"
+
+  dir_a = String(get(a, "output_dir", ""))
+  dir_b = String(get(b, "output_dir", ""))
+
+  diff = _webui_compare_config_diff(dir_a, dir_b)
+  cfg_section = if isempty(diff)
+    "<section class=\"panel\"><h2>Configuration</h2><p>Both runs used the same effective configuration.</p></section>"
+  else
+    rows = join(("<tr><td><code>$(_webui_escape(k))</code></td><td>$(_webui_escape(va))</td><td>$(_webui_escape(vb))</td></tr>" for (k, va, vb) in diff), "")
+    "<section class=\"panel\"><h2>Configuration differences ($(length(diff)))</h2><table><thead><tr><th>Key</th><th>A</th><th>B</th></tr></thead><tbody>$(rows)</tbody></table></section>"
+  end
+
+  qa = _webui_compare_qlimit_buses(dir_a)
+  qb = _webui_compare_qlimit_buses(dir_b)
+  q_section = if qa === nothing && qb === nothing
+    "<section class=\"panel\"><h2>Q-limit events</h2><p>Neither run recorded Q-limit events.</p></section>"
+  else
+    only_a = setdiff(something(qa, Int[]), something(qb, Int[]))
+    only_b = setdiff(something(qb, Int[]), something(qa, Int[]))
+    same = isempty(only_a) && isempty(only_b)
+    note = same ? "<p>Both runs clamped the same buses.</p>" :
+           "<p><strong>The runs clamped different buses.</strong> Only in A: $(_webui_escape(string(only_a))). Only in B: $(_webui_escape(string(only_b))).</p>"
+    "<section class=\"panel\"><h2>Q-limit events</h2>$(note)<table><thead><tr><th></th><th>Clamped buses</th></tr></thead><tbody><tr><td>A</td><td>$(_webui_escape(string(something(qa, "no file"))))</td></tr><tr><td>B</td><td>$(_webui_escape(string(something(qb, "no file"))))</td></tr></tbody></table></section>"
+  end
+
+  la = _webui_compare_losses(dir_a)
+  lb = _webui_compare_losses(dir_b)
+  loss_section = if la === nothing || lb === nothing
+    "<section class=\"panel\"><h2>Losses</h2><p>At least one run has no <code>branch_flows.csv</code>; it is written when the detailed result CSV export is on.</p></section>"
+  else
+    dp = la.p_MW - lb.p_MW
+    dq = la.q_MVAr - lb.q_MVAr
+    # a difference far below the convergence tolerance is the same operating
+    # point written twice, not a finding
+    verdict = abs(dp) < 1e-6 ? "<p>Both runs end on the same losses.</p>" :
+              "<p><strong>The runs differ by $(round(dp; sigdigits = 4)) MW</strong> of active losses ($(round(100 * dp / max(abs(lb.p_MW), eps()); sigdigits = 3)) % of B).</p>"
+    body = string(
+      "<tr><td>Active losses [MW]</td><td>$(round(la.p_MW; digits = 4))</td><td>$(round(lb.p_MW; digits = 4))</td><td>$(round(dp; sigdigits = 4))</td></tr>",
+      "<tr><td>Reactive losses [MVAr]</td><td>$(round(la.q_MVAr; digits = 4))</td><td>$(round(lb.q_MVAr; digits = 4))</td><td>$(round(dq; sigdigits = 4))</td></tr>",
+      "<tr><td>Branches summed</td><td>$(la.branches)</td><td>$(lb.branches)</td><td>$(la.branches - lb.branches)</td></tr>",
+    )
+    "<section class=\"panel\"><h2>Losses</h2>$(verdict)<table><thead><tr><th>Quantity</th><th>A</th><th>B</th><th>A - B</th></tr></thead><tbody>$(body)</tbody></table></section>"
+  end
+
+  va = _webui_compare_voltages(dir_a)
+  vb = _webui_compare_voltages(dir_b)
+  v_section = if va === nothing || vb === nothing
+    "<section class=\"panel\"><h2>Bus voltages</h2><p>At least one run has no readable <code>bus_voltages_complex.csv</code>; it is written when the detailed result CSV export is on.</p></section>"
+  else
+    shared = sort(collect(intersect(keys(va), keys(vb))); by = k -> something(tryparse(Int, k), typemax(Int)))
+    if isempty(shared)
+      "<section class=\"panel\"><h2>Bus voltages</h2><p>The two runs have no bus in common, so they are not two runs of the same network.</p></section>"
+    else
+      deltas = [(bus, va[bus].vm - vb[bus].vm, va[bus].va - vb[bus].va) for bus in shared]
+      sort!(deltas; by = t -> -abs(t[2]))
+      maxdvm = maximum(abs(t[2]) for t in deltas)
+      maxdva = maximum(abs(t[3]) for t in deltas)
+      if maxdvm < 1e-9 && maxdva < 1e-9
+        # a table of zeros over every bus hides the one thing it says
+        "<section class=\"panel\"><h2>Bus voltages</h2><p>Both runs end on the same voltages at all $(length(shared)) shared buses.</p></section>"
+      else
+        rows = join(("<tr><td>$(_webui_escape(bus))</td><td>$(_webui_escape(va[bus].name))</td><td>$(round(va[bus].vm; digits = 6))</td><td>$(round(vb[bus].vm; digits = 6))</td><td>$(round(dvm; sigdigits = 4))</td><td>$(round(dva; sigdigits = 4))</td></tr>" for (bus, dvm, dva) in first(deltas, 10)), "")
+        summary = "<p>max |dVm| = <strong>$(round(maxdvm; sigdigits = 4)) pu</strong>, max |dVa| = $(round(maxdva; sigdigits = 4)) deg, over $(length(shared)) shared buses. The ten largest deviations:</p>"
+        "<section class=\"panel\"><h2>Bus voltages</h2>$(summary)<table><thead><tr><th>Bus</th><th>Name</th><th>A Vm [pu]</th><th>B Vm [pu]</th><th>dVm</th><th>dVa [deg]</th></tr></thead><tbody>$(rows)</tbody></table></section>"
+      end
+    end
+  end
+
+  return _webui_layout("Compare runs", string(head, cfg_section, q_section, loss_section, v_section); show_back = true)
 end
 
 function render_webui_operation_log(content::AbstractString; entries::Integer = 0, bytes::Integer = 0)::String

--- a/test/test_demo_cases.jl
+++ b/test/test_demo_cases.jl
@@ -25,6 +25,8 @@
 const _DEMO_CASE_DIR = normpath(joinpath(dirname(@__DIR__), "data", "scf"))
 const _DEMO_CASE_FIXTURES = normpath(joinpath(@__DIR__, "fixtures", "demo_cases"))
 const _DEMO_CASE_NAMES = ("sp_case5", "sp_case14", "sp_case60", "sp_case188")
+# same rule for the provenance stamp as the SCF tests use
+include("test_scf_support.jl")
 # the fixtures are machine-neutral: they were taken against the PACKAGE
 # defaults (colleague review 2026-09-03), so the comparison must never
 # resolve through this machine's configuration.yaml
@@ -152,6 +154,53 @@ function run_demo_case_tests()
     all_files = filter(f -> startswith(f, "sp_case"), readdir(_DEMO_CASE_DIR))
     @test sum(filesize(joinpath(_DEMO_CASE_DIR, f)) for f in all_files) < 900_000
 
+    # Why there is no byte round trip for these four, in case someone reaches
+    # for one here: importing a shipped case and exporting it again does NOT
+    # reproduce the file. `scenarios`, the `short_circuit` block with its PGM
+    # `fault` row, the `extra` names and the measurement provenance are EXPORT
+    # ARGUMENTS, not network state (measured 2026-09-08: sp_case5 comes back as
+    # 15354 characters against the shipped 16643). Handing those blocks back to
+    # the exporter from the file under test would compare it against its own
+    # input. These files are built by a generator that passes those arguments
+    # and is their provenance record, not by a re-export; the property such a
+    # comparison would be reaching for is checked directly below instead.
+    #
+    # Colleague review 2026-09-08, after the 0.10.0 -> 0.11.0 bump turned a
+    # fixture comparison red: a test that goes red on every version bump
+    # trains the reflex to regenerate the file, and the next time the diff
+    # may be more than the stamp line, with the regeneration hiding it. The
+    # shipped cases must therefore not depend on the release recorded in
+    # them at all. A copy stamped with a version that does not exist has to
+    # import to the same network and solve to the same result; nothing may
+    # read `created_by` except a human looking for provenance.
+    @testset "the provenance stamp does not reach behavior" begin
+      d = mktempdir()
+      for name in _DEMO_CASE_NAMES
+        original = joinpath(_DEMO_CASE_DIR, "$(name).scf.json")
+        # the case config next to the file pins the tolerance; it has to
+        # travel with the copy or the comparison resolves differently
+        cp(Sparlectra.case_config_path(original), joinpath(d, basename(Sparlectra.case_config_path(original))); force = true)
+        foreign = scf_with_foreign_stamp(original, d)
+        @test occursin("Sparlectra 0.0.0-nonexistent", read(foreign, String))
+        # and it is the ONLY difference
+        @test scf_without_stamp(read(foreign, String)) == scf_without_stamp(read(original, String))
+
+        ref = Sparlectra.import_case(original, _DEMO_REF_CONFIG()).net
+        alt = Sparlectra.import_case(foreign, _DEMO_REF_CONFIG()).net
+        @test length(alt.nodeVec) == length(ref.nodeVec)
+        @test length(alt.branchVec) == length(ref.branchVec)
+        @test length(alt.measurements) == length(ref.measurements)
+        ite_ref, erg_ref = runpf!(ref; verbose = 0)
+        ite_alt, erg_alt = runpf!(alt; verbose = 0)
+        @test (ite_alt, erg_alt) == (ite_ref, erg_ref)
+        calcNetLosses!(ref)
+        calcNetLosses!(alt)
+        p_ref, q_ref = Sparlectra.getTotalLosses(net = ref)
+        p_alt, q_alt = Sparlectra.getTotalLosses(net = alt)
+        @test p_alt == p_ref && q_alt == q_ref
+      end
+    end
+
     # maintainer request 2026-09-03: the shipped cases load through the Web
     # UI. The chooser offers them without any cache copy, and the run path
     # stages a bundled case into the cache WITH its sidecars (the per-case
@@ -197,43 +246,65 @@ function run_demo_case_tests()
       @test Sparlectra._webui_stage_bundled_case!(app_root, cache, "sp_nope.scf.json") === nothing
     end
 
-    # colleague follow-up 2026-09-03: the per-case config must neutralize a
-    # general config that changes the SOLUTION, not just the accuracy. Two
-    # legs: warm from the shipped start_state, and COLD with the start
-    # wiped, where the hostile max_iter 6 and 1e-3 tolerance would bite if
-    # anything leaked through (probed: cold runs take 5 to 6 genuine
-    # iterations and land on the same fixtures).
-    @testset "hostile general config cannot move the shipped fixtures (warm and cold start)" begin
-      hostile = Sparlectra.SparlectraConfig(Dict{String,Any}(
-        "power_flow" => Dict{String,Any}(
-          "tol" => 1.0e-3,
-          "max_iter" => 6,
-          "autodamp" => false,
-          "qlimits" => Dict{String,Any}("enabled" => false, "enforcement_mode" => "classic_simultaneous"),
-          "distributed_slack" => Dict{String,Any}("enabled" => true, "p_mode" => "pmax_weighted"),
-        ),
-      ))
-      for name in _DEMO_CASE_NAMES
-        fixture = _demo_fixture(name)
-        bus_state = fixture["power_flow"]["bus_state"]
-        scf_path = joinpath(_DEMO_CASE_DIR, "$(name).scf.json")
-        for cold in (false, true)
-          net = Sparlectra.import_case(scf_path, hostile).net
-          if cold
-            for nd in net.nodeVec
-              Sparlectra.setVmVa!(node = nd, vm_pu = 1.0, va_deg = 0.0)
-            end
-          end
-          ite, erg = runpf!(net; verbose = 0)
-          @test erg == 0
-          # the cold leg must genuinely iterate, or it proves nothing
-          cold && @test ite > 1
-          ids = Sparlectra.scf_id_map(net)
-          for i in eachindex(net.nodeVec)
-            @test isapprox(net.nodeVec[i]._vm_pu, bus_state[string(ids.node[i])]["vm_pu"]; atol = 1e-6)
-          end
-        end
+    # REPLACES the former testset "hostile general config cannot move the
+    # shipped fixtures" (2026-09-03 to 2026-09-08). That test could not fail:
+    # it handed a hostile configuration to `import_case` and then called
+    # `runpf!(net; verbose = 0)`, and that call form solved under the GLOBAL
+    # configuration, so the hostile values never reached the solver. Its
+    # premise was wrong twice over: `import_case` does not merge the case
+    # sidecar at all (that happens in `resolve_config`, on the service path),
+    # and a sidecar that pins only `power_flow.tol` cannot neutralize a
+    # hostile `distributed_slack` anyway. Measured on 2026-09-08: with the
+    # hostile configuration actually applied, sp_case14 throws
+    # "distributed slack: no valid participant ... p_mode=pmax_weighted".
+    #
+    # What holds instead, and what this testset guards: the configuration a
+    # net was imported with is the one it is solved under.
+    @testset "the imported configuration reaches the solver" begin
+      scf_path = joinpath(_DEMO_CASE_DIR, "sp_case14.scf.json")
+
+      # structural: the net carries what it was built with
+      strict = Sparlectra.SparlectraConfig(Dict{String,Any}("power_flow" => Dict{String,Any}("max_iter" => 1)))
+      carried = Sparlectra.import_case(scf_path, strict).net._import_config
+      @test carried isa Sparlectra.SparlectraConfig
+      @test carried.powerflow.max_iter == 1
+
+      # behavioural, and the actual regression: a cold start cannot converge
+      # in a single iteration. Under the old behaviour this run silently used
+      # the global max_iter and converged, which is exactly what hid the bug.
+      cold_net = Sparlectra.import_case(scf_path, strict).net
+      for nd in cold_net.nodeVec
+        Sparlectra.setVmVa!(node = nd, vm_pu = 1.0, va_deg = 0.0)
       end
+      _, erg_strict = runpf!(cold_net; verbose = 0)
+      @test erg_strict != 0
+
+      # the same cold start converges under the package defaults, so the
+      # failure above comes from the configuration and not from the case
+      ref_net = Sparlectra.import_case(scf_path, _DEMO_REF_CONFIG()).net
+      for nd in ref_net.nodeVec
+        Sparlectra.setVmVa!(node = nd, vm_pu = 1.0, va_deg = 0.0)
+      end
+      ite_ref, erg_ref = runpf!(ref_net; verbose = 0)
+      @test erg_ref == 0
+      @test ite_ref > 1
+
+      # and it still lands on the shipped fixture
+      fixture = _demo_fixture("sp_case14")
+      bus_state = fixture["power_flow"]["bus_state"]
+      ids = Sparlectra.scf_id_map(ref_net)
+      for i in eachindex(ref_net.nodeVec)
+        @test isapprox(ref_net.nodeVec[i]._vm_pu, bus_state[string(ids.node[i])]["vm_pu"]; atol = 1e-6)
+      end
+
+      # an explicit `config` still wins over the carried one
+      loose = Sparlectra.SparlectraConfig(Dict{String,Any}("power_flow" => Dict{String,Any}("max_iter" => 50)))
+      win_net = Sparlectra.import_case(scf_path, strict).net
+      for nd in win_net.nodeVec
+        Sparlectra.setVmVa!(node = nd, vm_pu = 1.0, va_deg = 0.0)
+      end
+      _, erg_win = runpf!(win_net, loose; verbose = 0)
+      @test erg_win == 0
     end
   end
 end

--- a/test/test_scf.jl
+++ b/test/test_scf.jl
@@ -22,6 +22,9 @@
 # the shared capture helper needs both stdlibs when this file runs standalone
 using Logging
 
+# the fixture comparison lives with the demo-case tests, so both use one rule
+include("test_scf_support.jl")
+
 # warmup_casePST.m is TRACKED and lives in the checkout; anything else has to
 # come from SPARLECTRA_LARGE_CASES_DIR, so a caller passing another name gates
 # on large_case_path first
@@ -55,6 +58,7 @@ const _SCF_RT_ALLOWED = Dict{Symbol,Dict{Symbol,String}}(
     :_locked => "construction state",
     :_rectangular_pf_status => "a run result",
     :_dc_pf_status => "a run result",
+    :_import_config => "the configuration the net was imported with; session state, like the two status fields above, and not part of the model",
     :busOriginalNameDict => "source-format naming aid; the reference names are compared directly",
     :busOrigIdxDict => "source-format index aid; the bus order is compared directly",
     :cgmes_ids => "CGMES mRIDs travel in `external_id` and are compared through the names",
@@ -503,7 +507,14 @@ function run_scf_tests()
       d = mktempdir()
       pristine = importSCF(fixture)
       again = exportSCF(pristine; file = joinpath(d, "again.scf.json"), case_name = "warmup_casePST", source_format = "matpower", source_reference = "warmup_casePST.m", intended_calculations = String["power_flow", "state_estimation"], include_start_state = true, notes = root["sparlectra"]["meta"]["notes"])
-      @test read(again, String) == read(fixture, String)
+      # This is the PERMANENT v1 format fixture: it keeps the version stamp of
+      # the release that wrote it, on purpose, so a re-export cannot match it
+      # byte for byte across a release. A plain equality broke on the
+      # 0.10.0 -> 0.11.0 bump for exactly that reason, with nothing wrong in
+      # the round trip (see test_scf_support.jl).
+      verdict = scf_matches_fixture(again, fixture)
+      @test verdict.stamp_is_current
+      @test verdict.rest_identical
     end
 
     @testset "reader validation: unknown keys and broken references" begin

--- a/test/test_scf_support.jl
+++ b/test/test_scf_support.jl
@@ -1,0 +1,67 @@
+# Copyright 2023-2026 Udo Schmitz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# file: test/test_scf_support.jl
+# purpose: one place for comparing a freshly written SCF file against a
+#          tracked fixture. A shipped SCF file records the release that
+#          wrote it (`created_by: Sparlectra <version>`), so a plain byte
+#          equality against a tracked file breaks on EVERY version bump
+#          while nothing is wrong with the round trip. That red run trains
+#          the reflex to regenerate the fixture, and the next time the diff
+#          may be more than the stamp line, with the regeneration hiding
+#          it (0.10.0 -> 0.11.0 was the first occurrence). Split the claim
+#          instead: the fresh file names the CURRENT version, and
+#          everything apart from that stamp is byte for byte. Both callers
+#          use these helpers so they cannot drift apart.
+
+"The provenance stamp an SCF file carries, whatever release wrote it."
+const SCF_PROVENANCE_STAMP = r"\"created_by\": \"Sparlectra [^\"]*\""
+
+"An SCF document with its provenance stamp neutralized, for byte comparison."
+scf_without_stamp(text::AbstractString) = replace(String(text), SCF_PROVENANCE_STAMP => "\"created_by\": \"<provenance stamp>\"")
+
+"""
+    scf_matches_fixture(fresh_path, fixture_path) -> NamedTuple
+
+The two halves a fixture comparison really claims, separately, so a failure
+names which one broke:
+
+- `stamp_is_current`: the freshly written file records the running version.
+- `rest_identical`: everything except that stamp is byte for byte identical.
+
+Use this for every comparison between a file written during the test run and
+a tracked fixture. Two files written by the same run carry the same stamp and
+can be compared directly.
+"""
+function scf_matches_fixture(fresh_path::AbstractString, fixture_path::AbstractString)
+  fresh = read(fresh_path, String)
+  return (
+    stamp_is_current = occursin("\"created_by\": \"Sparlectra $(Sparlectra.version())\"", fresh),
+    rest_identical = scf_without_stamp(fresh) == scf_without_stamp(read(fixture_path, String)),
+  )
+end
+
+"""
+    scf_with_foreign_stamp(path, directory) -> String
+
+A copy of `path` in `directory` whose provenance stamp names a release that
+does not exist. Reading it must produce the same network as the original: a
+shipped case that behaves differently because of the version that wrote it
+would tie behavior to provenance.
+"""
+function scf_with_foreign_stamp(path::AbstractString, directory::AbstractString)
+  target = joinpath(directory, basename(path))
+  write(target, replace(read(path, String), SCF_PROVENANCE_STAMP => "\"created_by\": \"Sparlectra 0.0.0-nonexistent\""))
+  return target
+end

--- a/test/test_solver_interface.jl
+++ b/test/test_solver_interface.jl
@@ -1561,6 +1561,62 @@ mpc.branch = [
       @test occursin("Last-iteration Q-limit diagnostic (NR did not converge; values are not a valid final solution)", String(take!(io)))
     end
 
+    # A solved state can satisfy every limit and still be non-physical: a
+    # machine pinned at Qmax whose voltage ends ABOVE its setpoint cannot be
+    # an operating point, because a machine at its upper reactive limit has
+    # nothing left to raise the voltage with. The counter is what makes the
+    # difference between two enforcement modes visible at all.
+    @testset "Q-V characteristic check finds non-physical generator states" begin
+      # STATION1 carries the machine with vm_pu = 1.027273 and the Q band
+      net = createTest3BusNet(qlim_min = -20.0, qlim_max = 20.0)
+      bus = Sparlectra.geNetBusIdx(net = net, busName = "STATION1")
+
+      # the machine sits at Qmax and the voltage ended ABOVE its setpoint
+      net.qLimitEvents[bus] = :max
+      net.nodeVec[bus]._qƩGen = 20.0
+      Sparlectra.setVmVa!(node = net.nodeVec[bus], vm_pu = 1.0300, va_deg = 0.0)
+      rows = qvCharacteristicViolations(net)
+      @test length(rows) == 1
+      @test rows[1].bus == bus
+      @test rows[1].side === :max
+      @test rows[1].significant
+      @test rows[1].dv_pu > 0
+
+      # same clamp, voltage BELOW the setpoint: that is the physical case
+      Sparlectra.setVmVa!(node = net.nodeVec[bus], vm_pu = 1.0200, va_deg = 0.0)
+      @test isempty(qvCharacteristicViolations(net))
+
+      # voltage on the wrong side again, but the machine is no longer at the
+      # limit: a stale switching event is not a violation
+      Sparlectra.setVmVa!(node = net.nodeVec[bus], vm_pu = 1.0300, va_deg = 0.0)
+      net.nodeVec[bus]._qƩGen = 19.0
+      @test isempty(qvCharacteristicViolations(net))
+
+      # within the band around the setpoint the state counts, but not as
+      # significant: a converged solve may land on either side by rounding
+      net.nodeVec[bus]._qƩGen = 20.0
+      Sparlectra.setVmVa!(node = net.nodeVec[bus], vm_pu = 1.027273 + 1.0e-5, va_deg = 0.0)
+      band_rows = qvCharacteristicViolations(net)
+      @test length(band_rows) == 1
+      @test !band_rows[1].significant
+
+      # printing: the section is always there, so a missing line can never be
+      # mistaken for a clean result
+      Sparlectra.setVmVa!(node = net.nodeVec[bus], vm_pu = 1.0300, va_deg = 0.0)
+      io = IOBuffer()
+      printQVCharacteristicCheck(net; io = io)
+      out = String(take!(io))
+      @test occursin("Q-V characteristic:", out)
+      @test occursin("non-physical generator state", out)
+      io = IOBuffer()
+      printQVCharacteristicCheck(net; io = io, converged = false)
+      @test occursin("skipped (no converged solution)", String(take!(io)))
+      io = IOBuffer()
+      empty!(net.qLimitEvents)
+      printQVCharacteristicCheck(net; io = io)
+      @test occursin("no non-physical generator states", String(take!(io)))
+    end
+
     @testset "AC rescue ladder and DC fallback" begin
       # NOTE: private inner name — an anonymous fixture assigning to a name
       # that also exists in the enclosing testset would rebind that local.

--- a/test/test_webui.jl
+++ b/test/test_webui.jl
@@ -1254,6 +1254,195 @@ function run_webui_fast_tests()
       @test occursin("topbar-info-menu", Sparlectra.render_webui_error(404, "not found"))
     end
 
+    # Two runs of the same case under different settings are the normal way to
+    # look at a Q-limit mode or a solver choice. The history could list them but
+    # not put them side by side, so the comparison had to happen in the head or
+    # in two browser tabs.
+    @testset "run comparison" begin
+      @testset "history offers a selection and a compare button" begin
+        root = Sparlectra.default_webui_output_root()
+        body = String(Sparlectra.route_sparlectra_webui("GET", "/powerflow/history"; output_root = root).body)
+        @test occursin("action=\"/powerflow/compare\"", body)
+        @test occursin("Compare selected runs", body)
+        @test occursin("<th>Compare</th>", body)
+      end
+
+      @testset "the route insists on exactly two runs" begin
+        root = Sparlectra.default_webui_output_root()
+        for target in ("/powerflow/compare", "/powerflow/compare?run=only-one")
+          response = Sparlectra.route_sparlectra_webui("GET", target; output_root = root)
+          @test (target, response.status) == (target, 400)
+        end
+        missing_response = Sparlectra.route_sparlectra_webui("GET", "/powerflow/compare?run=nope-a&run=nope-b"; output_root = root)
+        @test missing_response.status == 404
+      end
+
+      @testset "repeated query keys survive the parser" begin
+        # `_webui_parse_pairs` returns a Dict and keeps only the last value;
+        # a set of checkboxes with one name needs all of them
+        @test Sparlectra._webui_query_values("/powerflow/compare?run=a&run=b", "run") == ["a", "b"]
+        @test Sparlectra._webui_query_values("/powerflow/compare?other=x", "run") == String[]
+        @test Sparlectra._webui_query_values("/powerflow/compare", "run") == String[]
+      end
+
+      @testset "the page reads what the runs wrote" begin
+        dir_a = mktempdir()
+        dir_b = mktempdir()
+        write(joinpath(dir_a, "effective_config.yaml"), "power_flow:\n  tol: 1.0e-8\n  qlimits:\n    enforcement_mode: active_set\n")
+        write(joinpath(dir_b, "effective_config.yaml"), "power_flow:\n  tol: 1.0e-8\n  qlimits:\n    enforcement_mode: classic_simultaneous\n")
+        diff = Sparlectra._webui_compare_config_diff(dir_a, dir_b)
+        # the nested key keeps its real path; a "remember the last section"
+        # reader concatenated every section it had ever seen
+        @test diff == [("power_flow.qlimits.enforcement_mode", "active_set", "classic_simultaneous")]
+
+        write(joinpath(dir_a, "q_limit_events.csv"), "iteration,bus,side\n2,19,min\n2,32,min\n")
+        write(joinpath(dir_b, "q_limit_events.csv"), "iteration,bus,side\n1,19,min\n")
+        @test Sparlectra._webui_compare_qlimit_buses(dir_a) == [19, 32]
+        @test Sparlectra._webui_compare_qlimit_buses(dir_b) == [19]
+        @test Sparlectra._webui_compare_qlimit_buses(mktempdir()) === nothing
+
+        # The detailed export writes one of three formats, and A carries the
+        # German one: ';' delimiter, decimal comma. A comma-splitting reader
+        # found no columns there and the page then claimed the two runs had
+        # nothing in common ("The two runs share no bus names", reported
+        # 2026-09-08). The fixtures below are the real header of
+        # bus_voltages_complex.csv, both formats, so the parser is judged on
+        # what the runs actually write.
+        head_de = "bus;bus_name;type;vm_pu;va_deg;vn_kV;q_limit_hit;original_bus_name"
+        head_us = "bus,bus_name,type,vm_pu,va_deg,vn_kV,q_limit_hit,original_bus_name"
+        write(joinpath(dir_a, "bus_voltages_complex.csv"),
+          "$(head_de)\n1;11001;PQ;1;0;138;false;NEWBERRY 1\n2;11002;PQ;0,99;-1,5;69;false;NEWBERRY 2\n")
+        write(joinpath(dir_b, "bus_voltages_complex.csv"),
+          "$(head_us)\n1,11001,PQ,1.0,0.0,138,false,NEWBERRY 1\n2,11002,PQ,0.98,-1.0,69,false,NEWBERRY 2\n")
+        va = Sparlectra._webui_compare_voltages(dir_a)
+        vb = Sparlectra._webui_compare_voltages(dir_b)
+        @test va["2"].vm == 0.99
+        @test va["2"].va == -1.5           # decimal comma, not a second field
+        @test va["2"].name == "NEWBERRY 2"  # the name a reader recognizes
+        @test vb["2"].vm == 0.98
+        @test Sparlectra._webui_compare_voltages(mktempdir()) === nothing
+
+        # grouped thousands, and a quoted cell because the group separator IS
+        # the delimiter in the excel_us format
+        @test Sparlectra._webui_compare_split_csv("a,\"1,234.5\",b", ',') == ["a", "1,234.5", "b"]
+        @test Sparlectra._webui_compare_number("1,234.5", '.', ',') == 1234.5
+        @test Sparlectra._webui_compare_number("1.234,5", ',', '.') == 1234.5
+
+        # losses come from the branch table the run wrote, summed
+        write(joinpath(dir_a, "branch_flows.csv"),
+          "branch;from_bus;to_bus;p_loss_MW;q_loss_MVar\nB1;1;2;0,5;1,25\nB2;2;3;0,25;0,75\n")
+        write(joinpath(dir_b, "branch_flows.csv"),
+          "branch,from_bus,to_bus,p_loss_MW,q_loss_MVar\nB1,1,2,0.4,1.25\nB2,2,3,0.25,0.75\n")
+        la = Sparlectra._webui_compare_losses(dir_a)
+        @test la.p_MW ≈ 0.75
+        @test la.q_MVAr ≈ 2.0
+        @test la.branches == 2
+        @test Sparlectra._webui_compare_losses(mktempdir()) === nothing
+
+        a = Dict{String,Any}("run_id" => "run-a", "output_dir" => dir_a, "casefile" => "case118.m",
+          "status" => "succeeded", "converged" => true, "iterations" => 6, "final_mismatch" => 1.0e-13)
+        b = Dict{String,Any}("run_id" => "run-b", "output_dir" => dir_b, "casefile" => "case118.m",
+          "status" => "succeeded", "converged" => true, "iterations" => 23, "final_mismatch" => 7.4e-12)
+        html = Sparlectra.render_powerflow_compare(a, b)
+        @test occursin("Configuration differences (1)", html)
+        @test occursin("power_flow.qlimits.enforcement_mode", html)
+        @test occursin("The runs clamped different buses", html)
+        @test occursin("max |dVm|", html)
+        @test occursin("0.01", html)          # 0.99 gegen 0.98
+        @test occursin("NEWBERRY 2", html)
+        @test occursin("Losses", html)
+        @test occursin("0.1 MW", html) || occursin("0.09999", html)  # 0.75 gegen 0.65
+        @test occursin("/powerflow/result/run-a", html)
+
+        # two identical runs say so in one line instead of a table of zeros
+        same = Sparlectra.render_powerflow_compare(a, a)
+        @test occursin("Both runs end on the same voltages", same)
+        @test occursin("Both runs end on the same losses", same)
+      end
+    end
+
+    # Reported from a live session 2026-09-08: "Case input format" offered
+    # MATPOWER, DTF and CGMES but neither SCF nor power-grid-model, although
+    # the API has accepted `scf` all along and a PGM `input.json` is read by
+    # that very importer.
+    @testset "case input format offers SCF and power-grid-model" begin
+      @test Sparlectra._normalize_case_format(:scf) === :scf
+      # pgm is a spelling of scf, not a second reader
+      @test Sparlectra._normalize_case_format(:pgm) === :scf
+      @test Sparlectra._normalize_case_format("pgm") === :scf
+      @test_throws ArgumentError Sparlectra._normalize_case_format("nonsense")
+
+      root = mktempdir()
+      cases = mktempdir()
+      write(joinpath(cases, "fmt_probe.m"), "function mpc = fmt_probe\nmpc.baseMVA = 100;\n")
+      rt = (; case_directory = cases, config_file = Sparlectra.DEFAULT_SPARLECTRA_CONFIG_PATH, operation_log = Sparlectra.webui_operation_log_path(root), startup_config_error = nothing, runner = Sparlectra.start_powerflow_run)
+      body = String(Sparlectra.route_sparlectra_webui("GET", "/powerflow/case"; output_root = root, runtime = rt).body)
+      @test occursin("value=\"scf\"", body)
+      @test occursin("value=\"pgm\"", body)
+
+      # the two whitelists that persist the choice (save, read back) both have
+      # to know the new values, or the selection is silently dropped to auto
+      Sparlectra.route_sparlectra_webui("POST", "/powerflow/case/options/save",
+        Dict{String,Any}("casefile" => "fmt_probe.m", "case_format" => "pgm"); output_root = root, runtime = rt)
+      @test Sparlectra._webui_case_form_defaults("fmt_probe.m", cases)["case_format"] == "pgm"
+    end
+
+    # Also reported live: the mode was set and nothing happened, because the
+    # enable checkbox sat elsewhere in the form and stayed off. Both controls
+    # now live in one block, and the mode itself can say "off".
+    @testset "Q-limit handling reads as one setting" begin
+      root = mktempdir()
+      rt = (; case_directory = mktempdir(), config_file = Sparlectra.DEFAULT_SPARLECTRA_CONFIG_PATH, operation_log = Sparlectra.webui_operation_log_path(root), startup_config_error = nothing, runner = Sparlectra.start_powerflow_run)
+      body = String(Sparlectra.route_sparlectra_webui("GET", "/powerflow/settings"; output_root = root, runtime = rt).body)
+      block_start = findfirst("Q-limit handling", body)
+      @test block_start !== nothing
+      block = body[block_start[1]:min(lastindex(body), block_start[1] + 1200)]
+      @test occursin("power_flow_qlimits_enabled", block)
+      @test occursin("value=\"off\"", block)
+
+      # "off" disables the handling instead of being sent as a mode the
+      # configuration would reject
+      form = Dict{String,String}(
+        "casefile" => "case14.m",
+        "config_file" => Sparlectra.DEFAULT_SPARLECTRA_CONFIG_PATH,
+        "power_flow_qlimits_enforcement_mode" => "off",
+        "power_flow_qlimits_enabled" => "true",
+      )
+      overrides = get(Sparlectra.powerflow_webui_request(form), "config_overrides", Dict{String,Any}())
+      @test !haskey(overrides, "power_flow.qlimits.enforcement_mode")
+      @test overrides["power_flow.qlimits.enabled"] === false
+
+      # a real mode is passed through untouched
+      form["power_flow_qlimits_enforcement_mode"] = "classic_simultaneous"
+      overrides2 = get(Sparlectra.powerflow_webui_request(form), "config_overrides", Dict{String,Any}())
+      @test overrides2["power_flow.qlimits.enforcement_mode"] == "classic_simultaneous"
+    end
+
+    # A diagnose run takes ONE step from the case's own voltages, so it never
+    # converges by design. Reported as a failed power flow it was unusable:
+    # every diagnosis looked like a crash.
+    @testset "a completed diagnose run reads as a diagnosis" begin
+      probe = Dict{String,Any}("run_mode" => "diagnose", "status" => "not_converged", "success" => false)
+      @test Sparlectra._webui_is_completed_diagnose(probe)
+      @test Sparlectra.webui_status_class(probe) == "status-info"
+
+      # a result page has no run_mode; the self-check configuration the
+      # diagnose flow writes is the marker there
+      by_artifact = Dict{String,Any}("status" => "not_converged",
+        "artifacts" => [Dict{String,Any}("name" => "diagnose_self_check_config.yaml")])
+      @test Sparlectra._webui_is_completed_diagnose(by_artifact)
+
+      # a diagnose run that could NOT run keeps the failure vocabulary
+      broken = Dict{String,Any}("run_mode" => "diagnose", "status" => "failed", "success" => false)
+      @test !Sparlectra._webui_is_completed_diagnose(broken)
+      @test Sparlectra.webui_status_class(broken) == "status-error"
+
+      # an ordinary non-converged run stays an error
+      plain = Dict{String,Any}("run_mode" => "", "status" => "not_converged", "success" => false)
+      @test !Sparlectra._webui_is_completed_diagnose(plain)
+      @test Sparlectra.webui_status_class(plain) == "status-error"
+    end
+
     @testset "the environment is checked before the sysimage question" begin
       # Regression 2026-09-07 (Windows 11). A checkout carried a Manifest.toml
       # from before AnalyticLoadFlow became a required dependency. The start


### PR DESCRIPTION
Release 0.11.0.

## What is in it

**Compare two runs.** The run history has a selection column and a **Compare
selected runs** button. The comparison page shows where the two runs differ:
configuration keys with both values, the buses where Q limits engaged, total
active and reactive losses, and the largest voltage deviation between the
results. Until now this took two browser tabs and a good memory.

**A grid is solved under the configuration it was imported with.** 

**Non-physical generator states appear in the result.** When a machine sits at
its Q limit while the voltage is on the wrong side of its setpoint, the classic
result print names bus, side, voltage, setpoint, Q and limit.

**Three Web UI controls that misled.** 


