### PR TITLE
Release 0.11.1: names instead of paths, comparable runs only, file pickers in the page's language

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sparlectra"
 uuid = "31ce9bba-fd9d-44a1-b005-f5f509afda38"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Udo Schmitz"]
 description = "load flow calculation using newton-raphson"
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,3 +1,7 @@
+# Version 0.11.1 - 2026-09-10
+
+- **Fix.** Cosmetic changes in the Web UI: file pickers speak the page's language, run history and result pages name the case instead of its path, and only power-flow runs offer the comparison checkbox.
+
 # Version 0.11.0 - 2026-09-10
 
 Two runs side by side, and a configuration trap in the solver call.

--- a/docs/src/webui.md
+++ b/docs/src/webui.md
@@ -849,13 +849,27 @@ a Q-limit enforcement mode, a solver choice or a start strategy. Tick the
   left out, so one difference is listed once);
 - the buses each run clamped, from `q_limit_events.csv`, and which buses only
   one of the two clamped;
-- the largest voltage deviation and the ten buses that differ most, when both
-  runs wrote `bus_voltages_complex.csv` (that file needs the detailed result
-  CSV export).
+- total active and reactive losses, summed from the `branch_flows.csv` each
+  run wrote, with their difference;
+- the largest voltage deviation and the ten buses that differ most, by bus
+  index and name, when both runs wrote `bus_voltages_complex.csv` (both files
+  need the detailed result CSV export).
 
 Everything shown comes from what the runs themselves wrote, so runs from an
 earlier session compare as well as fresh ones. Exactly two runs are required;
 anything else answers with a message rather than a half-filled page.
+
+The **Compare** box is offered only on rows the page could read: finished
+power-flow runs (plain, diagnose, or started from a state estimate) whose
+result is still on disk. A state estimation, short circuit, N-1 or import
+analysis run gets no box, because the comparison reads power-flow artifacts and
+would have nothing to show. Network size is deliberately not a criterion: the
+same case modelled with an external-grid source and with a slack is exactly the
+pair one wants side by side, and the page says so when the two runs share no
+bus.
+
+The **Case file** and **Config file** columns show the file name; the full path
+is in the cell's tooltip.
 
 Each registered run has a **Delete** action, and **Delete all runs** removes all
 safely registered runs for the current configured root. These actions update

--- a/src/webui/handlers.jl
+++ b/src/webui/handlers.jl
@@ -1563,6 +1563,12 @@ function handle_powerflow_compare(run_ids::Vector{String})::SparlectraWebUIRespo
   b = get_webui_powerflow_job(ids[2])
   for (id, entry) in zip(ids, (a, b))
     get(entry, "reason", "") == "run_not_found" && return _webui_html(render_webui_error(404, "Run $(id) was not found."); status = 404)
+    # the page reads power-flow artifacts; another kind has nothing it would
+    # show, and a half-empty comparison reads like a finding
+    metadata = get(entry, "metadata", Dict{String,Any}())
+    kind = metadata isa AbstractDict ? string(get(metadata, "run_mode", "")) : ""
+    _webui_comparable_kind(kind) || return _webui_html(render_webui_error(400,
+      "Run $(id) is a $(kind) run. The comparison reads power-flow results (configuration, Q-limit events, losses, bus voltages), so both runs have to be power-flow runs."); status = 400)
   end
   return _webui_html(render_powerflow_compare(a, b))
 end

--- a/src/webui/static/sparlectra.css
+++ b/src/webui/static/sparlectra.css
@@ -1171,3 +1171,39 @@ nav {
   border-radius: 6px;
   font-size: 0.85rem;
 }
+
+/* File pickers: the native control speaks the browser's language
+   ("Durchsuchen", "Keine Datei ausgewählt" on a German browser) while the
+   page is English. The input stays in the form but off screen; the label
+   is the visible button and the span names the selection (2026-09-09). */
+.file-field {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: .55rem;
+}
+
+.file-field-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.file-field-button {
+  display: inline-block;
+  cursor: pointer;
+}
+
+.file-field-input:focus-visible + .file-field-button {
+  outline: 2px solid #1768d4;
+  outline-offset: 2px;
+}
+
+.file-field-name {
+  color: #60708a;
+  font-weight: 400;
+  overflow-wrap: anywhere;
+}

--- a/src/webui/views.jl
+++ b/src/webui/views.jl
@@ -2164,11 +2164,18 @@ function render_powerflow_result(result::AbstractDict)::String
   # `casefile`/`resolved_casefile` rows below carried the same path twice and
   # broke the layout; `final_outcome` said nothing a reader could use
   # (maintainer 2026-09-09). The path survives in the tooltip.
-  case_path = string(get(result, "resolved_casefile", ""))
-  isempty(strip(case_path)) && (case_path = string(get(result, "casefile", "")))
-  case_card = ("Case", "<code title=\"$(_webui_escape(case_path))\">$(_webui_escape(isempty(strip(case_path)) ? "n/a" : basename(case_path)))</code>")
-  phase = string(get(result, "current_phase", ""))
-  isempty(strip(phase)) && (phase = string(get(result, "last_phase", "n/a")))
+  # A live job snapshot carries `nothing` for what the run has not produced
+  # yet, and `string(nothing)` is the word "nothing": the card said so during
+  # every run and named the case only at the end (maintainer 2026-09-10).
+  # First non-empty of the resolved path and the requested one; the requested
+  # one is known from the first second.
+  text = value -> (value === nothing || value === missing) ? "" : String(strip(string(value)))
+  case_path = text(get(result, "resolved_casefile", nothing))
+  isempty(case_path) && (case_path = text(get(result, "casefile", nothing)))
+  case_card = ("Case", "<code title=\"$(_webui_escape(case_path))\">$(_webui_escape(isempty(case_path) ? "n/a" : basename(case_path)))</code>")
+  phase = text(get(result, "current_phase", nothing))
+  isempty(phase) && (phase = text(get(result, "last_phase", nothing)))
+  isempty(phase) && (phase = "n/a")
   phase_card = ("Phase", "<code>$(_webui_escape(phase))</code>")
   summary_rows = if active
     (("Run status", status_badge), case_card, phase_card, ("Elapsed time", "<strong>$(_webui_escape(_format_elapsed_duration(_webui_elapsed_seconds(result, active))))</strong>"))

--- a/src/webui/views.jl
+++ b/src/webui/views.jl
@@ -150,6 +150,64 @@ const _WEBUI_BUSY_FORM_SCRIPT = """<script>
 })();
 </script>"""
 
+# A native <input type="file"> renders its button and its "no file selected"
+# text in the BROWSER's language, so on a German browser an otherwise English
+# page said "Durchsuchen" and "Keine Datei ausgewählt" (maintainer, reported
+# 2026-09-09). The native input stays in the form (it is what carries the
+# bytes and the `required` check) but is moved off screen; a label styled as
+# a button opens it, and a span next to it names what was picked. The span is
+# kept current by the script below, wired into the layout, so any page can
+# use `_webui_file_input` without further work.
+const _WEBUI_FILE_FIELD_SCRIPT = """<script>
+(function () {
+  var describe = function (input) {
+    var field = input.closest('[data-file-field]');
+    if (field === null) return;
+    var name = field.querySelector('[data-file-field-name]');
+    if (name === null) return;
+    var files = input.files;
+    if (!files || files.length === 0) {
+      name.textContent = 'No file selected';
+    } else if (files.length === 1) {
+      name.textContent = files[0].name;
+    } else {
+      name.textContent = files.length + ' files selected';
+    }
+  };
+  document.addEventListener('change', function (event) {
+    var target = event.target;
+    if (target && target.matches && target.matches('input[type=file][data-file-field-input]')) describe(target);
+  });
+  // bfcache restores the input's selection but not our text
+  window.addEventListener('pageshow', function () {
+    document.querySelectorAll('input[type=file][data-file-field-input]').forEach(describe);
+  });
+})();
+</script>"""
+
+"""
+    _webui_file_input(name; accept, multiple, required, id) -> String
+
+A file picker whose button and status text are in the page's language rather
+than the browser's. `id` defaults to `name`; pass one when a page carries two
+pickers with the same field name.
+"""
+function _webui_file_input(name::AbstractString; accept::AbstractString = "", multiple::Bool = false, required::Bool = false, id::AbstractString = name)::String
+  input_id = "file-field-$(id)"
+  attrs = string(
+    isempty(accept) ? "" : " accept=\"$(_webui_escape(accept))\"",
+    multiple ? " multiple" : "",
+    required ? " required" : "",
+  )
+  return string(
+    "<span class=\"file-field\" data-file-field>",
+    "<input id=\"$(input_id)\" class=\"file-field-input\" data-file-field-input type=\"file\" name=\"$(_webui_escape(name))\"$(attrs)>",
+    "<label for=\"$(input_id)\" class=\"button secondary-button file-field-button\">$(multiple ? "Choose files" : "Choose file")</label>",
+    "<span class=\"file-field-name\" data-file-field-name>No file selected</span>",
+    "</span>",
+  )
+end
+
 """Render a file-path dropdown while showing only each file's basename."""
 
 const WEBUI_STATUS_AUTO_REFRESH_SECONDS = 2
@@ -321,7 +379,7 @@ $(latency_banner)<main class="$(main_class)"$(refresh_attrs)>$(back_button)<h1>$
   };
   scheduleAutoRefresh();
 })();
-</script>$(_WEBUI_BUSY_FORM_SCRIPT)</body></html>"""
+</script>$(_WEBUI_BUSY_FORM_SCRIPT)$(_WEBUI_FILE_FIELD_SCRIPT)</body></html>"""
 end
 
 function _webui_powerflow_info_menu(; output_root::AbstractString, config_file::AbstractString, case_directory::AbstractString, operation_log::AbstractString)::String
@@ -1035,7 +1093,7 @@ function render_case_page(;
   info_menu = _webui_powerflow_info_menu(; output_root, config_file = config_default, case_directory = effective_case_directory, operation_log)
   import_form = """
 <form id=\"case-import-form\" method=\"post\" action=\"/powerflow/import-cases\" enctype=\"multipart/form-data\" class=\"panel form-grid case-import-form\">
-<label class=\"span-2\">$(_webui_field_label("casefiles", "Import case files"))<input type=\"file\" name=\"casefiles\" accept=\".m,.M,.dat,.DAT,.zip,.ZIP,.json\" multiple></label>
+<label class=\"span-2\">$(_webui_field_label("casefiles", "Import case files"))$(_webui_file_input("casefiles"; accept = ".m,.M,.dat,.DAT,.zip,.ZIP,.json", multiple = true))</label>
 <div class=\"actions span-2\"><button class=\"secondary-button\" type=\"submit\">Import case files</button></div>
 </form>
 """
@@ -1649,13 +1707,10 @@ const _WEBUI_RESULT_FIELDS = (
   "Q-limit active-set events",
   "Classical Q-limit outer-loop passes",
   "Runtime casefile",
-  "casefile",
-  "resolved_casefile",
   "config_file",
   "started_at",
   "elapsed_seconds",
   "output_dir",
-  "current_phase",
   "phase_started_at",
   "last_progress_at",
   "abort_requested_at",
@@ -1666,7 +1721,6 @@ const _WEBUI_RESULT_FIELDS = (
   "run_status",
   "last_phase",
   "last_heartbeat",
-  "final_outcome",
 )
 
 const _WEBUI_IMPORTANT_RESULT_FIELDS = Set(("converged", "numerical_converged", "solution_available", "iterations", "final_mismatch", "reason"))
@@ -1858,7 +1912,7 @@ function _webui_weights_editor_fragment(; case::AbstractString, elements::Abstra
   msg_html = isempty(message) ? "" : "<p class=\"notice\">$(esc(message))</p>"
   cesc = esc(case)
   cenc = _webui_urlencode(case)
-  upload = "<section class=\"panel\"><h2>Upload / download</h2><form method=\"post\" action=\"/powerflow/contingency-weights/upload\" enctype=\"multipart/form-data\"><input type=\"hidden\" name=\"casefile\" value=\"$(cesc)\"><input type=\"file\" name=\"weights_file\" accept=\".csv\" required> <button type=\"submit\">Upload (replaces existing)</button></form><p><a href=\"/powerflow/contingency-weights/download?case=$(cenc)\">download current file</a></p><form method=\"post\" action=\"/powerflow/contingency-weights/reset\"><input type=\"hidden\" name=\"casefile\" value=\"$(cesc)\"><button type=\"submit\">reset (delete the weight file)</button></form></section>"
+  upload = "<section class=\"panel\"><h2>Upload / download</h2><form method=\"post\" action=\"/powerflow/contingency-weights/upload\" enctype=\"multipart/form-data\"><input type=\"hidden\" name=\"casefile\" value=\"$(cesc)\">$(_webui_file_input("weights_file"; accept = ".csv", required = true)) <button type=\"submit\">Upload (replaces existing)</button></form><p><a href=\"/powerflow/contingency-weights/download?case=$(cenc)\">download current file</a></p><form method=\"post\" action=\"/powerflow/contingency-weights/reset\"><input type=\"hidden\" name=\"casefile\" value=\"$(cesc)\"><button type=\"submit\">reset (delete the weight file)</button></form></section>"
   table_html = if !isempty(net_error)
     "<section class=\"panel\"><h2>Weights table</h2><p class=\"notice\">Element names could not be listed for this case ($(esc(net_error))). Edit the raw CSV below or upload a file.</p></section>"
   else
@@ -2106,10 +2160,20 @@ function render_powerflow_result(result::AbstractDict)::String
   stored_solver = final_outcome_value isa AbstractDict ? String(get(final_outcome_value, "solver", "")) : ""
   meta_for_mode = get(result, "metadata", Dict{String,Any}())
   solver_name = _webui_run_method(meta_for_mode isa AbstractDict ? meta_for_mode : Dict{String,Any}(), stored_solver)
+  # The case by name and the phase, up top where a reader looks first. The
+  # `casefile`/`resolved_casefile` rows below carried the same path twice and
+  # broke the layout; `final_outcome` said nothing a reader could use
+  # (maintainer 2026-09-09). The path survives in the tooltip.
+  case_path = string(get(result, "resolved_casefile", ""))
+  isempty(strip(case_path)) && (case_path = string(get(result, "casefile", "")))
+  case_card = ("Case", "<code title=\"$(_webui_escape(case_path))\">$(_webui_escape(isempty(strip(case_path)) ? "n/a" : basename(case_path)))</code>")
+  phase = string(get(result, "current_phase", ""))
+  isempty(strip(phase)) && (phase = string(get(result, "last_phase", "n/a")))
+  phase_card = ("Phase", "<code>$(_webui_escape(phase))</code>")
   summary_rows = if active
-    (("Run status", status_badge), ("Elapsed time", "<strong>$(_webui_escape(_format_elapsed_duration(_webui_elapsed_seconds(result, active))))</strong>"))
+    (("Run status", status_badge), case_card, phase_card, ("Elapsed time", "<strong>$(_webui_escape(_format_elapsed_duration(_webui_elapsed_seconds(result, active))))</strong>"))
   else
-    base = [("Run status", status_badge), ("Solver", "<code>$(_webui_escape(solver_name))</code>")]
+    base = [("Run status", status_badge), case_card, phase_card, ("Solver", "<code>$(_webui_escape(solver_name))</code>")]
     solver_name == "dc" && push!(base, ("Model", "<span class=\"status-badge status-info\">DC solution</span>"))
     solver_elapsed = _webui_solver_elapsed_seconds(result)
     solver_elapsed === nothing || push!(base, ("Solver time", "<strong>$(_webui_escape(_format_elapsed_duration(solver_elapsed)))</strong>"))
@@ -2333,6 +2397,26 @@ function _webui_run_timestamp(run::AbstractDict)::String
   return isempty(strip(string(timestamp))) ? "Unknown" : string(timestamp)
 end
 
+"""
+    _webui_comparable_kind(kind) -> Bool
+
+Whether a run of this kind can go into the side-by-side comparison. The page
+reads power-flow artifacts (effective configuration, Q-limit events, branch
+flows, bus voltages), so a plain power flow, a diagnose probe and a power flow
+started from a state estimate qualify; a state estimation, short circuit, N-1
+or import analysis has nothing the page would read. Deliberately NOT decided
+by network size: the same case modelled with an external-grid source and with
+a slack is exactly the pair one wants side by side (maintainer 2026-09-09).
+"""
+_webui_comparable_kind(kind::AbstractString)::Bool = lowercase(strip(kind)) in ("", "powerflow", "diagnose", "powerflow_se_start")
+
+"A history row that may be ticked for comparison: comparable kind, finished, and its result still on disk."
+function _webui_run_comparable(run::AbstractDict)::Bool
+  get(run, "available", false) == true || return false
+  _webui_comparable_kind(string(get(run, "run_mode", ""))) || return false
+  return !(lowercase(string(get(run, "status", ""))) in _WEBUI_ACTIVE_RUN_STATUSES)
+end
+
 function render_powerflow_history(runs, output_root::AbstractString; active_run = nothing)::String
   ordered_runs = sort!(collect(runs); by = run -> _webui_run_timestamp(run), rev = true)
   rows = join((begin
@@ -2340,8 +2424,9 @@ function render_powerflow_history(runs, output_root::AbstractString; active_run 
     available = get(run, "available", false)
     # Two runs of the same case under different settings are the normal way to
     # look at a Q-limit mode or a solver choice; the history could list them
-    # but not put them side by side. The checkbox feeds /powerflow/compare.
-    pick = available ? "<td><input type=\"checkbox\" name=\"run\" value=\"$(_webui_escape(run_id))\" aria-label=\"Select run $(_webui_escape(run_id)) for comparison\"></td>" : "<td></td>"
+    # but not put them side by side. The checkbox feeds /powerflow/compare and
+    # is offered only where the comparison has something to read.
+    pick = _webui_run_comparable(run) ? "<td><input type=\"checkbox\" name=\"run\" value=\"$(_webui_escape(run_id))\" aria-label=\"Select run $(_webui_escape(run_id)) for comparison\"></td>" : "<td></td>"
     link = available ? "<a href=\"/powerflow/result/$(_webui_urlencode(run_id))\">$(_webui_escape(run_id))</a>" : _webui_escape(run_id)
     status = _webui_is_completed_diagnose(run) ? "diagnosed" : string(get(run, "status", "unknown"))
     status_badge = _webui_status_badge(webui_status_class(run), status, string(get(run, "status", "")))
@@ -2351,8 +2436,12 @@ function render_powerflow_history(runs, output_root::AbstractString; active_run 
     # entries without the field fall back to
     kind = string(get(run, "run_mode", ""))
     kind_label = isempty(kind) ? "powerflow" : kind
-    fields = (_webui_run_timestamp(run), link, status_badge, kind_label, available, _webui_run_method(run, String(get(run, "solver", ""))), get(run, "iterations", ""), get(run, "final_mismatch", ""), get(run, "casefile", ""), get(run, "config_file", ""))
-    cells = "<td>$(_webui_escape(fields[1]))</td><td>$(fields[2])</td><td>$(fields[3])</td>" * join(("<td>$(_webui_escape(field))</td>" for field in fields[4:end]), "")
+    fields = (_webui_run_timestamp(run), link, status_badge, kind_label, available, _webui_run_method(run, String(get(run, "solver", ""))), get(run, "iterations", ""), get(run, "final_mismatch", ""))
+    # The two paths no longer fit the row. The name says which case and
+    # which configuration; the tooltip keeps the path for whoever needs it
+    # (maintainer 2026-09-09).
+    path_cell = path -> "<td title=\"$(_webui_escape(string(path)))\">$(_webui_escape(basename(string(path))))</td>"
+    cells = "<td>$(_webui_escape(fields[1]))</td><td>$(fields[2])</td><td>$(fields[3])</td>" * join(("<td>$(_webui_escape(field))</td>" for field in fields[4:end]), "") * path_cell(get(run, "casefile", "")) * path_cell(get(run, "config_file", ""))
     "<tr>$(pick)$(cells)<td>$(abort_form)$(delete_form)</td></tr>"
   end for run in ordered_runs), "")
   # The compare button submits the surrounding form; the handler is the place
@@ -3073,7 +3162,7 @@ function render_se_form(; cases::Vector{String} = String[], measurements::Vector
     "<form method=\"post\" action=\"/powerflow/import-cases\" enctype=\"multipart/form-data\">",
     "<input type=\"hidden\" name=\"return_to\" value=\"stateestimation\">",
     "<input type=\"hidden\" name=\"return_case\" value=\"$(esc(selected_case))\">",
-    "<label title=\"Upload a measurement CSV v1 (content-sniffed; lands in the case cache and appears in the set selector)\">Upload measurement file <input type=\"file\" name=\"casefiles\" accept=\".csv\"></label> ",
+    "<label title=\"Upload a measurement CSV v1 (content-sniffed; lands in the case cache and appears in the set selector)\">Upload measurement file $(_webui_file_input("casefiles"; accept = ".csv", id = "measurements"))</label> ",
     "<button type=\"submit\">Upload</button>",
     "</form>",
   )

--- a/test/test_webui.jl
+++ b/test/test_webui.jl
@@ -1267,6 +1267,81 @@ function run_webui_fast_tests()
         @test occursin("<th>Compare</th>", body)
       end
 
+      # Maintainer 2026-09-09: the box should appear only where the two runs
+      # are comparable, and NOT decided by network size, because the same
+      # case with an external-grid source and with a slack is a pair one
+      # wants side by side. The criterion is the run kind: the page reads
+      # power-flow artifacts, so only power-flow kinds qualify.
+      @testset "only finished power-flow runs offer the box" begin
+        @test Sparlectra._webui_comparable_kind("")
+        @test Sparlectra._webui_comparable_kind("powerflow")
+        @test Sparlectra._webui_comparable_kind("diagnose")
+        @test Sparlectra._webui_comparable_kind("powerflow_se_start")
+        for kind in ("se", "short_circuit", "contingency", "import_analysis")
+          @test !Sparlectra._webui_comparable_kind(kind)
+        end
+
+        pf = Dict{String,Any}("run_id" => "pf-1", "available" => true, "status" => "succeeded", "run_mode" => "",
+          "timestamp" => "2026-09-09 01:00:00", "casefile" => "/very/long/path/to/cases/case118.m", "config_file" => "/etc/sparlectra/configuration.yaml")
+        se = merge(pf, Dict{String,Any}("run_id" => "se-1", "run_mode" => "se"))
+        running = merge(pf, Dict{String,Any}("run_id" => "pf-2", "status" => "running"))
+        gone = merge(pf, Dict{String,Any}("run_id" => "pf-3", "available" => false))
+        @test Sparlectra._webui_run_comparable(pf)
+        @test !Sparlectra._webui_run_comparable(se)
+        @test !Sparlectra._webui_run_comparable(running)
+        @test !Sparlectra._webui_run_comparable(gone)
+
+        html = Sparlectra.render_powerflow_history([pf, se], mktempdir())
+        @test occursin("name=\"run\" value=\"pf-1\"", html)
+        @test !occursin("name=\"run\" value=\"se-1\"", html)
+        # the paths no longer fit the row: name in the cell, path in the tooltip
+        @test occursin("<td title=\"/very/long/path/to/cases/case118.m\">case118.m</td>", html)
+        @test occursin("<td title=\"/etc/sparlectra/configuration.yaml\">configuration.yaml</td>", html)
+        @test !occursin("<td>/very/long/path/to/cases/case118.m</td>", html)
+      end
+
+      # The result page names the case and the phase up top, where a reader
+      # looks first; the rows that carried the path twice and the
+      # final_outcome row that said nothing are gone (maintainer 2026-09-09).
+      @testset "result page: case and phase up top, path rows gone" begin
+        probe = Dict{String,Any}("run_id" => "r-1", "status" => "succeeded", "success" => true, "converged" => true,
+          "casefile" => "/some/where/sp_case14.scf.json", "resolved_casefile" => "/some/where/sp_case14.scf.json",
+          "current_phase" => "finished", "final_outcome" => Dict{String,Any}("solver" => "rectangular"), "artifacts" => Any[])
+        html = Sparlectra.render_powerflow_result(probe)
+        @test occursin("<span class=\"summary-label\">Case</span><code title=\"/some/where/sp_case14.scf.json\">sp_case14.scf.json</code>", html)
+        @test occursin("<span class=\"summary-label\">Phase</span><code>finished</code>", html)
+        for gone in ("<th>casefile</th>", "<th>resolved_casefile</th>", "<th>current_phase</th>", "<th>final_outcome</th>")
+          @test !occursin(gone, html)
+        end
+        # an active run carries the same two cards
+        active = merge(probe, Dict{String,Any}("status" => "running", "current_phase" => "linear_solve"))
+        active_html = Sparlectra.render_powerflow_result(active)
+        @test occursin("<span class=\"summary-label\">Phase</span><code>linear_solve</code>", active_html)
+        @test occursin(">sp_case14.scf.json</code>", active_html)
+      end
+
+      # A native file input speaks the BROWSER's language ("Durchsuchen",
+      # "Keine Datei ausgewählt" on a German browser) on an English page
+      # (maintainer 2026-09-09). The input stays in the form, off screen; a
+      # label is the button and a span names the selection.
+      @testset "file pickers speak the page's language" begin
+        one = Sparlectra._webui_file_input("weights_file"; accept = ".csv", required = true)
+        many = Sparlectra._webui_file_input("casefiles"; accept = ".m,.zip", multiple = true)
+        alias = Sparlectra._webui_file_input("casefiles"; accept = ".csv", id = "measurements")
+        @test occursin("type=\"file\" name=\"weights_file\" accept=\".csv\" required>", one)
+        @test occursin("<label for=\"file-field-weights_file\" class=\"button secondary-button file-field-button\">Choose file</label>", one)
+        @test occursin("No file selected", one)
+        @test occursin("multiple>", many)
+        @test occursin(">Choose files</label>", many)
+        # two pickers with one field name on one page need distinct ids
+        @test occursin("id=\"file-field-measurements\"", alias)
+        @test occursin("name=\"casefiles\"", alias)
+        # the script that keeps the span current is part of every page
+        page = Sparlectra._webui_layout("t", "<p>x</p>")
+        @test occursin("data-file-field-input", page)
+        @test occursin("'No file selected'", page)
+      end
+
       @testset "the route insists on exactly two runs" begin
         root = Sparlectra.default_webui_output_root()
         for target in ("/powerflow/compare", "/powerflow/compare?run=only-one")

--- a/test/test_webui.jl
+++ b/test/test_webui.jl
@@ -1318,6 +1318,15 @@ function run_webui_fast_tests()
         active_html = Sparlectra.render_powerflow_result(active)
         @test occursin("<span class=\"summary-label\">Phase</span><code>linear_solve</code>", active_html)
         @test occursin(">sp_case14.scf.json</code>", active_html)
+        # A live snapshot carries `nothing` where the run has not produced
+        # the value yet; the card once printed that word for the whole run
+        # and named the case only at the end (maintainer 2026-09-10).
+        live = Dict{String,Any}("run_id" => "r-2", "status" => "running", "success" => false,
+          "casefile" => "/some/where/case14.m", "resolved_casefile" => nothing, "current_phase" => nothing, "last_phase" => nothing, "artifacts" => Any[])
+        live_html = Sparlectra.render_powerflow_result(live)
+        @test occursin("<span class=\"summary-label\">Case</span><code title=\"/some/where/case14.m\">case14.m</code>", live_html)
+        @test occursin("<span class=\"summary-label\">Phase</span><code>n/a</code>", live_html)
+        @test !occursin(">nothing<", live_html)
       end
 
       # A native file input speaks the BROWSER's language ("Durchsuchen",


### PR DESCRIPTION
Release 0.11.1. Four things the maintainer ran into on the live page after
0.11.0 went out; cosmetic, no solver change.

