### PR TITLE
Workflows: cache restore/save on the Node 24 generation, checkout on v6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
@@ -46,7 +46,7 @@ jobs:
       # The key hashes the test sources: when tests start using additional
       # cases, a new cache is saved, seeded from the previous one via the
       # restore-keys prefix match.
-      - uses: actions/cache/restore@v6
+      - uses: actions/cache/restore@v5
         id: matpower-cases
         with:
           path: data/mpower
@@ -63,7 +63,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           SPARLECTRA_TEST_PROFILE: fast
-      - uses: actions/cache/save@v6
+      - uses: actions/cache/save@v5
         if: always() && steps.matpower-cases.outputs.cache-hit != 'true'
         with:
           path: data/mpower

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
@@ -46,7 +46,7 @@ jobs:
       # The key hashes the test sources: when tests start using additional
       # cases, a new cache is saved, seeded from the previous one via the
       # restore-keys prefix match.
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v6
         id: matpower-cases
         with:
           path: data/mpower
@@ -63,7 +63,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           SPARLECTRA_TEST_PROFILE: fast
-      - uses: actions/cache/save@v4
+      - uses: actions/cache/save@v6
         if: always() && steps.matpower-cases.outputs.cache-hit != 'true'
         with:
           path: data/mpower

--- a/.github/workflows/SBOM.yml
+++ b/.github/workflows/SBOM.yml
@@ -90,7 +90,7 @@ jobs:
           gh release upload "${{ steps.target.outputs.tag }}" Sparlectra.spdx.json --clobber
       - name: Upload as workflow artifact (manual run)
         if: steps.target.outputs.skip != 'true' && steps.target.outputs.tag == ''
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: sbom
           path: ${{ steps.sbomname.outputs.file }}

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Setup Julia
         uses: julia-actions/setup-julia@v3

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Julia
         uses: julia-actions/setup-julia@v3


### PR DESCRIPTION
Removes the Node 20 deprecation warning without suppressing it: the actions are updated. Workflow files only, in their own commits, so that no release commit touches `.github/workflows/`: the registration guard refuses such a HEAD and TagBot cannot tag it. **Merge order: #367 (release 0.12.0) first, then this.**

Audit of every action the workflows use, `runs.using` read from the action's own `action.yml` at the tag in use:

| Action | before | runtime | after | runtime | smallest Node 24 major |
|---|---|---|---|---|---|
| `actions/cache/restore` (CI.yml) | v4 | node20 | **v5** | node24 | v5 |
| `actions/cache/save` (CI.yml) | v4 | node20 | **v5** | node24 | v5 |
| `actions/upload-artifact` (SBOM.yml) | v5 | node20 | **v6** | node24 | v6 |
| `actions/checkout` (CI, jekyll: v5; SBOM, registration: v6) | v5 / v6 | node24 | unchanged | | v5 |
| `actions/deploy-pages` | v5 | node24 | unchanged | | |
| `actions/github-script` | v8 | node24 | unchanged | | |
| `actions/upload-pages-artifact` | v5 | composite, calls upload-artifact v7 (node24) | unchanged | | |
| `julia-actions/cache` | v3 | node24 | unchanged | | |
| `julia-actions/setup-julia` | v3 | node24 | unchanged | | |
| `julia-actions/julia-buildpkg`, `julia-runtest` | v1 | composite, no foreign action | unchanged | | |
| `JuliaRegistries/TagBot` | v1 | docker | unchanged | | |
| `Mattraks/delete-workflow-runs` | v2 | node24 | unchanged | | |

`actions/cache/restore` and `save` are used directly in CI.yml, not through `julia-actions/cache` (which is node24 already), so the direct references are bumped. Cache keys are unchanged. `codecov/codecov-action` and `julia-actions/julia-processcoverage` are not used in this repository.

Acceptance: the CI run of this PR carries no Node 20 annotation (checked after the run).
