### PR TITLE
Release 0.12.1: the test suite is silent

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Sparlectra"
 uuid = "31ce9bba-fd9d-44a1-b005-f5f509afda38"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Udo Schmitz"]
 description = "load flow calculation using newton-raphson"
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,3 +1,7 @@
+# Version 0.12.1 - 2026-09-11
+
+- **Tests.** Warnings the suite provokes on purpose (version-less and legacy configuration files, the in-file config block, a coarse tolerance, a skipped feeder, the topology advisory, a strict export) are captured and checked instead of printed; a green run shows no warnings.
+
 # Version 0.12.0 - 2026-09-11
 
 A Q(U) or P(U) characteristic travels in the case file.

--- a/test/test_configuration_coverage.jl
+++ b/test/test_configuration_coverage.jl
@@ -1315,6 +1315,19 @@ function test_configuration_deprecated_diagnostics_warn()
   return nothing
 end
 
+# Version-less and legacy fixtures, the in-file config block, a coarse tol_MW
+# and the deprecated dcline mode are the tested behavior here, so they warn
+# by design. Captured, not printed (maintainer 2026-09-11: a printed warning
+# in a green run reads as a problem), and anything else that warns fails the
+# group; see run_with_expected_warnings.
+const CONFIG_EXPECTED_WARNINGS = (
+  r"declares no config_version",
+  r"legacy key name",
+  r"sparlectra\.config inside .* is deprecated",
+  r"is a very coarse convergence bound",
+  r"reject_active is deprecated",
+)
+
 function run_configuration_coverage_tests()
   for testfn in (
     test_configuration_yaml_key_coverage,
@@ -1337,7 +1350,7 @@ function run_configuration_coverage_tests()
     test_configuration_console_live_capture,
     test_configuration_deprecated_diagnostics_warn,
   )
-    testfn()
+    run_with_expected_warnings(testfn, CONFIG_EXPECTED_WARNINGS)
   end
   return nothing
 end

--- a/test/test_demo_cases.jl
+++ b/test/test_demo_cases.jl
@@ -77,7 +77,9 @@ function run_demo_case_tests()
         end
 
         # 2) state estimation on the measurements the file itself carries
-        se = runse!(net, Vector{Sparlectra.Measurement}(net.measurements), Sparlectra.StateEstimationConfig())
+        # the topology precheck advises on two of the shipped cases by design;
+        # captured, anything else that warns fails
+        se = run_with_expected_warnings(() -> runse!(net, Vector{Sparlectra.Measurement}(net.measurements), Sparlectra.StateEstimationConfig()), (r"topology precheck reported",))
         @test se.converged
         @test se.dof == fixture["state_estimation"]["dof"]
         @test isapprox(se.objectiveJ, fixture["state_estimation"]["objective"]; atol = 1e-4)

--- a/test/test_distributed_slack.jl
+++ b/test/test_distributed_slack.jl
@@ -283,7 +283,7 @@ function run_distributed_slack_tests()
       # treat it (and nothing/"") as an empty table instead of throwing —
       # otherwise EVERY default-merged load_sparlectra_config call fails.
       p0 = test_scratch_path(".yaml")
-      write(p0, "power_flow:\n  tol: 1.0e-8\n")
+      write(p0, "config_version: 1\npower_flow:\n  tol: 1.0e-8\n")
       cfg = Sparlectra.load_sparlectra_config(p0; reload = true)
       @test cfg.powerflow.distributed_slack.enabled == false
       @test isempty(cfg.powerflow.distributed_slack.weights)
@@ -291,6 +291,7 @@ function run_distributed_slack_tests()
       # (bus names) and must pass unknown-key validation.
       p1 = test_scratch_path(".yaml")
       write(p1, """
+config_version: 1
 power_flow:
   distributed_slack:
     enabled: true

--- a/test/test_external_grid.jl
+++ b/test/test_external_grid.jl
@@ -150,7 +150,8 @@ function run_external_grid_tests()
       addExternalGrid!(net = net, busName = "B1", sk_max_MVA = 3000.0)
       resmax = runShortCircuit!(net; case = :max)
       @test only(resmax.rows).status === :ok
-      resmin = runShortCircuit!(net; case = :min)
+      # the skipped feeder is the tested behavior: its warning is captured, not printed
+      resmin = @test_logs (:warn, r"no usable minInitialSymShCCurrent") match_mode = :any runShortCircuit!(net; case = :min)
       rowmin = only(resmin.rows)
       @test rowmin.status === :no_source
       @test rowmin.contains_defaulted_data == true
@@ -215,10 +216,10 @@ function run_external_grid_tests()
       # must reject the pair (same pattern as autodamp vs. trust region).
       mktempdir() do dir
         bad = joinpath(dir, "both.yaml")
-        write(bad, "power_flow:\n  external_grid:\n    enabled: true\n  distributed_slack:\n    enabled: true\n")
+        write(bad, "config_version: 1\npower_flow:\n  external_grid:\n    enabled: true\n  distributed_slack:\n    enabled: true\n")
         @test_throws ArgumentError load_sparlectra_config(bad; reload = true)
         ok = joinpath(dir, "one.yaml")
-        write(ok, "power_flow:\n  external_grid:\n    enabled: true\n")
+        write(ok, "config_version: 1\npower_flow:\n  external_grid:\n    enabled: true\n")
         cfg = load_sparlectra_config(ok; reload = true)
         @test cfg.powerflow.external_grid.enabled
         @test !cfg.powerflow.distributed_slack.enabled

--- a/test/test_scf.jl
+++ b/test/test_scf.jl
@@ -714,7 +714,9 @@ mpc.branch = [
         # with the start state, because carrying it is opt-in and the
         # comparison must see the same operating point on both sides
         full = exportSCF(net; file = joinpath(d, "full_$(case).json"), source_format = "matpower", include_start_state = true)
-        via_service = Sparlectra._import_sparlectra_net(full, nothing, cfg)
+        # a tap-band advisory on some cases is the import's business, not a
+        # finding of this round trip: captured, anything else fails
+        via_service = run_with_expected_warnings(() -> Sparlectra._import_sparlectra_net(full, nothing, cfg), (r"neutral tap position",))
         diffs = scf_roundtrip_field_diffs(net, via_service)
         @test (case, diffs) == (case, String[])
         # A setpoint is written only where it ACTS. The check belongs on the
@@ -1137,7 +1139,10 @@ mpc.branch = [
       Sparlectra.readMeasurementsCSV!(se_net; file = abspath(joinpath(dirname(@__DIR__), "data", "mpower", "warmup_casePST.measurements.csv")))
       se_case = exportSCF(se_net; file = joinpath(d, "se_case.scf.json"), intended_calculations = String["power_flow", "state_estimation"])
       @test !isempty(importSCF(se_case).measurements)
-      res_se = redirect_stdout(devnull) do
+      # the service's SE run advises on the topology of these small sets by
+      # design; the advisory is captured, anything else that warns fails
+      se_quiet(f) = run_with_expected_warnings(() -> redirect_stdout(f, devnull), (r"topology precheck reported",))
+      res_se = se_quiet() do
         Sparlectra._run_state_estimation_service(se_case, cfg, joinpath(d, "run_se"), "scf_se", joinpath(d, "no_such_set.csv"))
       end
       d_se = Sparlectra.to_dict(res_se)
@@ -1184,7 +1189,7 @@ mpc.branch = [
       @test back["tap_deviations"][1]["steps"] == 2.0
       @test length(back["truth_values"]) == 1
       @test Sparlectra._scf_source_reference(prov_case) == "warmup_casePST.m"
-      res_prov = redirect_stdout(devnull) do
+      res_prov = se_quiet() do
         Sparlectra._run_state_estimation_service(prov_case, cfg, joinpath(d, "run_prov"), "scf_prov", joinpath(d, "no_such_set.csv"))
       end
       @test Sparlectra.to_dict(res_prov)["status"] == "succeeded"
@@ -1214,7 +1219,7 @@ mpc.branch = [
       @test length(dbl_back.measurements) == length(doubled)
       @test sort([m.id for m in dbl_back.measurements]) == sort([m.id for m in doubled])
       @test sort([m.value for m in dbl_back.measurements]) == sort([m.value for m in doubled])
-      res_dbl = redirect_stdout(devnull) do
+      res_dbl = se_quiet() do
         Sparlectra._run_state_estimation_service(dbl_case, cfg, joinpath(d, "run_dbl"), "scf_dbl", joinpath(d, "no_such_set.csv"))
       end
       d_dbl = Sparlectra.to_dict(res_dbl)
@@ -1224,7 +1229,7 @@ mpc.branch = [
       # a case file WITHOUT measurements says what is missing instead of
       # failing on a file that was never there
       plain_case = exportSCF(_scf_test_net(); file = joinpath(d, "plain_case.scf.json"))
-      res_none = redirect_stdout(devnull) do
+      res_none = se_quiet() do
         Sparlectra._run_state_estimation_service(plain_case, cfg, joinpath(d, "run_se_none"), "scf_se_none", joinpath(d, "no_such_set.csv"))
       end
       d_none = Sparlectra.to_dict(res_none)
@@ -1454,7 +1459,7 @@ mpc.branch = [
       se_run = Sparlectra.start_powerflow_run(Dict("casefile" => "warmup_casePST.pgm.json", "config_file" => Sparlectra.DEFAULT_SPARLECTRA_CONFIG_PATH, "output_root" => joinpath(root, "runs_se_gen"), "se_mode" => true, "measurement_file" => "warmup_casePST.pgm.measurements.csv"); case_directory = cases)
       @test se_run["status"] == "succeeded"
       # exporting a case FILE again must not grow format suffixes
-      Sparlectra.route_sparlectra_webui("POST", "/powerflow/export-scf", Dict{String,Any}("casefile" => "warmup_casePST.scf.json", "config_file" => Sparlectra.DEFAULT_SPARLECTRA_CONFIG_PATH, "scf_strict_pgm" => "true"); output_root = root, runtime = rt)
+      @test_logs (:warn, r"strict_pgm = true") match_mode = :any Sparlectra.route_sparlectra_webui("POST", "/powerflow/export-scf", Dict{String,Any}("casefile" => "warmup_casePST.scf.json", "config_file" => Sparlectra.DEFAULT_SPARLECTRA_CONFIG_PATH, "scf_strict_pgm" => "true"); output_root = root, runtime = rt)
       @test !isfile(joinpath(cases, "warmup_casePST.scf.pgm.json"))
       @test isfile(joinpath(cases, "warmup_casePST.pgm.json"))
 

--- a/test/test_short_circuit.jl
+++ b/test/test_short_circuit.jl
@@ -262,10 +262,10 @@ function run_short_circuit_tests()
     @testset "short_circuit.c_factor config coverage" begin
       @test Sparlectra.ShortCircuitConfig().c_factor == 0.0
       ok_yaml = test_scratch_path(".yaml")
-      write(ok_yaml, "short_circuit:\n  c_factor: 1.05\n")
+      write(ok_yaml, "config_version: 1\nshort_circuit:\n  c_factor: 1.05\n")
       @test Sparlectra.load_sparlectra_config(ok_yaml; reload = true).shortcircuit.c_factor == 1.05
       bad_yaml = test_scratch_path(".yaml")
-      write(bad_yaml, "short_circuit:\n  c_factor: 1.4\n")
+      write(bad_yaml, "config_version: 1\nshort_circuit:\n  c_factor: 1.4\n")
       err = try
         Sparlectra.load_sparlectra_config(bad_yaml; reload = true)
         nothing

--- a/test/test_solver_interface.jl
+++ b/test/test_solver_interface.jl
@@ -923,19 +923,19 @@ mpc.branch = [
 
       @testset "Config validation" begin
         armijo_bad = test_scratch_path(".yaml")
-        write(armijo_bad, "power_flow:\n  autodamp: true\n  merit:\n    armijo_c1: 0.5\n")
+        write(armijo_bad, "config_version: 1\npower_flow:\n  autodamp: true\n  merit:\n    armijo_c1: 0.5\n")
         @test_throws ArgumentError Sparlectra.load_sparlectra_config(armijo_bad; reload = true)
 
         scale_bad = test_scratch_path(".yaml")
-        write(scale_bad, "power_flow:\n  autodamp: true\n  merit:\n    scale_p: -1.0\n")
+        write(scale_bad, "config_version: 1\npower_flow:\n  autodamp: true\n  merit:\n    scale_p: -1.0\n")
         @test_throws ArgumentError Sparlectra.load_sparlectra_config(scale_bad; reload = true)
 
         enabled_without_autodamp = test_scratch_path(".yaml")
-        write(enabled_without_autodamp, "power_flow:\n  autodamp: false\n  merit:\n    enabled: true\n")
+        write(enabled_without_autodamp, "config_version: 1\npower_flow:\n  autodamp: false\n  merit:\n    enabled: true\n")
         @test_throws ArgumentError Sparlectra.load_sparlectra_config(enabled_without_autodamp; reload = true)
 
         ok_cfg = test_scratch_path(".yaml")
-        write(ok_cfg, "power_flow:\n  autodamp: true\n  merit:\n    enabled: true\n")
+        write(ok_cfg, "config_version: 1\npower_flow:\n  autodamp: true\n  merit:\n    enabled: true\n")
         loaded = Sparlectra.load_sparlectra_config(ok_cfg; reload = true)
         @test loaded.powerflow.merit.enabled == true
       end
@@ -1043,34 +1043,34 @@ mpc.branch = [
     @testset "Trust-region step control" begin
       @testset "Config validation" begin
         min_ge_initial = test_scratch_path(".yaml")
-        write(min_ge_initial, "power_flow:\n  trust_region:\n    initial_radius: 1.0\n    min_radius: 1.0\n")
+        write(min_ge_initial, "config_version: 1\npower_flow:\n  trust_region:\n    initial_radius: 1.0\n    min_radius: 1.0\n")
         @test_throws ArgumentError Sparlectra.load_sparlectra_config(min_ge_initial; reload = true)
 
         bad_shrink = test_scratch_path(".yaml")
-        write(bad_shrink, "power_flow:\n  trust_region:\n    shrink_factor: 1.5\n")
+        write(bad_shrink, "config_version: 1\npower_flow:\n  trust_region:\n    shrink_factor: 1.5\n")
         @test_throws ArgumentError Sparlectra.load_sparlectra_config(bad_shrink; reload = true)
 
         bad_expand = test_scratch_path(".yaml")
-        write(bad_expand, "power_flow:\n  trust_region:\n    expand_factor: 0.5\n")
+        write(bad_expand, "config_version: 1\npower_flow:\n  trust_region:\n    expand_factor: 0.5\n")
         @test_throws ArgumentError Sparlectra.load_sparlectra_config(bad_expand; reload = true)
 
         mutually_exclusive = test_scratch_path(".yaml")
-        write(mutually_exclusive, "power_flow:\n  autodamp: true\n  trust_region:\n    enabled: true\n")
+        write(mutually_exclusive, "config_version: 1\npower_flow:\n  autodamp: true\n  trust_region:\n    enabled: true\n")
         @test_throws ArgumentError Sparlectra.load_sparlectra_config(mutually_exclusive; reload = true)
 
         ok_cfg = test_scratch_path(".yaml")
-        write(ok_cfg, "power_flow:\n  autodamp: false\n  trust_region:\n    enabled: true\n    initial_radius: 2.0\n")
+        write(ok_cfg, "config_version: 1\npower_flow:\n  autodamp: false\n  trust_region:\n    enabled: true\n    initial_radius: 2.0\n")
         loaded = Sparlectra.load_sparlectra_config(ok_cfg; reload = true)
         @test loaded.powerflow.trust_region.enabled == true
         @test loaded.powerflow.trust_region.initial_radius == 2.0
         @test loaded.powerflow.trust_region.step_mode === :scaled
 
         bad_step_mode = test_scratch_path(".yaml")
-        write(bad_step_mode, "power_flow:\n  trust_region:\n    step_mode: bogus\n")
+        write(bad_step_mode, "config_version: 1\npower_flow:\n  trust_region:\n    step_mode: bogus\n")
         @test_throws ArgumentError Sparlectra.load_sparlectra_config(bad_step_mode; reload = true)
 
         dogleg_cfg = test_scratch_path(".yaml")
-        write(dogleg_cfg, "power_flow:\n  autodamp: false\n  trust_region:\n    enabled: true\n    step_mode: dogleg\n")
+        write(dogleg_cfg, "config_version: 1\npower_flow:\n  autodamp: false\n  trust_region:\n    enabled: true\n    step_mode: dogleg\n")
         loaded_dogleg = Sparlectra.load_sparlectra_config(dogleg_cfg; reload = true)
         @test loaded_dogleg.powerflow.trust_region.step_mode === :dogleg
       end

--- a/test/test_tap_controller.jl
+++ b/test/test_tap_controller.jl
@@ -938,6 +938,7 @@ function run_tap_controller_tests()
       write(
         io,
         """
+config_version: 1
 power_flow:
   max_iter: 30
   tol: 1.0e-9

--- a/test/testgrid.jl
+++ b/test/testgrid.jl
@@ -2951,7 +2951,7 @@ function test_condition_number_estimator()::Bool
   # legacy config key: a YAML still carrying output.condition_number loads
   # silently (no error, no warning), and the struct has no such field
   legacy_cfg = mktemp() do path, io
-    write(io, "output:\n  condition_number: true\n")
+    write(io, "config_version: 1\noutput:\n  condition_number: true\n")
     close(io)
     load_sparlectra_config(path; reload = true)
   end


### PR DESCRIPTION
Release 0.12.1: the test suite is silent.

## What changed

Tests only, no package code. The CI log of 0.12.0 showed eight package
warnings in a green run, all provoked on purpose by tests (version-less and
legacy configuration files, the in-file config block, a coarse `tol_MW`, the
deprecated dcline mode, a `strict_pgm` export, a skipped feeder, the topology
advisory). A printed warning in a green run reads as a problem, so:

- the configuration group runs under `run_with_expected_warnings` with its
  five expected patterns (the same pattern the state-estimation group uses),
  and anything else that warns fails the group;
- single sites (SCF round trip, strict export, demo-case and SCF service
  estimation runs, the skipped feeder) capture their warning with
  `@test_logs` or the same helper;
- fixtures that never meant to test version-0 handling carry
  `config_version: 1` (their keys have no 0 -> 1 alias, so nothing changes).

Julia 1.13's `Random.shuffle` change and the Dict-order tie are already in
0.12.0; this release only removes the noise.

## Verification

- fast profile on Julia 1.13.0: green, 6773 tests, zero warnings in the log
- docs build on Julia 1.13.0: green
- does not touch `.github/workflows/`

Registration is not triggered by this PR; say the word after the merge.
